### PR TITLE
Fixes issues #124 and #125 for incremental parsing

### DIFF
--- a/TypeCobol.Test/TestCollection.cs
+++ b/TypeCobol.Test/TestCollection.cs
@@ -115,7 +115,7 @@ namespace TypeCobol.Test
             TestCodeElements.Check_IdentificationCodeElements();
             TestCodeElements.Check_ParagraphCodeElements();
             //TODO  TestCodeElements.Check_EntryCodeElements();// RefreshProgramClassDocumentSnapshot
-            //TODO  TestParser.Check_BeforeAfterInsertion();  // breaks when calling these <-- FIXME
+            TestParser.Check_BeforeAfterInsertion();
 
             string root = "Compiler" + Path.DirectorySeparatorChar + "Parser" + Path.DirectorySeparatorChar + "Samples";
             foreach (string directory in Directory.GetDirectories(PlatformUtils.GetPathForProjectFile(root)))

--- a/TypeCobol/Compiler/AntlrUtils/DiagnosticSyntaxErrorListener.cs
+++ b/TypeCobol/Compiler/AntlrUtils/DiagnosticSyntaxErrorListener.cs
@@ -44,7 +44,7 @@ namespace TypeCobol.Compiler.AntlrUtils
             }
 
             // Register a new diagnostic
-            ParserDiagnostic diagnostic = new ParserDiagnostic(msg, (Token)offendingSymbol, ruleStack.ToString());
+            ParserDiagnostic diagnostic = new ParserDiagnostic(msg, (IToken)offendingSymbol, ruleStack.ToString());
             Diagnostics.Add(diagnostic);
         }
     }
@@ -55,17 +55,17 @@ namespace TypeCobol.Compiler.AntlrUtils
     /// </summary>
     public class ParserDiagnostic : Diagnostic
     {
-        public ParserDiagnostic(string message, Token offendingSymbol, string ruleStack) :
-            base(MessageCode.SyntaxErrorInParser, offendingSymbol != null ? offendingSymbol.Column : -1, offendingSymbol != null ? offendingSymbol.EndColumn : -1, message)
+        public ParserDiagnostic(string message, IToken offendingSymbol, string ruleStack) :
+            base(MessageCode.SyntaxErrorInParser, offendingSymbol != null ? offendingSymbol.Column : -1, offendingSymbol != null ? offendingSymbol.StopIndex + 1 : -1, message)
         {
             OffendingSymbol = offendingSymbol;
             RuleStack = ruleStack;
         }
 
         /// <summary>
-        /// First token which did not match the current rule in the gramme
+        /// First token which did not match the current rule in the grammar
         /// </summary>
-        public Token OffendingSymbol { get; private set; }
+        public IToken OffendingSymbol { get; private set; }
 
         /// <summary>
         /// Stack of grammar rules which were being recognized when an incorrect token occured

--- a/TypeCobol/Compiler/CodeElements/CodeElement.cs
+++ b/TypeCobol/Compiler/CodeElements/CodeElement.cs
@@ -95,7 +95,7 @@ namespace TypeCobol.Compiler.CodeElements
         {
             get
             {
-                throw new NotImplementedException();
+                return -1;
                 //return ConsumedTokens[0].Line;
             }
         }
@@ -112,7 +112,7 @@ namespace TypeCobol.Compiler.CodeElements
         {
             get
             {
-                return 1;
+                return Token.CHANNEL_SourceTokens;
             }
         }
 

--- a/TypeCobol/Compiler/CodeElements/CodeElementType.cs
+++ b/TypeCobol/Compiler/CodeElements/CodeElementType.cs
@@ -14,7 +14,7 @@ namespace TypeCobol.Compiler.CodeElements
         // Code structure
 
         // -- Program --
-        ProgramIdentification,
+        ProgramIdentification = 1, // <- value 1 is mandatory to synchronize this list with the Antlr parser
         ProgramEnd,
         // -- Class --
         ClassIdentification,

--- a/TypeCobol/Compiler/CompilationDocument.cs
+++ b/TypeCobol/Compiler/CompilationDocument.cs
@@ -451,7 +451,7 @@ namespace TypeCobol.Compiler
                     currentProcessedTokensLineVersion = currentProcessedTokensLineVersion.next;
 
                     // Update the processed tokens document snapshot
-                    ProcessedTokensDocumentSnapshot = new ProcessedTokensDocument(tokensDocument, currentProcessedTokensLineVersion, processedTokensDocumentLines);
+                    ProcessedTokensDocumentSnapshot = new ProcessedTokensDocument(tokensDocument, currentProcessedTokensLineVersion, processedTokensDocumentLines.ToImmutable());
                 }
 
                 // Send events to all listeners

--- a/TypeCobol/Compiler/CompilationUnit.cs
+++ b/TypeCobol/Compiler/CompilationUnit.cs
@@ -70,7 +70,7 @@ namespace TypeCobol.Compiler
                 }
                 else
                 {
-                    ImmutableList<CodeElementsLine>.Builder codeElementsDocumentLines = ((ImmutableList<CodeElementsLine>)previousCodeElementsDocument.Lines).ToBuilder();
+                    ImmutableList<CodeElementsLine>.Builder codeElementsDocumentLines = ((ImmutableList<CodeElementsLine>)processedTokensDocument.Lines).ToBuilder();
                     IList<DocumentChange<ICodeElementsLine>> documentChanges = CodeElementsParserStep.ParseProcessedTokensLinesChanges(TextSourceInfo, codeElementsDocumentLines, processedTokensLineChanges, PrepareDocumentLineForUpdate, CompilerOptions);
 
                     // Create a new version of the document to track these changes
@@ -83,7 +83,7 @@ namespace TypeCobol.Compiler
                     currentCodeElementsLinesVersion = currentCodeElementsLinesVersion.next;
 
                     // Update the code elements document snapshot
-                    CodeElementsDocumentSnapshot = new CodeElementsDocument(processedTokensDocument, currentCodeElementsLinesVersion, codeElementsDocumentLines);
+                    CodeElementsDocumentSnapshot = new CodeElementsDocument(processedTokensDocument, currentCodeElementsLinesVersion, codeElementsDocumentLines.ToImmutable());
                 }
 
                 // Send events to all listeners

--- a/TypeCobol/Compiler/Parser/ProgramClassParserStep.cs
+++ b/TypeCobol/Compiler/Parser/ProgramClassParserStep.cs
@@ -30,8 +30,6 @@ namespace TypeCobol.Compiler.Parser
             CobolProgramClassParser cobolParser = new CobolProgramClassParser(tokenStream);
             // -> activate full ambiguities detection
             //parser.Interpreter.PredictionMode = PredictionMode.LlExactAmbigDetection; 
-            IAntlrErrorStrategy cobolErrorStrategy = new CobolErrorStrategy();
-            cobolParser.ErrorHandler = cobolErrorStrategy;
 
             // Register all parse errors in a list in memory
             DiagnosticSyntaxErrorListener errorListener = new DiagnosticSyntaxErrorListener();

--- a/TypeCobol/Compiler/Preprocessor/PreprocessorStep.cs
+++ b/TypeCobol/Compiler/Preprocessor/PreprocessorStep.cs
@@ -338,6 +338,7 @@ namespace TypeCobol.Compiler.Preprocessor
                     // Previous line is not a continuation but is continued : reset this line and stop navigating backwards
                     else if (previousLine.HasDirectiveTokenContinuationFromPreviousLine || previousLine.HasDirectiveTokenContinuedOnNextLine)
                     {
+                        lineIndex = previousLineIndex;
                         previousLine = (ProcessedTokensLine)prepareDocumentLineForUpdate(previousLineIndex, previousLine, CompilationStep.Preprocessor);
                         processedTokensLinesChanges.Add(new DocumentChange<IProcessedTokensLine>(DocumentChangeType.LineUpdated, previousLineIndex, previousLine));
                         if(!previousLine.HasDirectiveTokenContinuationFromPreviousLine)


### PR DESCRIPTION
The test TestPaser.Check_BeforeAfterInsertion() now runs correctly.
Main fixes for issue 124 :
- copy/paste error : choosed the wrong list of lines as a starting point when initializing the CodeElements parsing step
- the incremental parsing of CodeElements is not implement yet, so we must reset all CodeElements each time before starting to parse again

Main fixes for issue 125 : 
- bad channel number returned by CodeElement when used as IToken
- CodeElementType values were starting at 0 while the enumeration of tokens in an Antlr grammar is always transformed in a list of values starting at 1