### PR TITLE
Implementation of the legacy non-standard "*REMARKS COPY=()" EI syntax 

### DIFF
--- a/TypeCobol.Test/Compiler/Preprocessor/DirectiveResultFiles/Copy.txt
+++ b/TypeCobol.Test/Compiler/Preprocessor/DirectiveResultFiles/Copy.txt
@@ -118,7 +118,7 @@
 -- Line 33 --
 
 -- Line 34 --
-[8,72:REMARKS. COPY=(YIDCHB1                                           ]<CommentLine>
+*** DIRECTIVE REMARKS YIDCHB1 ([8,72:REMARKS. COPY=(YIDCHB1                                           ]<CommentLine>) ***
 
 -- Line 35 --
 [8,9:01]<IntegerLiteral>{1}

--- a/TypeCobol/Compiler/Directives/CompilerDirective.cs
+++ b/TypeCobol/Compiler/Directives/CompilerDirective.cs
@@ -49,6 +49,10 @@ namespace TypeCobol.Compiler.Directives
         // readyOrResetTraceCompilerStatement
         READY_TRACE,
         RESET_TRACE,
+        /// ------------
+        /// NON-STANDARD EI Compiler Directive
+        /// ------------
+        REMARKS,
         // replaceCompilerStatement
         REPLACE,
         REPLACE_OFF,
@@ -385,6 +389,28 @@ namespace TypeCobol.Compiler.Directives
         /// For details, see “REPLACING phrase” on page 533.       
         /// </summary>
         public IList<ReplaceOperation> ReplaceOperations { get; set; }
+
+#if EUROINFO_LEGACY_REPLACING_SYNTAX
+
+        /// <summary>
+        /// If true, remove the first 01 level data item found in the COPY text 
+        /// before copying it into the main program (legacy REPLACING syntax).
+        /// </summary>
+        public bool RemoveFirst01Level { get; set; }
+
+        /// <summary>
+        /// If true, insert SuffixChar before the first '-' in all user defined words found in the COPY text 
+        /// before copying it into the main program (legacy REPLACING syntax).
+        /// </summary>
+        public bool InsertSuffixChar { get; set; }
+
+        /// <summary>
+        /// Character which should be inserted before the first '-' in all user defined words found in the COPY text 
+        /// before copying it into the main program (legacy REPLACING syntax).
+        /// </summary>
+        public char SuffixChar { get; set; }
+
+#endif
 
         public override string ToString()
         {
@@ -754,6 +780,103 @@ namespace TypeCobol.Compiler.Directives
             sb.Append('>');
         }
     }
+
+#if EUROINFO_LEGACY_REPLACING_SYNTAX
+
+    /// <summary>
+    /// Legacy syntax used instead of COPY REPLACING :
+    /// *REMARKS. COPY=(YI03PCBA YI03PCBB).
+    /// 01 I03PCBA. COPY YI03PCBA.
+    /// 01 I03PCBB. COPY YI03PCBB.
+    /// 
+    /// Operations exécuted by the preprocessor :
+    /// - import COPY YI03PCB (text name without one char suffix)
+    /// - remove level 01 code element in the imported COPY
+    /// - insert one char suffix A or B before the first '-' in each data name inside the COPY
+    /// 
+    /// This enables to import two times the same COPY but with different names for its fields.
+    /// It is a legacy equivalent of COPY REPLACING + usage of partial names in the copy text.
+    /// </summary>
+    public class RemarksDirective : CompilerDirective
+    {
+        public RemarksDirective() : base(CompilerDirectiveType.REMARKS)
+        {
+            CopyTextNamesVariations = new List<TextNameVariation>();
+        }
+
+        /// <summary>
+        /// List of variations for COPY text names included in the program
+        /// </summary>
+        public IList<TextNameVariation> CopyTextNamesVariations { get; set; }        
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            bool isFirst = true;
+            foreach (var textNameViariation in CopyTextNamesVariations)
+            {
+                if (isFirst)
+                {
+                    isFirst = false;
+                }
+                else
+                {
+                    sb.Append(" ,");
+                }
+                sb.Append(textNameViariation.ToString());
+            }
+            return Type.ToString() + " " + sb.ToString();
+        }
+
+        /// <summary>
+        /// Stores a text name : if the text name is of length 8, then the last character must be interpreted like a suffix
+        /// </summary>
+        public class TextNameVariation
+        {
+            public TextNameVariation(string textNameWithSuffix)
+            {
+                if (textNameWithSuffix.Length > 8)
+                {
+                    throw new ArgumentException("Text name should be at most 8 chars long");
+                }
+                TextNameWithSuffix = textNameWithSuffix;
+            }
+
+            /// <summary>
+            /// Text name with potential appended suffix
+            /// </summary>
+            public string TextNameWithSuffix { get; private set; }
+
+            /// <summary>
+            /// True if a suffix was appended to text name
+            /// </summary>
+            public bool HasSuffix { get { return TextNameWithSuffix.Length == 8; } }
+
+            /// <summary>
+            /// Text name without suffix
+            /// </summary>
+            public string TextName { get { return HasSuffix ? TextNameWithSuffix.Substring(0, 7) : TextNameWithSuffix; } }
+
+            /// <summary>
+            /// Suffix appended to text name
+            /// </summary>
+            public char SuffixChar { get { return HasSuffix ? TextNameWithSuffix[7] : (char)0; } }
+
+            public override string ToString()
+            {
+                if (HasSuffix)
+                {
+                    return TextName.Substring(0, 7) + "(" + SuffixChar + ")";
+                }
+                else
+                {
+                    return TextName;
+                }
+            }
+        }
+    }
+
+#endif
 
     /// <summary>
     /// p541: REPLACE statement

--- a/TypeCobol/Compiler/Directives/CompilerDirective.cs
+++ b/TypeCobol/Compiler/Directives/CompilerDirective.cs
@@ -49,10 +49,10 @@ namespace TypeCobol.Compiler.Directives
         // readyOrResetTraceCompilerStatement
         READY_TRACE,
         RESET_TRACE,
-        /// ------------
-        /// NON-STANDARD EI Compiler Directive
-        /// ------------
+#if EUROINFO_LEGACY_REPLACING_SYNTAX
+        // NON-STANDARD EI Compiler Directive, roughly equivalent to COPY REPLACING
         REMARKS,
+#endif
         // replaceCompilerStatement
         REPLACE,
         REPLACE_OFF,

--- a/TypeCobol/Compiler/Preprocessor/ImportedTokensDocument.cs
+++ b/TypeCobol/Compiler/Preprocessor/ImportedTokensDocument.cs
@@ -43,7 +43,11 @@ namespace TypeCobol.Compiler.Preprocessor
         public ITokensLinesIterator GetProcessedTokensIterator()
         {
             ITokensLinesIterator sourceIterator = ProcessedTokensDocument.GetProcessedTokensIterator(SourceDocument.TextSourceInfo, SourceDocument.Lines);
-            if (HasReplacingDirective)
+            if (HasReplacingDirective
+#if EUROINFO_LEGACY_REPLACING_SYNTAX
+                || CopyDirective.RemoveFirst01Level || CopyDirective.InsertSuffixChar       
+#endif               
+                )
             {
                 ITokensLinesIterator replaceIterator = new ReplaceTokensLinesIterator(sourceIterator, CopyDirective);
                 return replaceIterator;

--- a/TypeCobol/Documentation/Studies/Specific syntax - REMARKS.txt
+++ b/TypeCobol/Documentation/Studies/Specific syntax - REMARKS.txt
@@ -368,12 +368,11 @@ When the keyword is found, enter a special state :
 Exit this special state when :
 - a period separator token is encountered
 - a line without * in column 7 is encountered
-=> produce a pseudo token of type 'END-REMARKS' without underlying chars when either condition is found
 
 ** PREPROCESSOR **
 
 Add a new type of compiler directive, with the following grammar :
-'*REMARKS' ( 'COPY' '=' ( UserDefinedName | ( '(' UserDefinedName+ ')' ) ) )+ '.'? 'END-REMARKS'
+'*REMARKS' ( 'COPY' '=' ( UserDefinedName | ( '(' UserDefinedName+ ')' ) ) )+ '.'?
 
 The compiler directive object stores a list of user defined names, with two types :
 - text names (at most 7 characters)

--- a/TypeCobol/Tools/CommandLine/TypeCobolCompiler.cs
+++ b/TypeCobol/Tools/CommandLine/TypeCobolCompiler.cs
@@ -19,7 +19,7 @@ namespace TypeCobol.Tools.CommandLine
             // Basic test program, useful to debug : compiles all sample programs located under TypeCobol.Test\Samples\EI Cobol samples\EI-Production"
 
             string currentDirectory = Directory.GetCurrentDirectory();
-            string projectRootPath = @"D:\Users\Laurent\OneDrive\Dev\Visual Studio 2012\Projects\TypeCobol\";//currentDirectory.Substring(0, currentDirectory.IndexOf(@"\TypeCobol\") + 11);
+            string projectRootPath = currentDirectory.Substring(0, currentDirectory.IndexOf(@"\TypeCobol\") + 11);
 
             string sourcePath = projectRootPath + @"TypeCobol.Test\Samples\EI Cobol samples\EI-Production";
             string[] programExtensions = { "*.PGM" };

--- a/TypeCobol/Tools/CommandLine/TypeCobolCompiler.cs
+++ b/TypeCobol/Tools/CommandLine/TypeCobolCompiler.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
 using TypeCobol.Compiler;
 using TypeCobol.Compiler.Directives;
 using TypeCobol.Compiler.File;
@@ -13,13 +16,51 @@ namespace TypeCobol.Tools.CommandLine
     {
         public static void Main(string[] args)
         {
+            // Basic test program, useful to debug : compiles all sample programs located under TypeCobol.Test\Samples\EI Cobol samples\EI-Production"
+
+            string currentDirectory = Directory.GetCurrentDirectory();
+            string projectRootPath = @"D:\Users\Laurent\OneDrive\Dev\Visual Studio 2012\Projects\TypeCobol\";//currentDirectory.Substring(0, currentDirectory.IndexOf(@"\TypeCobol\") + 11);
+
+            string sourcePath = projectRootPath + @"TypeCobol.Test\Samples\EI Cobol samples\EI-Production";
+            string[] programExtensions = { "*.PGM" };
+            string[] copyExtensions = { "*.CPY" };
+
+            DocumentFormat docFormat = new DocumentFormat(Encoding.GetEncoding("iso8859-1"), EndOfLineDelimiter.CrLfCharacters, 80, ColumnsLayout.CobolReferenceFormat);
+
+            TypeCobolOptions compilerOptions = new TypeCobolOptions();
+            CompilationProject project = new CompilationProject("samples", sourcePath, programExtensions.Concat(copyExtensions).ToArray(),
+                docFormat.Encoding, docFormat.EndOfLineDelimiter, docFormat.FixedLineLength, docFormat.ColumnsLayout, compilerOptions);
+            
+            // Iterate over all programs in the source directory
+            foreach (string programExtension in programExtensions)
+            {
+                foreach (string filePath in Directory.EnumerateFiles(sourcePath, programExtension))
+                {
+                    // Compile program
+                    string textName = Path.GetFileNameWithoutExtension(filePath);
+                    Console.Write(textName + " ... ");
+                    try
+                    {
+                        FileCompiler fileCompiler = new FileCompiler(null, textName, project.SourceFileProvider, project, ColumnsLayout.CobolReferenceFormat, compilerOptions.Clone(), false);
+                        fileCompiler.CompileOnce();
+                        Console.WriteLine(" OK");
+                    }
+                    catch(Exception e)
+                    {
+                        Console.WriteLine("error :");
+                        Console.WriteLine(e.Message);
+                    }
+                }                
+            }
+
+            /*
             // TO DO : read compiler options on the command line
             // Start with the default compiler options
             TypeCobolOptions compilerOptions = new TypeCobolOptions();
 
             // Simple test version
             // - all referenced files should be located under the current directory
-
+            
             CompilationProject project = new CompilationProject("project", ".", new string[] { "*.cbl", "*.cpy" },
                 IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147), EndOfLineDelimiter.FixedLengthLines, 80, ColumnsLayout.CobolReferenceFormat, compilerOptions);
 
@@ -55,6 +96,7 @@ namespace TypeCobol.Tools.CommandLine
             {
                 Console.WriteLine("ERROR : Invalid number of arguments");
             }
+            */
         }
     }
 }

--- a/TypeCobol/TypeCobol.csproj
+++ b/TypeCobol/TypeCobol.csproj
@@ -24,7 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;EUROINFO_LEGACY_REPLACING_SYNTAX</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -33,7 +33,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;EUROINFO_LEGACY_REPLACING_SYNTAX</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
*REMARKS is a legacy Euro Info proprietary syntax, roughly equivalent to COPY REPLACING.

All the non-standard code sections have been wrapped inside conditional compilation directives : 

#if EUROINFO_LEGACY_REPLACING_SYNTAX

Just undefine this compilation symbol in the project build properties, and all traces of this non standard syntax will instantly disappear.