### PR TITLE
WI #1051 Optimize visitor on children nodes

### DIFF
--- a/Codegen/src/Actions/Qualifier.cs
+++ b/Codegen/src/Actions/Qualifier.cs
@@ -59,6 +59,11 @@ namespace TypeCobol.Codegen.Actions
             }
 
             /// <summary>
+            /// CodeGen visitor can modify Node's children
+            /// </summary>
+            public override bool CanModifyChildrenNode => true;
+
+            /// <summary>
             /// Visitor
             /// </summary>
             /// <param name="typeCobolQualifiedSymbolReference"></param>

--- a/Codegen/src/Generators/SignaturesGenerator.cs
+++ b/Codegen/src/Generators/SignaturesGenerator.cs
@@ -66,6 +66,10 @@ namespace TypeCobol.Codegen.Generators
             get { return false; }
         }
 
+        /// <summary>
+        /// CodeGen visitor can modify Node's children
+        /// </summary>
+        public override bool CanModifyChildrenNode => true;
 
         public override bool BeginNode(Node node)
         {

--- a/TypeCobol/Compiler/CodeElements/CobolLanguageLevelVisitor.cs
+++ b/TypeCobol/Compiler/CodeElements/CobolLanguageLevelVisitor.cs
@@ -81,6 +81,11 @@ namespace TypeCobol.Compiler.CodeElements
             get;
         }
 
+        /// <summary>
+        /// Can this visitor modify Node children?
+        /// </summary>
+        bool CanModifyChildrenNode { get; }
+
         bool BeginNode([NotNull] Node node);
         void EndNode([NotNull] Node node);
 
@@ -374,6 +379,11 @@ namespace TypeCobol.Compiler.CodeElements
                 return true;
             }
         }
+
+        /// <summary>
+        /// By default the visitor cannot modify Node's children
+        /// </summary>
+        public virtual bool CanModifyChildrenNode => false;
 
         public virtual bool BeginNode(Node node) {
             return true;

--- a/TypeCobol/Compiler/Nodes/Node.cs
+++ b/TypeCobol/Compiler/Nodes/Node.cs
@@ -628,7 +628,7 @@ namespace TypeCobol.Compiler.Nodes {
                 }
                 else
                 {
-                    continueVisit = VisitChildrens(astVisitor, true, children.ToArray());
+                    continueVisit = VisitChildrens(astVisitor, true, children);
                 }
                 
             }
@@ -637,7 +637,7 @@ namespace TypeCobol.Compiler.Nodes {
             return continueVisit;
         }
 
-        private static bool VisitChildrens(IASTVisitor astVisitor, bool continueVisit, Node[] childrenNodes)
+        private static bool VisitChildrens(IASTVisitor astVisitor, bool continueVisit, IEnumerable<Node> childrenNodes)
         {
             foreach (Node child in childrenNodes)
             {

--- a/TypeCobol/Compiler/Nodes/Node.cs
+++ b/TypeCobol/Compiler/Nodes/Node.cs
@@ -612,26 +612,43 @@ namespace TypeCobol.Compiler.Nodes {
         public bool AcceptASTVisitor(IASTVisitor astVisitor) {
             bool continueVisit = astVisitor.BeginNode(this) && VisitNode(astVisitor);
 
-            if (continueVisit && CodeElement != null)
+            if (continueVisit)
             {
-                CodeElement.AcceptASTVisitor(astVisitor);
+                CodeElement?.AcceptASTVisitor(astVisitor);
             }
 
             if (continueVisit) {
                 //To Handle concurrent modifications during traverse.
                 //Get the array of Children that must be traverse.
-                Node[] childrenNodes = children.ToArray();
-                foreach (Node child in childrenNodes)
+                if (astVisitor.CanModifyChildrenNode)
                 {
-                    if (!continueVisit && astVisitor.IsStopVisitingChildren)
-                    {
-                        break;
-                    }
-                    continueVisit = child.AcceptASTVisitor(astVisitor);                    
+                    //Make copy of  children array if the visitor can modify the children
+                    Node[] childrenNodes = children.ToArray();
+                    continueVisit = VisitChildrens(astVisitor, true, childrenNodes);
                 }
+                else
+                {
+                    continueVisit = VisitChildrens(astVisitor, true, children.ToArray());
+                }
+                
             }
 
             astVisitor.EndNode(this);
+            return continueVisit;
+        }
+
+        private static bool VisitChildrens(IASTVisitor astVisitor, bool continueVisit, Node[] childrenNodes)
+        {
+            foreach (Node child in childrenNodes)
+            {
+                if (!continueVisit && astVisitor.IsStopVisitingChildren)
+                {
+                    break;
+                }
+
+                continueVisit = child.AcceptASTVisitor(astVisitor);
+            }
+
             return continueVisit;
         }
 


### PR DESCRIPTION
- only CodeGen visitor will make a copy of Node's children before visit, as it can modify them