### PR TITLE
Upgraded references to Antlr Nuget packages : version 4.4 => 4.5.

### DIFF
--- a/TypeCobol.Grammar/Grammars/Cobol/CobolCodeElements.g4
+++ b/TypeCobol.Grammar/Grammars/Cobol/CobolCodeElements.g4
@@ -2268,7 +2268,7 @@ linkageSectionHeader:
 //	fdFormat1 | fdFormat2 | fdFormat3 | fdFormat4;
 
 fdFormat1:
-	FD fileName fdExternal? fdGlobal? fdBlock? (fdRecord1 | fdRecord2 | fdRecord3)? fdLabel1? fdValue? fdData? fdLineage? fdRecording? fdCodeset? PeriodSeparator;
+	FD fileName fdExternal? fdGlobal? fdBlock? (fdRecord1 | fdRecord2 | fdRecord3)? fdLabel1? fdValue? fdData? fdLinage? fdRecording? fdCodeset? PeriodSeparator;
 
 fdFormat2:
 	FD fileName fdExternal? fdGlobal? fdBlock? (fdRecord1 | fdRecord2 | fdRecord3)? fdLabel2? fdValue? fdData? PeriodSeparator;
@@ -2277,7 +2277,7 @@ fdFormat3:
 	FD fileName fdExternal? fdGlobal? (fdRecord1 | fdRecord3)? PeriodSeparator;
 
 fdFormat4:
-	SD fileName (fdRecord1 | fdRecord2 | fdRecord3)? fdData? fdBlock? fdLabel1? fdValue? fdLineage? fdCodeset? PeriodSeparator;
+	SD fileName (fdRecord1 | fdRecord2 | fdRecord3)? fdData? fdBlock? fdLabel1? fdValue? fdLinage? fdCodeset? PeriodSeparator;
 
 fdExternal:
 	IS? EXTERNAL;
@@ -2311,8 +2311,8 @@ fdValue:
 fdData:
 	DATA fdRecordVerb dataName+;
 
-fdLineage:
-	LINEAGE IS? (dataName | IntegerLiteral) LINES? fdClause2;
+fdLinage:
+	LINAGE IS? (dataName | IntegerLiteral) LINES? fdClause2;
 
 fdClause2:
 	fdFooting? fdTop? fdBottom?;

--- a/TypeCobol.Grammar/TypeCobol.Grammar.csproj
+++ b/TypeCobol.Grammar/TypeCobol.Grammar.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Antlr4.4.4.1-alpha001\build\Antlr4.props" Condition="Exists('..\packages\Antlr4.4.4.1-alpha001\build\Antlr4.props')" />
+  <Import Project="..\packages\Antlr4.4.5-alpha002\build\Antlr4.props" Condition="Exists('..\packages\Antlr4.4.5-alpha002\build\Antlr4.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -39,8 +39,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr4.Runtime, Version=4.4.0.0, Culture=neutral, PublicKeyToken=edc21c04cf562012, processorArchitecture=MSIL">
-      <HintPath>..\packages\Antlr4.Runtime.4.4.1-alpha001\lib\net45\Antlr4.Runtime.dll</HintPath>
+    <Reference Include="Antlr4.Runtime, Version=4.5.0.0, Culture=neutral, PublicKeyToken=e9931a4108ef2354, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr4.Runtime.4.5-alpha002\lib\net45\Antlr4.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -71,21 +71,23 @@
       <CustomToolNamespace>TypeCobol.Compiler.Parser.Generated</CustomToolNamespace>
     </Antlr4>
     <None Include="Grammars\Cobol\TokenTypes.xlsx" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="How to configure antlr 4 in Visual Studio.txt" />
     <Content Include="How to edit antlr 4 grammar files.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild"> 
-     <PropertyGroup> 
-       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText> 
-     </PropertyGroup> 
-     <Error Condition="!Exists('..\packages\Antlr4.4.4.1-alpha001\build\Antlr4.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.4.4.1-alpha001\build\Antlr4.props'))" /> 
-     <Error Condition="!Exists('..\packages\Antlr4.4.4.1-alpha001\build\Antlr4.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.4.4.1-alpha001\build\Antlr4.targets'))" /> 
-   </Target> 
-  <Import Project="..\packages\Antlr4.4.4.1-alpha001\build\Antlr4.targets" Condition="Exists('..\packages\Antlr4.4.4.1-alpha001\build\Antlr4.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Antlr4.4.5-alpha002\build\Antlr4.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.4.5-alpha002\build\Antlr4.props'))" />
+    <Error Condition="!Exists('..\packages\Antlr4.4.5-alpha002\build\Antlr4.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.4.5-alpha002\build\Antlr4.targets'))" />
+  </Target>
+  <Import Project="..\packages\Antlr4.4.5-alpha002\build\Antlr4.targets" Condition="Exists('..\packages\Antlr4.4.5-alpha002\build\Antlr4.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/TypeCobol.Grammar/packages.config
+++ b/TypeCobol.Grammar/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr4" version="4.4.1-alpha001" targetFramework="net452" userInstalled="true" />
-  <package id="Antlr4.Runtime" version="4.4.1-alpha001" targetFramework="net452" userInstalled="true" />
+  <package id="Antlr4" version="4.5-alpha002" targetFramework="net45" developmentDependency="true" />
+  <package id="Antlr4.Runtime" version="4.5-alpha002" targetFramework="net45" />
 </packages>

--- a/TypeCobol.Test/Compiler/Preprocessor/DirectiveResultFiles/Copy.txt
+++ b/TypeCobol.Test/Compiler/Preprocessor/DirectiveResultFiles/Copy.txt
@@ -78,7 +78,7 @@
 [32,33]<28,Error,Syntax>Syntax error : mismatched input 'IN' expecting PeriodSeparator
 
 -- Line 24 --
-*** DIRECTIVE INVALID SYNTAX -> COPY TEXTNAME6 ([8,11:COPY]<COPY>[12,12: ]<SpaceSeparator>[13,21:TEXTNAME6]<UserDefinedWord>[22,22: ]<SpaceSeparator>[23,24:OF]<OF>[25,25: ]<SpaceSeparator>[26,33:SUPPRESS]<SUPPRESS>[34,34+:.]<PeriodSeparator>) ***
+*** DIRECTIVE INVALID SYNTAX -> COPY.SUPPRESS TEXTNAME6 ([8,11:COPY]<COPY>[12,12: ]<SpaceSeparator>[13,21:TEXTNAME6]<UserDefinedWord>[22,22: ]<SpaceSeparator>[23,24:OF]<OF>[25,25: ]<SpaceSeparator>[26,33:SUPPRESS]<SUPPRESS>[34,34+:.]<PeriodSeparator>) ***
 [26,33]<28,Error,Syntax>Syntax error : missing {AlphanumericLiteral, UserDefinedWord} at 'SUPPRESS'
 
 -- Line 25 --

--- a/TypeCobol.Test/TypeCobol.Test.csproj
+++ b/TypeCobol.Test/TypeCobol.Test.csproj
@@ -38,8 +38,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr4.Runtime, Version=4.4.0.0, Culture=neutral, PublicKeyToken=edc21c04cf562012, processorArchitecture=MSIL">
-      <HintPath>..\packages\Antlr4.Runtime.4.4.1-alpha001\lib\net45\Antlr4.Runtime.dll</HintPath>
+    <Reference Include="Antlr4.Runtime, Version=4.5.0.0, Culture=neutral, PublicKeyToken=e9931a4108ef2354, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr4.Runtime.4.5-alpha002\lib\net45\Antlr4.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -327,7 +327,9 @@
     <None Include="Compiler\Preprocessor\ReplaceTestFiles\PgmReplaceSingleToMultiple.cbl" />
     <None Include="Compiler\Text\Samples\MSVCINP free format.cpy" />
     <None Include="Compiler\Text\Samples\MSVCOUT.cpy" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TypeCobol\TypeCobol.csproj">

--- a/TypeCobol.Test/packages.config
+++ b/TypeCobol.Test/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr4.Runtime" version="4.4.1-alpha001" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-Main" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" userInstalled="true" />
+  <package id="Antlr4.Runtime" version="4.5-alpha002" targetFramework="net45" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
 </packages>

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder.cs
@@ -80,27 +80,27 @@ namespace TypeCobol.Compiler.Parser
         {
             var authoringProperties = new AuthoringProperties();
 
-            if (context.authorParagraph().Count > 0)
+            if (context.authorParagraph().Length > 0)
             {
                 authoringProperties.Author =
                     BuildCommentEntriesProperty(context.authorParagraph().SelectMany(p => p.CommentEntry()));
             }
-            if (context.dateCompiledParagraph().Count > 0)
+            if (context.dateCompiledParagraph().Length > 0)
             {
                 authoringProperties.DateCompiled =
                     BuildCommentEntriesProperty(context.dateCompiledParagraph().SelectMany(p => p.CommentEntry()));
             }
-            if (context.dateWrittenParagraph().Count > 0)
+            if (context.dateWrittenParagraph().Length > 0)
             {
                 authoringProperties.DateWritten =
                     BuildCommentEntriesProperty(context.dateWrittenParagraph().SelectMany(p => p.CommentEntry()));
             }
-            if (context.installationParagraph().Count > 0)
+            if (context.installationParagraph().Length > 0)
             {
                 authoringProperties.Installation =
                     BuildCommentEntriesProperty(context.installationParagraph().SelectMany(p => p.CommentEntry()));
             }
-            if (context.securityParagraph().Count > 0)
+            if (context.securityParagraph().Length > 0)
             {
                 authoringProperties.Security =
                     BuildCommentEntriesProperty(context.securityParagraph().SelectMany(p => p.CommentEntry()));
@@ -505,7 +505,7 @@ namespace TypeCobol.Compiler.Parser
         public override void EnterAlterStatement(CobolCodeElementsParser.AlterStatementContext context)
         {
             var statement = new AlterStatement();
-            // context.procedureName().Count %2 != 0 can never happen outside of syntax errors
+            // context.procedureName().Length %2 != 0 can never happen outside of syntax errors
             AlterStatement.Alter alter = null;
             foreach (var p in context.procedureName())
             {

--- a/TypeCobol/Compiler/Parser/LogicalExpressionBuilder.cs
+++ b/TypeCobol/Compiler/Parser/LogicalExpressionBuilder.cs
@@ -24,10 +24,10 @@ namespace TypeCobol.Compiler.Parser
             if (context.andCondition() != null)
             {
                 var conditions = context.andCondition();
-                if (conditions.Count > 0)
+                if (conditions.Length > 0)
                 {
                     LogicalExpression left = createCondition(conditions[0]);
-                    if (conditions.Count > 1)
+                    if (conditions.Length > 1)
                     {
                         LogicalExpression right = createCondition(conditions[1]);
                         return new OR(left, right);
@@ -43,10 +43,10 @@ namespace TypeCobol.Compiler.Parser
             if (context.notCondition() != null)
             {
                 var conditions = context.notCondition();
-                if (conditions.Count > 0)
+                if (conditions.Length > 0)
                 {
                     LogicalExpression left = createCondition(conditions[0]);
-                    if (conditions.Count > 1)
+                    if (conditions.Length > 1)
                     {
                         LogicalExpression right = createCondition(conditions[1]);
                         return new AND(left, right);
@@ -254,10 +254,10 @@ namespace TypeCobol.Compiler.Parser
             char op = CreateOperator(context.relationalOperator());
             /*
             var operands = context.operand();
-            if (operands != null && operands.Count > 0)
+            if (operands != null && operands.Length > 0)
             {
                 Expression left = createOperand(operands[0]);
-                if (operands.Count > 1)
+                if (operands.Length > 1)
                 {
                     Expression right = createOperand(operands[1]);
                     relation = new Relation(left, op, right);
@@ -278,7 +278,7 @@ namespace TypeCobol.Compiler.Parser
             }
             *//*
             var relations = context.abbreviatedRelation();
-            if (relations != null && relations.Count > 0)
+            if (relations != null && relations.Length > 0)
             {
                 return createAbbreviatedRelation(relation, relations.ToArray());
             }
@@ -288,7 +288,7 @@ namespace TypeCobol.Compiler.Parser
 
         private LogicalExpression createCondition(CobolCodeElementsParser.DataPointerRelationConditionContext context)
         {
-            if (context.dataPointer() != null && context.dataPointer().Count > 0)
+            if (context.dataPointer() != null && context.dataPointer().Length > 0)
             {
                 var first = context.dataPointer().ElementAt(0);
                 Expression left = createOperand(context.dataPointer().ElementAt(0));
@@ -297,7 +297,7 @@ namespace TypeCobol.Compiler.Parser
                 char op = createOperator(context.relationConditionEquality());
 
                 Expression right = null;
-                if (context.dataPointer().Count > 1)
+                if (context.dataPointer().Length > 1)
                 {
                     var second = context.dataPointer().ElementAt(1);
                     right = createOperand(second);
@@ -325,14 +325,14 @@ namespace TypeCobol.Compiler.Parser
 
         private LogicalExpression createCondition(CobolCodeElementsParser.ProgramPointerRelationConditionContext context)
         {
-            if (context.procedureOrFunctionPointer() != null && context.procedureOrFunctionPointer().Count > 0)
+            if (context.procedureOrFunctionPointer() != null && context.procedureOrFunctionPointer().Length > 0)
             {
                 Expression left = createOperand(context.procedureOrFunctionPointer().ElementAt(0));
 
                 char op = createOperator(context.relationConditionEquality());
 
                 Expression right = null;
-                if (context.procedureOrFunctionPointer().Count > 1)
+                if (context.procedureOrFunctionPointer().Length > 1)
                 {
                     right = createOperand(context.procedureOrFunctionPointer().ElementAt(1));
                 }
@@ -350,14 +350,14 @@ namespace TypeCobol.Compiler.Parser
 
         private LogicalExpression createCondition(CobolCodeElementsParser.ObjectReferenceRelationConditionContext context)
         {
-            if (context.objectReference() != null && context.objectReference().Count > 0)
+            if (context.objectReference() != null && context.objectReference().Length > 0)
             {
                 Expression left = createOperand(context.objectReference().ElementAt(0));
 
                 char op = createOperator(context.relationConditionEquality());
 
                 Expression right = null;
-                if (context.objectReference().Count > 1)
+                if (context.objectReference().Length > 1)
                 {
                     right = createOperand(context.objectReference().ElementAt(1));
                 }

--- a/TypeCobol/Compiler/Parser/StatementsBuilder.cs
+++ b/TypeCobol/Compiler/Parser/StatementsBuilder.cs
@@ -232,7 +232,7 @@ namespace TypeCobol.Compiler.Parser
         private InspectConvertingStatement CreateInspectConverting(CobolCodeElementsParser.InspectConvertingContext context, Identifier identifier)
         {
             var statement = new InspectConvertingStatement();
-            if (context.identifierOrLiteral().Count > 0)
+            if (context.identifierOrLiteral().Length > 0)
             {
                 int c = 0;
                 foreach (var i in context.identifierOrLiteral())

--- a/TypeCobol/TypeCobol.csproj
+++ b/TypeCobol/TypeCobol.csproj
@@ -38,8 +38,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr4.Runtime, Version=4.4.0.0, Culture=neutral, PublicKeyToken=edc21c04cf562012, processorArchitecture=MSIL">
-      <HintPath>..\packages\Antlr4.Runtime.4.4.1-alpha001\lib\net45\Antlr4.Runtime.dll</HintPath>
+    <Reference Include="Antlr4.Runtime, Version=4.5.0.0, Culture=neutral, PublicKeyToken=e9931a4108ef2354, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr4.Runtime.4.5-alpha002\lib\net45\Antlr4.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -379,7 +379,9 @@
     <None Include="Documentation\Studies\Literals and Identifiers in parser rules.xlsx" />
     <None Include="Documentation\Studies\Pipeline - compilation steps.docx" />
     <None Include="Documentation\Studies\Text editors functions study.xlsx" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Documentation\Presentations\" />

--- a/TypeCobol/packages.config
+++ b/TypeCobol/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr4.Runtime" version="4.4.1-alpha001" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-Main" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" userInstalled="true" />
+  <package id="Antlr4.Runtime" version="4.5-alpha002" targetFramework="net45" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
 </packages>

--- a/TypeCobolStudio/TypeCobolStudio.csproj
+++ b/TypeCobolStudio/TypeCobolStudio.csproj
@@ -38,8 +38,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr4.Runtime">
-      <HintPath>..\packages\Antlr4.Runtime.4.4.1-alpha001\lib\net45\Antlr4.Runtime.dll</HintPath>
+    <Reference Include="Antlr4.Runtime, Version=4.5.0.0, Culture=neutral, PublicKeyToken=e9931a4108ef2354, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr4.Runtime.4.5-alpha002\lib\net45\Antlr4.Runtime.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="ICSharpCode.AvalonEdit, Version=5.0.1.0, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
       <HintPath>..\packages\AvalonEdit.5.0.2\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>
@@ -130,7 +131,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/TypeCobolStudio/packages.config
+++ b/TypeCobolStudio/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr4.Runtime" version="4.4.1-alpha001" targetFramework="net452" />
-  <package id="AvalonEdit" version="5.0.2" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-Main" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-WPF" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="Rx-XAML" version="2.2.5" targetFramework="net452" userInstalled="true" />
+  <package id="Antlr4.Runtime" version="4.5-alpha002" targetFramework="net45" />
+  <package id="AvalonEdit" version="5.0.2" targetFramework="net452" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-WPF" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-XAML" version="2.2.5" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Fixed CodeElementBuilders source code to handle the following breaking change in Antlr v4.5 : "ParserRuleContext.GetTokens  now returns  ITerminalNode[]  in all runtimes (previously .NET 4.5+ did not)" => replaced IList.Count by Array.Length everywhere.
Spotted a typo in the grammar : "LINEAGE" instead of "LINAGE" => also fixed this error on the fly.