### PR TITLE
v1.2.3_2

### DIFF
--- a/Codegen/src/Nodes/ProcedureDivision.cs
+++ b/Codegen/src/Nodes/ProcedureDivision.cs
@@ -70,14 +70,7 @@ internal class ProcedureDivision: Compiler.Nodes.ProcedureDivision, Generated {
 				}
 				_cache.Add(new TextLineSnapshot(-1, "    .", null));
 
-                var originalProcedure = this.Children?.FirstOrDefault()?.Parent?.Parent?.CodeElement as FunctionDeclarationHeader;
-                if (originalProcedure != null && originalProcedure.Visibility == AccessModifier.Private && this.GetChildren<Declaratives>().Count == 0)
-                {
-                    var declarativesNode = this.Children.First().Parent.GetProgramNode().GetChildren<Compiler.Nodes.ProcedureDivision>().First().GetChildren<Compiler.Nodes.Declaratives>();
-                    if (declarativesNode != null && declarativesNode.Count == 1)
-                        foreach (var line in declarativesNode.First().SelfAndChildrenLines.Distinct())
-                            _cache.Add(line);
-                }
+                
                 }
 			return _cache;
 		}

--- a/Codegen/test/resources/output/TypeCobol/DeclarativesWithProcedures.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/DeclarativesWithProcedures.tcbl
@@ -135,14 +135,6 @@
                                        
        PROCEDURE DIVISION
            .
-      DDECLARATIVES.
-      DDECLARATION SECTION.
-      D    USE FOR DEBUGGING ON ALL PROCEDURES.
-      DAFFICHAGE-PARAGRAPHE.
-      D       display DEBUG-NAME
-      D    .
-      DX.  EXIT.
-      DEND DECLARATIVES.
 
       *     set Table-Tax::Tax::Idx-TaxElm to 1
             set ac7b6441Idx-TaxElm to 1

--- a/Codegen/test/resources/output/TypeCobol/DeclarativesWithProcedures2.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/DeclarativesWithProcedures2.tcbl
@@ -64,12 +64,6 @@
        SPECIAL-NAMES.  DECIMAL-POINT IS COMMA.
        PROCEDURE DIVISION
            .
-      DDECLARATIVES.
-      DDECLARATION SECTION.
-      D      USE FOR DEBUGGING ON ALL PROCEDURES.
-      DAFFICHAGE-PARAGRAPHE.
-      D    display "in main program".
-      DEND DECLARATIVES.
            goback
            .
        END PROGRAM e4c075b4Dump2.


### PR DESCRIPTION
Fix for Declaratives and procedure:
Do not copy Declaratives of enclosing program for procedure. #1108

The problem is a Declaratives in the main program can reference variables only reachable by the program and not the procedure.