### PR TITLE
Fixed issue #60

### DIFF
--- a/TypeCobol.Test/Compiler/Parser/ResultFiles/Statements/MOVE.txt
+++ b/TypeCobol.Test/Compiler/Parser/ResultFiles/Statements/MOVE.txt
@@ -11,3 +11,5 @@
 
 [[SentenceEnd]] [19,19+:.]<PeriodSeparator> --> [19,19+:.]<PeriodSeparator>
 
+[[MoveStatement]] [18,21:MOVE]<MOVE> --> [46,54:SOMEWHERE]<UserDefinedWord>
+

--- a/TypeCobol.Test/Compiler/Parser/Samples/Statements/MOVE.cbl
+++ b/TypeCobol.Test/Compiler/Parser/Samples/Statements/MOVE.cbl
@@ -3,3 +3,8 @@ MOVE FUNCTION LENGTH (x) TO x.
 * special registers
 MOVE LENGTH OF x TO x.
 MOVE LENGTH x TO x.
+* continuations
+                 MOVE 'Lorem ipsum dolor sit amet, consectetur adi
+-               'piscing elit, sed do eiusmod tempor incididunt ut
+-               'labore et dolore magna aliqua                 '  
+                                         TO  SOMEWHERE           

--- a/TypeCobol.Test/Compiler/Scanner/ResultFiles/AlphanumericLiterals-continuations.txt
+++ b/TypeCobol.Test/Compiler/Scanner/ResultFiles/AlphanumericLiterals-continuations.txt
@@ -201,3 +201,31 @@
 [3,3+:.]<PeriodSeparator>
 [1,1]<23,Warning,TextFormat>Area A (first 4 columns) of a continuation line must be blank, source text can only be continued in Area B of the next line
 
+-- Line 47 --
+[1,1: ]<SpaceSeparator>
+
+-- Line 48 --
+[2,9:Issue 60]<CommentLine>
+
+-- Line 49 --
+[1,17:                 ]<SpaceSeparator>
+[18,21:MOVE]<MOVE>
+[22,22: ]<SpaceSeparator>
+=>continued:[23,66:'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt utlabore et dolore magna aliqua                 ']<AlphanumericLiteral>(',Y,N){Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt utlabore et dolore magna aliqua                 }
+
+-- Line 50 --
+[2,16:               ]<SpaceSeparator>
+=>continuation:=>continued:[17,66:'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt utlabore et dolore magna aliqua                 ']<AlphanumericLiteral>(',Y,N){Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt utlabore et dolore magna aliqua                 }
+
+-- Line 51 --
+[2,16:               ]<SpaceSeparator>
+=>continuation:[17,64:'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt utlabore et dolore magna aliqua                 ']<AlphanumericLiteral>(',Y,Y){Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt utlabore et dolore magna aliqua                 }
+[65,66:  ]<SpaceSeparator>
+
+-- Line 52 --
+[1,42:                                          ]<SpaceSeparator>
+[43,44:TO]<TO>
+[45,46:  ]<SpaceSeparator>
+[47,55:SOMEWHERE]<UserDefinedWord>
+[56,66:           ]<SpaceSeparator>
+

--- a/TypeCobol.Test/Compiler/Scanner/TestContinuations.cs
+++ b/TypeCobol.Test/Compiler/Scanner/TestContinuations.cs
@@ -147,6 +147,12 @@ namespace TypeCobol.Test.Compiler.Scanner
                 new TestTextLine('-',"= ="),
                 new TestTextLine('-',"=cool="),
                 new TestTextLine('-',"=."),
+                new TestTextLine(" "),
+                new TestTextLine('*',"Issue 60"),
+                new TestTextLine(' ',"                MOVE 'Lorem ipsum dolor sit amet, consectetur adi"),
+                new TestTextLine('-',"               'piscing elit, sed do eiusmod tempor incididunt ut"),
+                new TestTextLine('-',"               'labore et dolore magna aliqua                 '  "),
+                new TestTextLine(' ',"                                         TO  SOMEWHERE           ")
             };
             string result = ScannerUtils.ScanLines(textLines);
             ScannerUtils.CheckWithResultFile(result, testName);

--- a/TypeCobol/Compiler/Scanner/Token.cs
+++ b/TypeCobol/Compiler/Scanner/Token.cs
@@ -271,9 +271,19 @@ namespace TypeCobol.Compiler.Scanner
         
         internal void CorrectType(TokenType tokenType)
         {
+            // Copy token type and family from the continuation token
             TokenType = tokenType;
             TokenFamily = TokenUtils.GetTokenFamilyFromTokenType(tokenType);
-            SetInitialChannelFromTokenFamily();
+
+            // If it is the first continued token on the top of a list of continuation lines
+            // => set its channel according to the global token type
+            if (Channel != CHANNEL_ContinuationTokens)
+            {
+                SetInitialChannelFromTokenFamily();
+            }
+            // If it is a continued ContinuationToken, a token in the middle of a list of continuation lines
+            // => leave its channel to the original value CHANNEL_ContinuationTokens 
+            //    because it should be filtered at the parser stage
         }
 
         // --- Continuation lines & multiline tokens ---


### PR DESCRIPTION
in Token class, a ContinuationToken should always keep a channel value of CHANNEL_ContinuationTokens (to be filtered before the parsing stage), even if it is itself continued (because it is in the middle of a list of continuation lines).
The Scanner and Parser tests suites have been augmented with the tests case given in the issue #60.