### PR TITLE
V1.1.1

### DIFF
--- a/Codegen/src/Nodes/ProcedureStyleCall.cs
+++ b/Codegen/src/Nodes/ProcedureStyleCall.cs
@@ -211,7 +211,21 @@ namespace TypeCobol.Codegen.Nodes {
 	private string ToString(TypeCobol.Compiler.CodeElements.CallSiteParameter parameter, Compiler.CodeModel.SymbolTable table, ArgMode mode,
         ref TypeCobol.Compiler.CodeElements.ParameterSharingMode previousSharingMode, ref int previousSpan) {
         Variable variable = parameter.StorageAreaOrValue;
-        var name = parameter.IsOmitted ? "omitted" : variable.ToString(true);
+        bool bTypeBool = false;
+        if (variable != null)
+        {//We must detect a boolean variable
+            if (!variable.IsLiteral)
+            {
+                var found = table.GetVariables(variable);
+                if (found.Count() >= 1)
+                {
+                    var data = found.First() as DataDescription;
+                    bTypeBool = (data != null && data.DataType == DataType.Boolean);
+                }
+            }
+        }
+
+        var name = parameter.IsOmitted ? "omitted" : variable.ToString(true, bTypeBool);
 
         string share_mode = "";
         int defaultSpan = string.Intern("by reference ").Length;
@@ -251,9 +265,6 @@ namespace TypeCobol.Codegen.Nodes {
             if (found.Count() < 1) {  //this can happens for special register : LENGTH OF, ADDRESS OF
                 return share_mode + variable.ToCobol85();
             }
-//		if (found.Count > 1) return "?AMBIGUOUS?";
-            var data = found.First() as DataDescription;
-            if (data != null && data.DataType == DataType.Boolean) name += "-value";
         }
         return share_mode + name;
 	}

--- a/Codegen/test/TestTypeCobolCodegen.cs
+++ b/Codegen/test/TestTypeCobolCodegen.cs
@@ -611,6 +611,16 @@ namespace TypeCobol.Codegen {
             CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CobolLineSplit_IN_Var2") + ".rdz.tcbl", skeletons, false, "TestTypeCobolVersion");
         }
 
+        [TestMethod]
+        [TestCategory("Codegen")]
+        [TestProperty("Time", "fast")]
+        public void GenQualifiedBoolVarTest()
+        {
+            var skeletons = CodegenTestUtils.ParseConfig(Path.Combine("TypeCobol", "skeletons") + ".xml");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenQualifiedBoolVar") + ".rdz.tcbl", skeletons, false, "TestTypeCobolVersion");
+        }
+
+
 #if EUROINFO_RULES
         [TestMethod]
         [TestCategory("Codegen")]

--- a/Codegen/test/TestTypeCobolCodegen.cs
+++ b/Codegen/test/TestTypeCobolCodegen.cs
@@ -600,6 +600,17 @@ namespace TypeCobol.Codegen {
             CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "ProgramParameterCompUsageTypes") + ".rdz.tcbl", skeletons, false, "TestTypeCobolVersion");
         }
 
+        [TestMethod]
+        [TestCategory("Codegen")]
+        [TestProperty("Time", "fast")]
+        public void CobolLineSplit_IN_VarTest()
+        {
+            var skeletons = CodegenTestUtils.ParseConfig(Path.Combine("TypeCobol", "skeletons") + ".xml");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CobolLineSplit_IN_Var") + ".rdz.tcbl", skeletons, false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CobolLineSplit_IN_Var1") + ".rdz.tcbl", skeletons, false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CobolLineSplit_IN_Var2") + ".rdz.tcbl", skeletons, false, "TestTypeCobolVersion");
+        }
+
 #if EUROINFO_RULES
         [TestMethod]
         [TestCategory("Codegen")]

--- a/Codegen/test/resources/input/TypeCobol/CobolLineSplit_IN_Var.rdz.tcbl
+++ b/Codegen/test/resources/input/TypeCobol/CobolLineSplit_IN_Var.rdz.tcbl
@@ -1,0 +1,28 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CobolLineSplitINVar.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 PERSON TYPEDEF STRICT.
+         05 FirstName              PIC X(30).
+         05 Grp123456789012312345678.
+            10 LastName               PIC X(30).
+         05 Birthday               TYPE Date.
+         05 Registered             TYPE Bool.
+       01 W-PERSON1      TYPE PERSON.
+       01 W-PERSON2      TYPE PERSON.
+
+       procedure division.
+
+       declare procedure check private
+          output mydate        PIC X(30)
+         .
+         PROCEDURE DIVISION.
+           CONTINUE.
+       END-DECLARE.
+
+
+           call check
+                Output
+           W-PERSON1::Grp123456789012312345678::LastName.
+
+       END PROGRAM CobolLineSplitINVar.

--- a/Codegen/test/resources/input/TypeCobol/CobolLineSplit_IN_Var1.rdz.tcbl
+++ b/Codegen/test/resources/input/TypeCobol/CobolLineSplit_IN_Var1.rdz.tcbl
@@ -1,0 +1,28 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CobolLineSplitINVar.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 PERSON TYPEDEF STRICT.
+         05 FirstName              PIC X(30).
+         05 Grp1234567890123123456789.
+            10 LastName               PIC X(30).
+         05 Birthday               TYPE Date.
+         05 Registered             TYPE Bool.
+       01 W-PERSON1      TYPE PERSON.
+       01 W-PERSON2      TYPE PERSON.
+
+       procedure division.
+
+       declare procedure check private
+          output mydate        PIC X(30)
+         .
+         PROCEDURE DIVISION.
+           CONTINUE.
+       END-DECLARE.
+
+
+           call check
+                Output
+           W-PERSON1::Grp1234567890123123456789::LastName.
+
+       END PROGRAM CobolLineSplitINVar.

--- a/Codegen/test/resources/input/TypeCobol/CobolLineSplit_IN_Var2.rdz.tcbl
+++ b/Codegen/test/resources/input/TypeCobol/CobolLineSplit_IN_Var2.rdz.tcbl
@@ -1,0 +1,28 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CobolLineSplitINVar.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 PERSON TYPEDEF STRICT.
+         05 FirstName              PIC X(30).
+         05 Grp12345678901231234567890.
+            10 LastName               PIC X(30).
+         05 Birthday               TYPE Date.
+         05 Registered             TYPE Bool.
+       01 W-PERSON1      TYPE PERSON.
+       01 W-PERSON2      TYPE PERSON.
+
+       procedure division.
+
+       declare procedure check private
+          output mydate        PIC X(30)
+         .
+         PROCEDURE DIVISION.
+           CONTINUE.
+       END-DECLARE.
+
+
+           call check
+                Output
+           W-PERSON1::Grp12345678901231234567890::LastName.
+
+       END PROGRAM CobolLineSplitINVar.

--- a/Codegen/test/resources/input/TypeCobol/GenQualifiedBoolVar.rdz.tcbl
+++ b/Codegen/test/resources/input/TypeCobol/GenQualifiedBoolVar.rdz.tcbl
@@ -1,0 +1,25 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. MyPgm.
+       DATA DIVISION .
+       working-storage section.
+
+       01 local.
+         05 overflw type bool.
+         05 grp.
+            10 overflw2 type bool.
+
+       PROCEDURE DIVISION.
+
+       declare procedure check private
+          output mydate  type bool
+         .
+         PROCEDURE DIVISION.
+           CONTINUE.
+       END-DECLARE.
+
+
+       CALL check Output local::overflw.
+       CALL check Output local::grp::overflw2.
+      *MOVE false TO local::overflw
+           .
+       END PROGRAM MyPgm.

--- a/Codegen/test/resources/output/TypeCobol/CobolLineSplit_IN_Var.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/CobolLineSplit_IN_Var.rdz.tcbl
@@ -1,0 +1,74 @@
+﻿      *TypeCobol_Version:TestTypeCobolVersion
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CobolLineSplitINVar.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      *01 PERSON TYPEDEF STRICT.
+      *  05 FirstName              PIC X(30).
+      *  05 Grp123456789012312345678.
+      *     10 LastName               PIC X(30).
+      *  05 Birthday               TYPE Date.
+      *  05 Registered             TYPE Bool.
+      *01 W-PERSON1      TYPE PERSON.
+       01 W-PERSON1.
+           02 FirstName PIC X(30).
+           02 Grp123456789012312345678.
+             03 LastName PIC X(30).
+           02 Birthday.
+             03 YYYY PIC 9(4).
+             03 MM PIC 9(2).
+             03 DD PIC 9(2).
+          02  Registered-value PIC X VALUE LOW-VALUE.
+              88  Registered       VALUE 'T'.
+              88  Registered-false VALUE 'F'
+                             X'00' thru 'S'
+                             'U' thru X'FF'.
+                                     
+      *01 W-PERSON2      TYPE PERSON.
+       01 W-PERSON2.
+           02 FirstName PIC X(30).
+           02 Grp123456789012312345678.
+             03 LastName PIC X(30).
+           02 Birthday.
+             03 YYYY PIC 9(4).
+             03 MM PIC 9(2).
+             03 DD PIC 9(2).
+          02  Registered-value PIC X VALUE LOW-VALUE.
+              88  Registered       VALUE 'T'.
+              88  Registered-false VALUE 'F'
+                             X'00' thru 'S'
+                             'U' thru X'FF'.
+                                     
+
+       procedure division.
+
+      *declare procedure check private
+      *   output mydate        PIC X(30)
+      *  .
+
+
+      *    call check
+      *         Output
+      *    W-PERSON1::Grp123456789012312345678::LastName.
+           CALL 'cb5016dbcheck' USING
+                    by reference LastName IN Grp123456789012312345678 IN
+            W-PERSON1
+           end-call
+                                                        .
+
+       END PROGRAM CobolLineSplitINVar.
+      *
+      *declare procedure check private
+      *   output mydate        PIC X(30)
+      *  .
+      *_________________________________________________________________
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. cb5016dbcheck.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01 mydate PIC X(30).
+       PROCEDURE DIVISION
+             USING BY REFERENCE mydate
+           .
+           CONTINUE.
+       END PROGRAM cb5016dbcheck.

--- a/Codegen/test/resources/output/TypeCobol/CobolLineSplit_IN_Var1.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/CobolLineSplit_IN_Var1.rdz.tcbl
@@ -1,0 +1,74 @@
+﻿      *TypeCobol_Version:TestTypeCobolVersion
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CobolLineSplitINVar.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      *01 PERSON TYPEDEF STRICT.
+      *  05 FirstName              PIC X(30).
+      *  05 Grp1234567890123123456789.
+      *     10 LastName               PIC X(30).
+      *  05 Birthday               TYPE Date.
+      *  05 Registered             TYPE Bool.
+      *01 W-PERSON1      TYPE PERSON.
+       01 W-PERSON1.
+           02 FirstName PIC X(30).
+           02 Grp1234567890123123456789.
+             03 LastName PIC X(30).
+           02 Birthday.
+             03 YYYY PIC 9(4).
+             03 MM PIC 9(2).
+             03 DD PIC 9(2).
+          02  Registered-value PIC X VALUE LOW-VALUE.
+              88  Registered       VALUE 'T'.
+              88  Registered-false VALUE 'F'
+                             X'00' thru 'S'
+                             'U' thru X'FF'.
+                                     
+      *01 W-PERSON2      TYPE PERSON.
+       01 W-PERSON2.
+           02 FirstName PIC X(30).
+           02 Grp1234567890123123456789.
+             03 LastName PIC X(30).
+           02 Birthday.
+             03 YYYY PIC 9(4).
+             03 MM PIC 9(2).
+             03 DD PIC 9(2).
+          02  Registered-value PIC X VALUE LOW-VALUE.
+              88  Registered       VALUE 'T'.
+              88  Registered-false VALUE 'F'
+                             X'00' thru 'S'
+                             'U' thru X'FF'.
+                                     
+
+       procedure division.
+
+      *declare procedure check private
+      *   output mydate        PIC X(30)
+      *  .
+
+
+      *    call check
+      *         Output
+      *    W-PERSON1::Grp1234567890123123456789::LastName.
+           CALL 'cb5016dbcheck' USING
+                    by reference LastName IN Grp1234567890123123456789 I
+      -    N W-PERSON1
+           end-call
+                                                         .
+
+       END PROGRAM CobolLineSplitINVar.
+      *
+      *declare procedure check private
+      *   output mydate        PIC X(30)
+      *  .
+      *_________________________________________________________________
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. cb5016dbcheck.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01 mydate PIC X(30).
+       PROCEDURE DIVISION
+             USING BY REFERENCE mydate
+           .
+           CONTINUE.
+       END PROGRAM cb5016dbcheck.

--- a/Codegen/test/resources/output/TypeCobol/CobolLineSplit_IN_Var2.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/CobolLineSplit_IN_Var2.rdz.tcbl
@@ -1,0 +1,74 @@
+﻿      *TypeCobol_Version:TestTypeCobolVersion
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CobolLineSplitINVar.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      *01 PERSON TYPEDEF STRICT.
+      *  05 FirstName              PIC X(30).
+      *  05 Grp12345678901231234567890.
+      *     10 LastName               PIC X(30).
+      *  05 Birthday               TYPE Date.
+      *  05 Registered             TYPE Bool.
+      *01 W-PERSON1      TYPE PERSON.
+       01 W-PERSON1.
+           02 FirstName PIC X(30).
+           02 Grp12345678901231234567890.
+             03 LastName PIC X(30).
+           02 Birthday.
+             03 YYYY PIC 9(4).
+             03 MM PIC 9(2).
+             03 DD PIC 9(2).
+          02  Registered-value PIC X VALUE LOW-VALUE.
+              88  Registered       VALUE 'T'.
+              88  Registered-false VALUE 'F'
+                             X'00' thru 'S'
+                             'U' thru X'FF'.
+                                     
+      *01 W-PERSON2      TYPE PERSON.
+       01 W-PERSON2.
+           02 FirstName PIC X(30).
+           02 Grp12345678901231234567890.
+             03 LastName PIC X(30).
+           02 Birthday.
+             03 YYYY PIC 9(4).
+             03 MM PIC 9(2).
+             03 DD PIC 9(2).
+          02  Registered-value PIC X VALUE LOW-VALUE.
+              88  Registered       VALUE 'T'.
+              88  Registered-false VALUE 'F'
+                             X'00' thru 'S'
+                             'U' thru X'FF'.
+                                     
+
+       procedure division.
+
+      *declare procedure check private
+      *   output mydate        PIC X(30)
+      *  .
+
+
+      *    call check
+      *         Output
+      *    W-PERSON1::Grp12345678901231234567890::LastName.
+           CALL 'cb5016dbcheck' USING
+                    by reference LastName IN Grp12345678901231234567890
+           IN W-PERSON1
+           end-call
+                                                          .
+
+       END PROGRAM CobolLineSplitINVar.
+      *
+      *declare procedure check private
+      *   output mydate        PIC X(30)
+      *  .
+      *_________________________________________________________________
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. cb5016dbcheck.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01 mydate PIC X(30).
+       PROCEDURE DIVISION
+             USING BY REFERENCE mydate
+           .
+           CONTINUE.
+       END PROGRAM cb5016dbcheck.

--- a/Codegen/test/resources/output/TypeCobol/GenQualifiedBoolVar.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/GenQualifiedBoolVar.rdz.tcbl
@@ -1,0 +1,60 @@
+﻿      *TypeCobol_Version:TestTypeCobolVersion
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. MyPgm.
+       DATA DIVISION .
+       working-storage section.
+
+       01 local.
+      *  05 overflw type bool.
+         05  overflw-value PIC X VALUE LOW-VALUE.
+           88  overflw       VALUE 'T'.
+           88  overflw-false VALUE 'F'
+                           X'00' thru 'S'
+                           'U' thru X'FF'.
+                              
+         05 grp.
+      *     10 overflw2 type bool.
+            10  overflw2-value PIC X VALUE LOW-VALUE.
+           88  overflw2       VALUE 'T'.
+           88  overflw2-false VALUE 'F'
+                           X'00' thru 'S'
+                           'U' thru X'FF'.
+                                  
+
+       PROCEDURE DIVISION.
+
+      *declare procedure check private
+      *   output mydate  type bool
+      *  .
+
+
+      *CALL check Output local::overflw.
+       CALL 'ea379882check' USING
+                    by reference overflw-value IN local
+           end-call
+                                       .
+      *CALL check Output local::grp::overflw2.
+       CALL 'ea379882check' USING
+                    by reference overflw2-value IN grp IN local
+           end-call
+                                             .
+      *MOVE false TO local::overflw
+           .
+       END PROGRAM MyPgm.
+      *
+      *declare procedure check private
+      *   output mydate  type bool
+      *  .
+      *_________________________________________________________________
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ea379882check.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01 mydate-value PIC X     VALUE LOW-VALUE.
+           88 mydate       VALUE 'T'.
+           88 mydate-false VALUE 'F'.
+       PROCEDURE DIVISION
+             USING BY REFERENCE mydate-value
+           .
+           CONTINUE.
+       END PROGRAM ea379882check.

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionElligibleTokens.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionElligibleTokens.cs
@@ -27,8 +27,6 @@ namespace TypeCobol.LanguageServer
             new Tuple<TokenType, bool>(TokenType.IN_OUT, false),
             new Tuple<TokenType, bool>(TokenType.MOVE, false),
             new Tuple<TokenType, bool>(TokenType.TO, false),
-            new Tuple<TokenType, bool>(TokenType.IF, false),
-            new Tuple<TokenType, bool>(TokenType.DISPLAY, false),
             new Tuple<TokenType, bool>(TokenType.SET, false),
             new Tuple<TokenType, bool>(TokenType.OF, false),
             new Tuple<TokenType, bool>(TokenType.INTO, false),

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionFactory.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionFactory.cs
@@ -211,6 +211,8 @@ namespace TypeCobol.LanguageServer
 
             }
 
+            if (potentialVariablesForCompletion == null) return completionItems;
+
             foreach (var potentialVariable in potentialVariablesForCompletion.Where(v => v.Name.StartsWith(userFilterText, StringComparison.InvariantCultureIgnoreCase)).Distinct())
                 SearchVariableInTypesAndLevels(node, potentialVariable, ref completionItems); //Add potential variables to completionItems
 

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionFactory.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionFactory.cs
@@ -298,10 +298,11 @@ namespace TypeCobol.LanguageServer
                     qualifiedNameTokens.Where(
                             t =>
                                 t.TokenType == TokenType.UserDefinedWord &&
-                                !(t.Text == userFilterText && userFilterToken != null && t.StartIndex == userFilterToken.StartIndex && t.EndColumn == userFilterToken.EndColumn) &&
-                                ((t.StartIndex >= firstSignificantToken.EndColumn &&
-                                  t.Line == firstSignificantToken.Line) || t.Line > firstSignificantToken.Line) &&
-                                ((t.EndColumn <= position.character && t.Line == position.line + 1) || t.Line < position.line + 1))
+                                !(t.Text == userFilterText && userFilterToken != null &&
+                                  t.StartIndex == userFilterToken.StartIndex && t.EndColumn == userFilterToken.EndColumn) &&
+                                ((firstSignificantToken != null && ((t.StartIndex >= firstSignificantToken.EndColumn && t.Line == firstSignificantToken.Line) || t.Line > firstSignificantToken.Line)) 
+                                || firstSignificantToken == null) 
+                                && ((t.EndColumn <= position.character && t.Line == position.line + 1) || t.Line < position.line + 1))
                         .Select(t => t.Text));
                 var possibleVariables = node.SymbolTable.GetVariablesExplicit(new URI(qualifiedName));
 

--- a/TypeCobol.LanguageServer/TypeCobolServer.cs
+++ b/TypeCobol.LanguageServer/TypeCobolServer.cs
@@ -64,6 +64,11 @@ namespace TypeCobol.LanguageServer
         /// </summary>
         public bool LsrSemanticTesting { get; set; }
 
+        /// <summary>
+        /// Are Log message notifications enabled ? false if yes, true otherwise.
+        /// </summary>
+        public bool NoLogsMessageNotification { get; set; }
+
         public Workspace Workspace
         {
             get { return typeCobolWorkspace; }
@@ -73,6 +78,7 @@ namespace TypeCobol.LanguageServer
 
         public override InitializeResult OnInitialize(InitializeParams parameters)
         {
+            this.RemoteConsole.NoLogsMessageNotification = NoLogsMessageNotification;
             var rootDirectory = new DirectoryInfo(parameters.rootPath);
             string workspaceName = rootDirectory.Name + "#" + parameters.processId;
 

--- a/TypeCobol.LanguageServer/TypeCobolServerHost.cs
+++ b/TypeCobol.LanguageServer/TypeCobolServerHost.cs
@@ -91,6 +91,11 @@ namespace TypeCobol.LanguageServer
         /// </summary>
         public static bool TimerDisabledOption { get; set; }
 
+        /// <summary>
+        /// Are Log message notifications enabled ? false if yes, true otherwise.
+        /// </summary>
+        public static bool NoLogsMessageNotification { get; set; }
+
         public static System.Diagnostics.Process Process;
 
         /// <summary>
@@ -164,6 +169,7 @@ namespace TypeCobol.LanguageServer
                 { "v|version","Show version", _ => version = true },
                 { "h|help","Show help", _ => help = true },
                 { "lf|logfile=","{PATH} the target log file", (string v) => LogFile = v },
+                { "nologs","No log message notifications", _ => NoLogsMessageNotification = true },
                 { "r|robot",  "Robot Client mode.", _ => LsrMode = true },
                 { "lsr=","{PATH} the lsr path", (string v) => LsrPath = v },
                 { "s|script=","{PATH} script path in lsr", (string v) => LsrScript = v },
@@ -236,6 +242,8 @@ namespace TypeCobol.LanguageServer
                 }
                 var jsonRPCServer = new JsonRPCServer(httpServer);
                 var typeCobolServer = new TypeCobolServer(jsonRPCServer, MessagesActionQueue);
+
+                typeCobolServer.NoLogsMessageNotification = NoLogsMessageNotification;
 
                 typeCobolServer.LsrSourceTesting = LsrSourceTesting;
                 typeCobolServer.LsrScannerTesting = LsrScannerTesting;

--- a/TypeCobol.LanguageServer/VsCodeProtocol/RemoteConsole.cs
+++ b/TypeCobol.LanguageServer/VsCodeProtocol/RemoteConsole.cs
@@ -37,13 +37,21 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
         }
 
         /// <summary>
+        /// Are Log message notifications enabled ? false if yes, true otherwise.
+        /// </summary>
+        public bool NoLogsMessageNotification { get; set; }
+
+        /// <summary>
         /// Log a message.
         /// 
         /// @param message The message to log.
         /// </summary>
         public void Log(string message)
         {
-            send(MessageType.Log, message);
+            if (!NoLogsMessageNotification)
+            {
+                send(MessageType.Log, message);
+            }
         }
 
         private void send(MessageType type, string message)

--- a/TypeCobol/Compiler/CodeElements/Expressions/SymbolName.cs
+++ b/TypeCobol/Compiler/CodeElements/Expressions/SymbolName.cs
@@ -87,7 +87,8 @@ namespace TypeCobol.Compiler.CodeElements
                 && this.ContinueVisitToChildren(astVisitor, NameLiteral);
         }
 
-        public override string ToString() {	return Name; }
+        public override string ToString() { return Name; }
+        public virtual string ToString(bool isBoolType) { return ToString() + (isBoolType ? "-value" : ""); }
     }
 
     /// <summary>
@@ -271,9 +272,23 @@ namespace TypeCobol.Compiler.CodeElements
 			get { return "\\." + Head.Name + "\\..*" + Tail.DefinitionPathPattern; }
 		}
 
-		public override string ToString() { return Head + " IN " + Tail; }
+	    public override string ToString()
+	    {
+	        return Head + " IN " + Tail;
+	    }
 
-		public override string Name { get { return Tail.Name+'.'+Head.Name; } }
+	    public override string ToString(bool isBoolType)
+	    {
+	        string head = "";
+	        if (Head.IsQualifiedReference)
+	            head = Head.ToString(isBoolType);
+	        else
+	        {
+	            head = Head.ToString() + (isBoolType ? "-value" : "");
+	        }
+            return head + " IN " + Tail;
+        }
+        public override string Name { get { return Tail.Name+'.'+Head.Name; } }
 
 
 

--- a/TypeCobol/Compiler/CodeElements/Expressions/Variable.cs
+++ b/TypeCobol/Compiler/CodeElements/Expressions/Variable.cs
@@ -186,25 +186,25 @@ namespace TypeCobol.Compiler.CodeElements {
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false, false);
         }
-        public new string ToString(bool bUseToString) {
+        public virtual string ToString(bool bUseToString, bool isBoolType) {
 		    if (NumericValue != null) return NumericValue.Value.ToString();
 		    try {
                 if (SymbolReference != null)
                 {
-                    return bUseToString ? SymbolReference.ToString() : SymbolReference.Name;
+                    return bUseToString ? SymbolReference.ToString(isBoolType) : (SymbolReference.Name + (isBoolType ? "-value" : ""));
                 }
                 if (StorageArea != null)
                 {
-                    var qualifiedName = StorageArea?.SymbolReference?.ToString();
+                    var qualifiedName = StorageArea?.SymbolReference?.ToString(isBoolType);
                     if (StorageArea is DataOrConditionStorageArea && ((DataOrConditionStorageArea)StorageArea).Subscripts.Count > 0)
                     {
                         var subscript = ((DataOrConditionStorageArea) StorageArea).ToString(true);
                         qualifiedName = qualifiedName + " " + subscript;
                     }
 
-                    return bUseToString ? qualifiedName : StorageArea?.SymbolReference?.Name;
+                    return bUseToString ? qualifiedName : StorageArea?.SymbolReference?.Name + (isBoolType ? "-value" : "");
                 }
 			    //these should be: return XXXValue.GetValueInContext(???);
 			    if (AlphanumericValue != null) return AlphanumericValue.Token.SourceText;

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -474,7 +474,7 @@ namespace TypeCobol.Compiler.Scanner
 
         private TypeCobolOptions compilerOptions;
 
-        private Scanner(string line, int startIndex, int lastIndex, TokensLine tokensLine, TypeCobolOptions compilerOptions, bool beSmartWithLevelNumber = true)
+        public Scanner(string line, int startIndex, int lastIndex, TokensLine tokensLine, TypeCobolOptions compilerOptions, bool beSmartWithLevelNumber = true)
         {
             this.tokensLine = tokensLine;
             this.line = line;
@@ -486,7 +486,7 @@ namespace TypeCobol.Compiler.Scanner
             this.BeSmartWithLevelNumber = beSmartWithLevelNumber;
         }
 
-        private Token GetNextToken()
+        public Token GetNextToken()
         {
             // Cannot read past end of line
             if(currentIndex > lastIndex)

--- a/TypeCobol/Compiler/Text/CobolTextLine.cs
+++ b/TypeCobol/Compiler/Text/CobolTextLine.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using TypeCobol.Compiler.Concurrency;
+using TypeCobol.Compiler.Directives;
+using TypeCobol.Compiler.File;
+using TypeCobol.Compiler.Scanner;
 
 namespace TypeCobol.Compiler.Text
 {
@@ -103,30 +106,39 @@ namespace TypeCobol.Compiler.Text
         private static ICollection<ITextLine> CreateCobolLines(ColumnsLayout layout, int index, char indicator, string indent, string text)
         {
             var result = new List<ITextLine>();
-            var lines = Split(text, 65);
-            result.Add(new TextLineSnapshot(index, Convert(layout, lines[0], indicator, indent), null));
-            if (indicator == ' ') indicator = '-';
+            int max = 65;
+            int min = 65;
+            int nLine = (text.Length / max) + ((text.Length % max) != 0 ? 1 : 0);
+            if (nLine == 1)
+            {
+                result.Add(new TextLineSnapshot(index, Convert(layout, text, indicator, indent), null));
+                return result;
+            }
+            if (indicator == ' ')
+            {
+                max = 65;
+                min = 61;
+                indicator = '-';                
+            }
 
+            IList<Tuple<string, bool>> lines = lines = Split(text, max, min);
 
-            if (lines.Count > 1) {
-                int i = 1;
-                //Issue #651, continuation lines must start in Area B
-                //Only 61 chars remains available
-                if (indicator == '-') {
-                    //Remove 65 chars already added to result
-                    lines = Split(text.Substring(65), 61);
-                    i = 0;
-                }
-                for (; i < lines.Count; i++) {
-                    if (index > -1) index++;
-                    result.Add(new TextLineSnapshot(index, Convert(layout, lines[i], indicator, indent), null));
-                }
+            for (int i = 0; i < lines.Count; i++) {
+                if (index > -1) index++;
+                result.Add(new TextLineSnapshot(index, Convert(layout, lines[i].Item1,
+                    indicator != '-'
+                    ? indicator 
+                    : ((lines[i].Item2 && i != 0) ? indicator : (i == 0 ? NoIndicator : NoOneIndicator)) , indent), null));
             }
             return result;
         }
 
+        private const int NoIndicator = 0;
+        private const int NoOneIndicator = -1;
         private const string ContinuationLinePrefix = "      -    ";
-        private static string Convert(ColumnsLayout layout, string text, char indicator, string indent)
+        private const string NoContinuationLinePrefix = "       ";
+        private const string NoOneContinuationLinePrefix = "           ";
+        private static string Convert(ColumnsLayout layout, string text, int indicator, string indent)
         {
             string result = "";
             if (layout == ColumnsLayout.FreeTextFormat)
@@ -136,20 +148,59 @@ namespace TypeCobol.Compiler.Text
             else {
                 var end = text.Length < 65 ? new string(' ', 65 - text.Length) : "";
                 if (indicator != '-') {
-                    result = "      " + indicator + indent + text + end + "      ";//+"000000";
+                    if (indicator == NoIndicator)
+                        result = NoContinuationLinePrefix + indent + text + end + "      ";
+                    else if (indicator == NoOneIndicator)
+                        result = NoOneContinuationLinePrefix + indent + text + end + "      ";
+                    else
+                        result = "      " + (char)indicator + indent + text + end + "      ";
                 } else {
-                    result = ContinuationLinePrefix + indent + text + end + "      "; //+"000000"
+                    result = ContinuationLinePrefix + indent + text + end + "      ";
                 }
             }
             return result;
         }
-        private static IList<string> Split(string line, int max)
+
+        private static IList<Tuple<string, bool> > Split(string line, int max, int min)
         {
-            var lines = new List<string>();
-            if (line.Length < 1) lines.Add(line);
+            var lines = new List<Tuple<string, bool>>();
+            int nLine = (line.Length / max) + ((line.Length % max) != 0 ? 1 : 0);
+            if (nLine == 1)
+            {
+                lines.Add(new Tuple<string, bool>(line, false));
+                return lines;
+            }
+            if (line.Length < 1) lines.Add(new Tuple<string, bool>(line, false));
             else {
-                for (int i = 0; i < line.Length; i += max)
-                    lines.Add(line.Substring(i, Math.Min(max, line.Length - i)));
+                for (int i = 0; i < line.Length; i += (i == 0 ? max : min))
+                {
+                    lines.Add(new Tuple<string, bool>(line.Substring(i, Math.Min((i == 0 ? max : min), line.Length - i)), true));
+                }
+            }
+            TokensLine tempTokensLine = TokensLine.CreateVirtualLineForInsertedToken(0, line);
+            tempTokensLine.InitializeScanState(new MultilineScanState(false, false, false, IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147)));
+
+            Scanner.Scanner scanner = new Scanner.Scanner(line, 0, line.Length - 1, tempTokensLine, null, false);
+            Token t = null;
+            int nCurLength = 0;
+            int nSpan = max;
+            int index = 0;
+            bool bNextNoIndicator = false;
+            while ((t = scanner.GetNextToken()) != null)
+            {
+                nCurLength += t.Length;
+                if (nCurLength >= nSpan)
+                {
+                    if (t.TokenFamily == TokenFamily.Whitespace || (nCurLength == nSpan))
+                        bNextNoIndicator = true;
+                    nSpan += min;
+                    index++;
+                }
+                else if (bNextNoIndicator)
+                {
+                    lines[index] = new Tuple<string, bool>(lines[index].Item1, false);
+                    bNextNoIndicator = false;
+                }                
             }
             return lines;
         }


### PR DESCRIPTION
V1.1.1
**This release `1.1.1` mainly fixes some bugs related to code gneration and improves code completion.**

# Visible Fixes
- Lines that exceed colum 72 and split inside a keyword followed by a variable, the keyword was concatenated to the variable. (#885).
- Qualified boolean variable names inside a procedure call parameters were not generated correctly.(#889)

# Language server issues
- Allow the possibility to disable TypeCobol.LanguageServer Logs (#881)
- Allow code completion support on any instruction and returns available contextual variables.(#879)
