### PR TITLE
Fix for the issue #50 : support for user defined words starting with a digit

### DIFF
--- a/TypeCobol.Test/Compiler/Scanner/ResultFiles/CblProcessCompilerDirective.txt
+++ b/TypeCobol.Test/Compiler/Scanner/ResultFiles/CblProcessCompilerDirective.txt
@@ -6,7 +6,7 @@
 *** DIRECTIVE CBL|CICS=’string2’|CICS="string3"|CURRENCY=X"0AB2"|BLOCK0 ([3,64:CBL CICS(’string2’),CICS("string3"),CURRENCY(X"0AB2"),  BLOCK0]<CompilerDirective>) ***
 
 -- Line 3 --
-[1,4:0120]<IntegerLiteral>{120}
+[1,4:    ]<SpaceSeparator>
 *** DIRECTIVE PROCESS|EXIT= INEXIT([’str1’,]mod1) ,LIBEXIT([’str2’,]mod2)  ([5,65:PROCESS EXIT( INEXIT([’str1’,]mod1) ,LIBEXIT([’str2’,]mod2) )]<CompilerDirective>) ***
 
 -- Line 4 --

--- a/TypeCobol.Test/Compiler/Scanner/ResultFiles/UserDefinedWords.txt
+++ b/TypeCobol.Test/Compiler/Scanner/ResultFiles/UserDefinedWords.txt
@@ -15,3 +15,33 @@
 [49,50:==]<PseudoTextDelimiter>
 [31,31]<5,Error,Tokens>Invalid character found after * : expecting space, *, > or C
 
+-- Line 3 --
+[1,9:123ABC-01]<UserDefinedWord>
+[10,10: ]<SpaceSeparator>
+[11,13:123]<IntegerLiteral>{123}
+[14,14: ]<SpaceSeparator>
+[15,18:123a]<UserDefinedWord>
+[19,19: ]<SpaceSeparator>
+[20,26:123-abc]<UserDefinedWord>
+
+-- Line 4 --
+[1,1: ]<SpaceSeparator>
+[2,5:-123]<DecimalLiteral>{-123|0>-123}
+[6,11:ABC-01]<UserDefinedWord>
+[12,12: ]<SpaceSeparator>
+[13,23:_123ABC-01_]<UserDefinedWord>
+[24,24: ]<SpaceSeparator>
+[25,31:123ABC-]<UserDefinedWord>
+[32,32: ]<SpaceSeparator>
+[33,35:123]<IntegerLiteral>{123}
+[36,37:- ]<MinusOperator>
+[38,40:123]<IntegerLiteral>{123}
+[41,44:-456]<DecimalLiteral>{-456|0>-456}
+[45,45: ]<SpaceSeparator>
+[46,52:123E-06]<FloatingPointLiteral>{123|0>123E-6>0,000123}
+[53,53: ]<SpaceSeparator>
+[54,56:123]<IntegerLiteral>{123}
+[57,58:-4]<DecimalLiteral>{-4|0>-4}
+[59,59:X]<UserDefinedWord>
+[46,52]<17,Error,Tokens>Invalid floating point numeric literal format : a decimal point must be included in the mantissa 1.23E+4
+

--- a/TypeCobol.Test/Compiler/Scanner/TestTokenTypes.cs
+++ b/TypeCobol.Test/Compiler/Scanner/TestTokenTypes.cs
@@ -197,7 +197,9 @@ namespace TypeCobol.Test.Compiler.Scanner
             testName = "UserDefinedWords";
             testLines = new string[] {
                 "laurent_prud-on10",
-                "!super-_@#1254540.10azfdaedf99*8:tshg; prud'hon'=="
+                "!super-_@#1254540.10azfdaedf99*8:tshg; prud'hon'==",
+                "123ABC-01 123 123a 123-abc",
+                " -123ABC-01 _123ABC-01_ 123ABC- 123- 123-456 123E-06 123-4X"
             };
             result = ScannerUtils.ScanLines(testLines);
             ScannerUtils.CheckWithResultFile(result, testName);
@@ -341,7 +343,7 @@ namespace TypeCobol.Test.Compiler.Scanner
             string[] testLines = new string[] {
                 "CBL NOADATA AFP(VOLATILE) ARCH(6) CODEPAGE(1140) BUFSIZE(1K)",
                 "  CBL CICS(’string2’),CICS(\"string3\"),CURRENCY(X\"0AB2\"),  BLOCK0",
-                "0120PROCESS EXIT( INEXIT([’str1’,]mod1) ,LIBEXIT([’str2’,]mod2) )",
+                "    PROCESS EXIT( INEXIT([’str1’,]mod1) ,LIBEXIT([’str2’,]mod2) )",
                 "PROCESS FLAG(I,I) FLAGSTD(x[yy][,0]) ",
                 "CBL TOTO",
                 "CBL ARCH.",

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -744,13 +744,13 @@ namespace TypeCobol.Compiler.Scanner
                 //   message informing the user that these spaces are mandatory, because a subtraction was most likey intended in this case.
                 // 000010-000050 should be interpreted as a range of numbers (indicated by separating the two bounding numbers of the range 
                 //   by a hyphen) in sequence-number-fields of compiler directive statements (ex: DELETE).
-                
+
                 // CURRENT behavior of method ScanNumericLiteral :
                 // This method matches chars as long as they are characters allowed in a numeric literal.
                 // Then, it checks the format of the matched string, and returns either a NumericLiteral or Invalid token.
                 // If we write 123ABC, ScanNumericLiteral will match only 123, return a perfectly valid numeric literal,
                 // and place the currentIndex to match the next token on the char A.
-                
+
                 // PROPOSED SOLUTION :
                 // * in the Scanner :
                 // If a token is starting with a digit, we first try to scan it as a numeric literal (most common case).
@@ -762,11 +762,18 @@ namespace TypeCobol.Compiler.Scanner
                 // (keyword, user defined word ...).
                 // * in the Grammar :
                 // We must allow numeric literal tokens (in addition to user defind words) in section and paragraph name rules.
-                
+
+                // => additional PROBLEM after test : 
+                // 123. is already matched by the grammar in the reference documentation as a valid dataDescriptionEntry.
+                // But according to the same spec, 123. is also a valid paragraphHeader.
+                // TO DO : check which one of the two alternatives must be favored in the real world ?
+                // In the meantime, nothing was changed in the grammar file : purely numeric paragraph identifiers are not supported.
+
                 // LIMITATIONS :
                 // User defined words of the form 123E-4 or 123-4X are valid according to the spec but will not be supported 
                 // by this compiler. 
-                // These cases are considered highly improbable, but we will have to ckeck on a large body of existing programs.
+                // These cases are considered highly improbable, but we will have to check on a large body of existing programs.
+                // Purely numeric aragraph and section names are not supported.
 
                 case '0':
                 case '1':
@@ -1475,7 +1482,7 @@ namespace TypeCobol.Compiler.Scanner
                 }
             }
 
-            /* The restriction below can not be p^roperly implemented, because we need to suport statements such as
+            /* The restriction below can not be prroperly implemented, because we need to suport statements such as
                REPLACING ==:TAG:== BY ==EXEC-==
 
             // a COBOL word can not end with a hyphen => exlude the hyphen from the matched word

--- a/TypeCobol/Compiler/Scanner/TokensLine.cs
+++ b/TypeCobol/Compiler/Scanner/TokensLine.cs
@@ -161,9 +161,17 @@ namespace TypeCobol.Compiler.Scanner
         internal void RemoveDiagnosticsForLastSourceToken()
         {
             Token lastToken = SourceTokens.Last();
-            if(lastToken != null)
+            RemoveDiagnosticsForToken(lastToken);
+        }
+
+        /// <summary>
+        /// Remove all diagnostics already registered for a given token 
+        /// </summary>
+        internal void RemoveDiagnosticsForToken(Token token)
+        {
+            if (token != null)
             {
-                foreach(Diagnostic diag in GetDiagnosticsForToken(lastToken).ToArray())
+                foreach (Diagnostic diag in GetDiagnosticsForToken(token).ToArray())
                 {
                     ScannerDiagnostics.Remove(diag);
                 }


### PR DESCRIPTION
First attempt to implement the ambiguous spec for user defined words starting with a digit :

PROBLEMS :   
123 is a valid user defined word (for section & paragraph names) AND a valid numeric literal.  
123E-4 is a valid user defined word (for any type of name) AND a valid numeric literal (floating point format).  
123-456 is a valid user defined word (for section & paragraph names), AND it could be interpreted as two numeric literals. NB: it is NOT a valid subtraction (minus must be preceded and followedf by space) but we would like to display a nice error message informing the user that these spaces are mandatory, because a subtraction was most likely intended in this case.  
000010-000050 should be interpreted as a range of numbers (indicated by separating the two bounding numbers of the range by a hyphen) in sequence-number-fields of compiler directive statements (ex: DELETE).  
