### PR TITLE
Make CUP runtime 25% faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ _Pvt_Extensions/
 ModelManifest.xml
 
 EITests/
+/.localhistory

--- a/CSCup/CSCup.csproj
+++ b/CSCup/CSCup.csproj
@@ -1,6 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  
+  <Import Project="..\TypeCobol\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -14,48 +16,22 @@
     <DoNotCopyLocalIfInGac>true</DoNotCopyLocalIfInGac>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>..\bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
     <OutputPath>..\bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'EI_Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\bin\EI_Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>6</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'EI_Debug_Net40|AnyCPU'">
     <OutputPath>..\bin\EI_Debug_Net40\</OutputPath>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'EI_Release|AnyCPU'">
     <OutputPath>..\bin\EI_Release\</OutputPath>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'EI_Release_Net40|AnyCPU'">
     <OutputPath>..\bin\EI_Release_Net40\</OutputPath>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/CSCup/emit.cs
+++ b/CSCup/emit.cs
@@ -355,7 +355,7 @@ public class emit {
 		     pre("do_action") + "(");
       cout.WriteLine("    int                        " + pre("act_num,"));
       cout.WriteLine("    TUVienna.CS_CUP.Runtime.lr_parser " + pre("parser,"));
-      cout.WriteLine("    System.Collections.Stack            xstack1,");
+      cout.WriteLine("    StackList<Symbol>            xstack1,");
       cout.WriteLine("    int                        " + pre("top)"));
     //  cout.WriteLine("    throws java.lang.Exception");
       cout.WriteLine("    {");
@@ -364,7 +364,7 @@ public class emit {
       /* New declaration!! now return Symbol
 	 6/13/96 frankf */
       cout.WriteLine("      /* Symbol object for return from actions */");
-      cout.WriteLine("      mStack "+pre("stack")+" =new mStack(xstack1);");
+      cout.WriteLine("      StackList<Symbol> " + pre("stack") + " =  xstack1;");
       cout.WriteLine("      TUVienna.CS_CUP.Runtime.Symbol " + pre("result") + ";");
       cout.WriteLine();
 
@@ -410,13 +410,23 @@ public class emit {
 	    int index = prod.rhs_length() - i - 1; // last rhs is on top.
 	    cout.WriteLine("              " + "// propagate RESULT from " +
 			s.name());
+
+                    string indexDecals;
+                    if (index != 0)
+                    {
+                        indexDecals = "-" + index;
+                    } else
+                    {
+                        indexDecals = "";
+                    }
+
 	    cout.WriteLine("              " + "if ( " +
-	      "((TUVienna.CS_CUP.Runtime.Symbol) " + emit.pre("stack") + ".elementAt("
-              + emit.pre("top") + "-" + index + ")).value != null )");
+	      "(" + emit.pre("stack") + ".ElementAtFromBottom("
+              + emit.pre("top") + indexDecals + ")).value != null )");
 	    cout.WriteLine("                " + "RESULT = " +
 	      "(" + prod.lhs().the_symbol().stack_type() + ") " +
-	      "((TUVienna.CS_CUP.Runtime.Symbol) " + emit.pre("stack") + ".elementAt("
-              + emit.pre("top") + "-" + index + ")).value;");
+	      "( " + emit.pre("stack") + ".ElementAtFromBottom("
+              + emit.pre("top") + indexDecals + ")).value;");
 	  }
 
         /* if there is an action string, emit it */
@@ -433,15 +443,24 @@ public class emit {
 	  if (emit.lr_values()) {	    
 	    int loffset;
 	    string leftstring, rightstring;
-	    int roffset = 0;
-	    rightstring = "((TUVienna.CS_CUP.Runtime.Symbol)" + emit.pre("stack") + ".elementAt(" + 
-	      emit.pre("top") + "-" + roffset + ")).right";	  
+
+	    rightstring = "(" + emit.pre("stack") + ".ElementAtFromBottom(" +
+	      emit.pre("top") + ")).right";	  
 	    if (prod.rhs_length() == 0) 
 	      leftstring = rightstring;
 	    else {
 	      loffset = prod.rhs_length() - 1;
-	      leftstring = "((TUVienna.CS_CUP.Runtime.Symbol)" + emit.pre("stack") + ".elementAt(" + 
-		emit.pre("top") + "-" + loffset + ")).left";	  
+            string loffsetText;
+            if (loffset != 0)
+            {
+                loffsetText = "-" + loffset;
+            } else
+            {
+                loffsetText = "";
+            }
+
+	      leftstring = "(" + emit.pre("stack") + ".ElementAtFromBottom(" +
+		emit.pre("top") + loffsetText + ")).left";	  
 	    }
 	    cout.WriteLine("              " + pre("result") + " = new TUVienna.CS_CUP.Runtime.Symbol(" + 
 			prod.lhs().the_symbol().index() + "/*" +
@@ -866,6 +885,8 @@ public class emit {
       while (myEnum.MoveNext())
 	cout.WriteLine("using " + myEnum.Current.ToString() + ";");
 
+    cout.WriteLine("using CSCupRuntime;"); //For StackList
+
       /* class header */
       cout.WriteLine();
       cout.WriteLine("/** "+version.title_str+" generated parser.");
@@ -911,10 +932,9 @@ public class emit {
       cout.WriteLine("  public override TUVienna.CS_CUP.Runtime.Symbol do_action(");
       cout.WriteLine("    int                        act_num,");
       cout.WriteLine("    TUVienna.CS_CUP.Runtime.lr_parser parser,");
-      cout.WriteLine("    System.Collections.Stack            xstack1,");
+      cout.WriteLine("    StackList<Symbol>            CUP_parser_stack,");
       cout.WriteLine("    int                        top)");
       cout.WriteLine("  {");
-      cout.WriteLine("  mStack CUP_parser_stack= new mStack(xstack1);");
       cout.WriteLine("    /* call code in generated class */");
       cout.WriteLine("    return action_obj." + pre("do_action(") +
                   "act_num, parser, stack, top);");

--- a/CSCup/parser.cs
+++ b/CSCup/parser.cs
@@ -9,6 +9,7 @@ namespace TUVienna.CS_CUP
 
 	using Runtime;
 	using System.Collections;
+	using CSCupRuntime;
 
 
     /** C# CUP v0.1 generated parser.
@@ -342,7 +343,7 @@ namespace TUVienna.CS_CUP
     	public override Symbol do_action(
         	int                        act_num,
         	lr_parser parser,
-        	Stack            stack,
+	        StackList<Symbol>            stack,
         	int                        top)
  
         {
@@ -508,12 +509,13 @@ namespace TUVienna.CS_CUP
     	public  Symbol CUP_parser_do_action(
                                   int                        CUP_parser_act_num,
                                   lr_parser CUP_parser_parser,
-                                  Stack            CUP_parser_stack1,
+                                  StackList<Symbol> CUP_parser_stack,
                                   int                        CUP_parser_top)
                               {
+            
                                   /* Symbol object for return from actions */
                                   Symbol CUP_parser_result;
-                                  mStack CUP_parser_stack= new mStack(CUP_parser_stack1);
+                                  
 
                                   /* select the action based on the action number */
                                   switch (CUP_parser_act_num)
@@ -523,7 +525,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(29/*empty*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(29/*empty*/, (CUP_parser_stack.ElementAtFromBottom(CUP_parser_top)).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -532,7 +534,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(7/*opt_semi*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(7/*opt_semi*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top - 0).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -541,7 +543,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(7/*opt_semi*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(7/*opt_semi*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -550,7 +552,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(8/*non_terminal*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(8/*non_terminal*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -559,7 +561,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(8/*non_terminal*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(8/*non_terminal*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -571,7 +573,7 @@ namespace TUVienna.CS_CUP
                                           lexer.emit_error("Illegal use of reserved word");
                                           RESULT="ILLEGAL";
     
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -580,7 +582,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "nonassoc"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -589,7 +591,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "right"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -598,7 +600,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "left"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -607,7 +609,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "precedence"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -616,7 +618,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "start"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -625,7 +627,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "with"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -634,7 +636,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "scan"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -643,7 +645,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "init"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -652,7 +654,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "nonterminal"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -661,7 +663,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "non"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -670,7 +672,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "terminal"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -679,7 +681,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "parser"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -688,7 +690,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "action"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -697,7 +699,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = "code"; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -705,11 +707,11 @@ namespace TUVienna.CS_CUP
                                       case 86: // robust_id ::= ID 
                                       {
                                           string RESULT = null;
-                                          int the_idleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int the_idright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string the_id = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int the_idleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int the_idright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string the_id = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
                                           RESULT = the_id; 
-                                          CUP_parser_result = new Symbol(42/*robust_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(42/*robust_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -717,11 +719,11 @@ namespace TUVienna.CS_CUP
                                       case 85: // label_id ::= robust_id 
                                       {
                                           string RESULT = null;
-                                          int the_idleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int the_idright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string the_id = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int the_idleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int the_idright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string the_id = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
                                           RESULT = the_id; 
-                                          CUP_parser_result = new Symbol(38/*label_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(38/*label_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -733,7 +735,7 @@ namespace TUVienna.CS_CUP
                                           lexer.emit_error("Illegal use of reserved word");
                                           RESULT="ILLEGAL";
     
-                                          CUP_parser_result = new Symbol(37/*symbol_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(37/*symbol_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -741,11 +743,11 @@ namespace TUVienna.CS_CUP
                                       case 83: // symbol_id ::= ID 
                                       {
                                           string RESULT = null;
-                                          int the_idleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int the_idright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string the_id = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int the_idleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int the_idright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string the_id = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
                                           RESULT = the_id; 
-                                          CUP_parser_result = new Symbol(37/*symbol_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(37/*symbol_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -757,7 +759,7 @@ namespace TUVienna.CS_CUP
                                           lexer.emit_error("Illegal use of reserved word");
                                           RESULT="ILLEGAL";
     
-                                          CUP_parser_result = new Symbol(36/*nt_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(36/*nt_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -765,11 +767,11 @@ namespace TUVienna.CS_CUP
                                       case 81: // nt_id ::= ID 
                                       {
                                           string RESULT = null;
-                                          int the_idleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int the_idright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string the_id = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int the_idleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int the_idright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string the_id = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
                                           RESULT = the_id; 
-                                          CUP_parser_result = new Symbol(36/*nt_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(36/*nt_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -777,9 +779,9 @@ namespace TUVienna.CS_CUP
                                       case 80: // new_non_term_id ::= ID 
                                       {
                                           object RESULT = null;
-                                          int non_term_idleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int non_term_idright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string non_term_id = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int non_term_idleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int non_term_idright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string non_term_id = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
          
                                           /* see if this non terminal has been declared before */
                                           if (symbols[non_term_id] != null)
@@ -805,7 +807,7 @@ namespace TUVienna.CS_CUP
                                               symbols.Add(non_term_id, new symbol_part(this_nt));
                                           }
     
-                                          CUP_parser_result = new Symbol(26/*new_non_term_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(26/*new_non_term_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -813,9 +815,9 @@ namespace TUVienna.CS_CUP
                                       case 79: // new_term_id ::= ID 
                                       {
                                           object RESULT = null;
-                                          int term_idleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int term_idright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string term_id = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int term_idleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int term_idright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string term_id = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
          
                                           /* see if this terminal has been declared before */
                                           if (symbols[term_id] != null)
@@ -836,7 +838,7 @@ namespace TUVienna.CS_CUP
                                                   new symbol_part(new terminal(term_id, multipart_name)));
                                           }
     
-                                          CUP_parser_result = new Symbol(25/*new_term_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(25/*new_term_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -845,7 +847,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           multipart_name = multipart_name+"[]"; 
-                                          CUP_parser_result = new Symbol(19/*type_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(19/*type_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -854,7 +856,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(19/*type_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(19/*type_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -863,7 +865,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(15/*import_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(15/*import_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -872,7 +874,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           append_multipart("*"); 
-                                          CUP_parser_result = new Symbol(15/*import_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(15/*import_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -880,11 +882,11 @@ namespace TUVienna.CS_CUP
                                       case 74: // multipart_id ::= robust_id 
                                       {
                                           object RESULT = null;
-                                          int an_idleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int an_idright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string an_id = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int an_idleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int an_idright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string an_id = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
                                           append_multipart(an_id); 
-                                          CUP_parser_result = new Symbol(13/*multipart_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(13/*multipart_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -892,11 +894,11 @@ namespace TUVienna.CS_CUP
                                       case 73: // multipart_id ::= multipart_id DOT robust_id 
                                       {
                                           object RESULT = null;
-                                          int another_idleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int another_idright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string another_id = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int another_idleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int another_idright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string another_id = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
                                           append_multipart(another_id); 
-                                          CUP_parser_result = new Symbol(13/*multipart_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(13/*multipart_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -905,7 +907,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           string RESULT = null;
                                           RESULT = null; 
-                                          CUP_parser_result = new Symbol(39/*opt_label*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(39/*opt_label*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -913,11 +915,11 @@ namespace TUVienna.CS_CUP
                                       case 71: // opt_label ::= COLON label_id 
                                       {
                                           string RESULT = null;
-                                          int labidleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int labidright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string labid = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int labidleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int labidright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string labid = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
                                           RESULT = labid; 
-                                          CUP_parser_result = new Symbol(39/*opt_label*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(39/*opt_label*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -925,14 +927,14 @@ namespace TUVienna.CS_CUP
                                       case 70: // prod_part ::= CODE_string 
                                       {
                                           object RESULT = null;
-                                          int code_strleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int code_strright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string code_str = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int code_strleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int code_strright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string code_str = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
          
                                           /* add a new production part */
                                           add_rhs_part(new action_part(code_str));
     
-                                          CUP_parser_result = new Symbol(24/*prod_part*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(24/*prod_part*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -940,12 +942,12 @@ namespace TUVienna.CS_CUP
                                       case 69: // prod_part ::= symbol_id opt_label 
                                       {
                                           object RESULT = null;
-                                          int symidleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left;
-                                          int symidright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).right;
-                                          string symid = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
-                                          int labidleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int labidright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string labid = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int symidleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left;
+                                          int symidright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).right;
+                                          string symid = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
+                                          int labidleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int labidright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string labid = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
          
                                           /* try to look up the id */
                                           production_part symb = (production_part)symbols[symid];
@@ -963,7 +965,7 @@ namespace TUVienna.CS_CUP
                                               add_rhs_part(add_lab(symb, labid));
                                           }
     
-                                          CUP_parser_result = new Symbol(24/*prod_part*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(24/*prod_part*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -972,7 +974,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(23/*prod_part_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(23/*prod_part_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -981,7 +983,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(23/*prod_part_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(23/*prod_part_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1017,7 +1019,7 @@ namespace TUVienna.CS_CUP
                                           /* reset the rhs accumulation in any case */
                                           new_rhs();
     
-                                          CUP_parser_result = new Symbol(28/*rhs*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(28/*rhs*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1025,9 +1027,9 @@ namespace TUVienna.CS_CUP
                                       case 65: // rhs ::= prod_part_list PERCENT_PREC term_id 
                                       {
                                           object RESULT = null;
-                                          int term_nameleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int term_nameright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string term_name = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int term_nameleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int term_nameright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string term_name = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
         
                                           symbol sym = null;
                                           if (lhs_nt != null) 
@@ -1089,7 +1091,7 @@ namespace TUVienna.CS_CUP
                                           /* reset the rhs accumulation in any case */
                                           new_rhs();
     
-                                          CUP_parser_result = new Symbol(28/*rhs*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(28/*rhs*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1098,7 +1100,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(27/*rhs_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(27/*rhs_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1107,7 +1109,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(27/*rhs_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(27/*rhs_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1116,10 +1118,10 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$13
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
 
-                                          CUP_parser_result = new Symbol(22/*production*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(22/*production*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1128,7 +1130,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           lexer.emit_error("Syntax Error"); 
-                                          CUP_parser_result = new Symbol(56/*NT$13*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(56/*NT$13*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1137,16 +1139,16 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$11
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-4)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-4)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-4).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-4).value;
                                           // propagate RESULT from NT$12
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-2)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-2)).value;
-                                          int lhs_idleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-5)).left;
-                                          int lhs_idright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-5)).right;
-                                          string lhs_id = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-5)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).value;
+                                          int lhs_idleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-5).left;
+                                          int lhs_idright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-5).right;
+                                          string lhs_id = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-5).value;
 
-                                          CUP_parser_result = new Symbol(22/*production*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-5)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(22/*production*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-5).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1154,11 +1156,11 @@ namespace TUVienna.CS_CUP
                                       case 59: // NT$12 ::= 
                                       {
                                           object RESULT = null;
-                                          int lhs_idleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left;
-                                          int lhs_idright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).right;
-                                          string lhs_id = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-2)).value;
+                                          int lhs_idleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left;
+                                          int lhs_idright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).right;
+                                          string lhs_id = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).value;
  
-                                          CUP_parser_result = new Symbol(55/*NT$12*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(55/*NT$12*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1166,9 +1168,9 @@ namespace TUVienna.CS_CUP
                                       case 58: // NT$11 ::= 
                                       {
                                           object RESULT = null;
-                                          int lhs_idleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int lhs_idright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string lhs_id = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int lhs_idleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int lhs_idright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string lhs_id = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
 
                                           /* lookup the lhs nt */
                                           lhs_nt = (non_terminal)non_terms[lhs_id];
@@ -1184,7 +1186,7 @@ namespace TUVienna.CS_CUP
                                           /* reset the rhs accumulation */
                                           new_rhs();
     
-                                          CUP_parser_result = new Symbol(54/*NT$11*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(54/*NT$11*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1193,7 +1195,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(12/*production_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(12/*production_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1202,7 +1204,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(12/*production_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(12/*production_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1211,7 +1213,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(11/*start_spec*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(11/*start_spec*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1220,13 +1222,13 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$10
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
-                                          int start_nameleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left;
-                                          int start_nameright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).right;
-                                          string start_name = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-2)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
+                                          int start_nameleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left;
+                                          int start_nameright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).right;
+                                          string start_name = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).value;
 
-                                          CUP_parser_result = new Symbol(11/*start_spec*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-4)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(11/*start_spec*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-4).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1234,9 +1236,9 @@ namespace TUVienna.CS_CUP
                                       case 53: // NT$10 ::= 
                                       {
                                           object RESULT = null;
-                                          int start_nameleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int start_nameright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string start_name = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int start_nameleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int start_nameright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string start_name = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
  
                                           /* verify that the name has been declared as a non terminal */
                                           non_terminal nt = (non_terminal)non_terms[start_name];
@@ -1260,7 +1262,7 @@ namespace TUVienna.CS_CUP
                                               new_rhs();
                                           }
     
-                                          CUP_parser_result = new Symbol(53/*NT$10*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(53/*NT$10*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1268,9 +1270,9 @@ namespace TUVienna.CS_CUP
                                       case 52: // term_id ::= symbol_id 
                                       {
                                           string RESULT = null;
-                                          int symleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int symright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string sym = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int symleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int symright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string sym = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
         
                                           /* check that the symbol_id is a terminal */
                                           if (symbols[sym] == null)
@@ -1281,7 +1283,7 @@ namespace TUVienna.CS_CUP
                                           }
                                           RESULT = sym;
          
-                                          CUP_parser_result = new Symbol(41/*term_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(41/*term_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1289,14 +1291,14 @@ namespace TUVienna.CS_CUP
                                       case 51: // terminal_id ::= term_id 
                                       {
                                           string RESULT = null;
-                                          int symleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left;
-                                          int symright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right;
-                                          string sym = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-0)).value;
+                                          int symleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left;
+                                          int symright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right;
+                                          string sym = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).value;
             
                                           add_precedence(sym);
                                           RESULT = sym;
     
-                                          CUP_parser_result = new Symbol(40/*terminal_id*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(40/*terminal_id*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1305,7 +1307,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(32/*terminal_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(32/*terminal_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1314,7 +1316,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(32/*terminal_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(32/*terminal_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1323,10 +1325,10 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$9
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-2)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-2)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).value;
 
-                                          CUP_parser_result = new Symbol(31/*preced*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-4)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(31/*preced*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-4).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1337,7 +1339,7 @@ namespace TUVienna.CS_CUP
 
                                           update_precedence(assoc.nonassoc);
     
-                                          CUP_parser_result = new Symbol(52/*NT$9*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(52/*NT$9*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1346,10 +1348,10 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$8
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-2)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-2)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).value;
 
-                                          CUP_parser_result = new Symbol(31/*preced*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-4)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(31/*preced*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-4).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1360,7 +1362,7 @@ namespace TUVienna.CS_CUP
 
                                           update_precedence(assoc.right);
     
-                                          CUP_parser_result = new Symbol(51/*NT$8*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(51/*NT$8*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1369,10 +1371,10 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$7
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-2)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-2)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).value;
 
-                                          CUP_parser_result = new Symbol(31/*preced*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-4)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(31/*preced*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-4).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1383,7 +1385,7 @@ namespace TUVienna.CS_CUP
 
                                           update_precedence(assoc.left);
     
-                                          CUP_parser_result = new Symbol(50/*NT$7*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(50/*NT$7*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1392,7 +1394,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(33/*precedence_l*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(33/*precedence_l*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1401,7 +1403,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(33/*precedence_l*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(33/*precedence_l*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1410,7 +1412,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(30/*precedence_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(30/*precedence_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1419,7 +1421,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(30/*precedence_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(30/*precedence_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1428,7 +1430,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(21/*non_term_name_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(21/*non_term_name_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1437,7 +1439,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(21/*non_term_name_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(21/*non_term_name_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1446,7 +1448,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(20/*term_name_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(20/*term_name_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1455,7 +1457,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(20/*term_name_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(20/*term_name_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1464,10 +1466,10 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$6
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
 
-                                          CUP_parser_result = new Symbol(35/*declares_non_term*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(35/*declares_non_term*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1479,7 +1481,7 @@ namespace TUVienna.CS_CUP
                                           /* reset the accumulated multipart name */
                                           multipart_name = "";
     
-                                          CUP_parser_result = new Symbol(49/*NT$6*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(49/*NT$6*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1488,10 +1490,10 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$5
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
 
-                                          CUP_parser_result = new Symbol(34/*declares_term*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(34/*declares_term*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1503,7 +1505,7 @@ namespace TUVienna.CS_CUP
                                           /* reset the accumulated multipart name */
                                           multipart_name = "";
     
-                                          CUP_parser_result = new Symbol(48/*NT$5*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(48/*NT$5*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1512,10 +1514,10 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$4
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
 
-                                          CUP_parser_result = new Symbol(18/*symbol*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-3)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(18/*symbol*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-3).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1527,7 +1529,7 @@ namespace TUVienna.CS_CUP
                                           /* reset the accumulated multipart name */
                                           multipart_name = "";
     
-                                          CUP_parser_result = new Symbol(47/*NT$4*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(47/*NT$4*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1536,10 +1538,10 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$3
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
 
-                                          CUP_parser_result = new Symbol(18/*symbol*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-3)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(18/*symbol*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-3).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1551,7 +1553,7 @@ namespace TUVienna.CS_CUP
                                           /* reset the accumulated multipart name */
                                           multipart_name = "";
     
-                                          CUP_parser_result = new Symbol(46/*NT$3*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(46/*NT$3*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1560,7 +1562,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(18/*symbol*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(18/*symbol*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1569,7 +1571,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(18/*symbol*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(18/*symbol*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1578,7 +1580,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(18/*symbol*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(18/*symbol*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1587,7 +1589,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(18/*symbol*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-2)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(18/*symbol*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-2).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1596,7 +1598,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(10/*symbol_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(10/*symbol_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1605,7 +1607,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(10/*symbol_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(10/*symbol_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1613,16 +1615,16 @@ namespace TUVienna.CS_CUP
                                       case 20: // scan_code ::= SCAN WITH CODE_string opt_semi 
                                       {
                                           object RESULT = null;
-                                          int user_codeleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left;
-                                          int user_coderight = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).right;
-                                          string user_code = ((string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value);
+                                          int user_codeleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left;
+                                          int user_coderight = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).right;
+                                          string user_code = ((string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value);
          
                                           if (emit.scan_code!=null)
                                               lexer.emit_error("Redundant scan code (skipping)");
                                           else /* save the user code */
                                               emit.scan_code = user_code;
     
-                                          CUP_parser_result = new Symbol(17/*scan_code*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-3)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(17/*scan_code*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-3).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1630,16 +1632,16 @@ namespace TUVienna.CS_CUP
                                       case 19: // init_code ::= INIT WITH CODE_string opt_semi 
                                       {
                                           object RESULT = null;
-                                          int user_codeleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left;
-                                          int user_coderight = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).right;
-                                          string user_code = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
+                                          int user_codeleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left;
+                                          int user_coderight = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).right;
+                                          string user_code = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
          
                                           if (emit.init_code!=null)
                                               lexer.emit_error("Redundant init code (skipping)");
                                           else /* save the user code */
                                               emit.init_code = user_code;
     
-                                          CUP_parser_result = new Symbol(16/*init_code*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-3)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(16/*init_code*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-3).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1647,16 +1649,16 @@ namespace TUVienna.CS_CUP
                                       case 18: // parser_code_part ::= PARSER CODE CODE_string opt_semi 
                                       {
                                           object RESULT = null;
-                                          int user_codeleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left;
-                                          int user_coderight = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).right;
-                                          string user_code = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
+                                          int user_codeleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left;
+                                          int user_coderight = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).right;
+                                          string user_code = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
         
                                           if (emit.parser_code!=null)
                                               lexer.emit_error("Redundant parser code (skipping)");
                                           else /* save the user included code string */
                                               emit.parser_code = user_code;
     
-                                          CUP_parser_result = new Symbol(9/*parser_code_part*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-3)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(9/*parser_code_part*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-3).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1664,16 +1666,16 @@ namespace TUVienna.CS_CUP
                                       case 17: // action_code_part ::= ACTION CODE CODE_string opt_semi 
                                       {
                                           object RESULT = null;
-                                          int user_codeleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left;
-                                          int user_coderight = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).right;
-                                          string user_code = (string)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
+                                          int user_codeleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left;
+                                          int user_coderight = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).right;
+                                          string user_code = (string)CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
         
                                           if (emit.action_code!=null)
                                               lexer.emit_error("Redundant action code (skipping)");
                                           else /* save the user included code string */
                                               emit.action_code = user_code;
     
-                                          CUP_parser_result = new Symbol(4/*action_code_part*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-3)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(4/*action_code_part*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-3).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1682,7 +1684,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(5/*code_parts*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(5/*code_parts*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1691,7 +1693,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(5/*code_parts*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(5/*code_parts*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1700,7 +1702,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(6/*code_part*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(6/*code_part*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1709,7 +1711,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(6/*code_part*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(6/*code_part*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1718,7 +1720,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(6/*code_part*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(6/*code_part*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1727,7 +1729,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(6/*code_part*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(6/*code_part*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1736,10 +1738,10 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$2
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
 
-                                          CUP_parser_result = new Symbol(14/*import_spec*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-3)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(14/*import_spec*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-3).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1754,7 +1756,7 @@ namespace TUVienna.CS_CUP
                                           /* reset the accumulated multipart name */
                                           multipart_name = "";
     
-                                          CUP_parser_result = new Symbol(45/*NT$2*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(45/*NT$2*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1763,7 +1765,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(3/*import_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(3/*import_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1772,7 +1774,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(3/*import_list*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(3/*import_list*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1781,7 +1783,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(2/*package_spec*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(2/*package_spec*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1790,10 +1792,10 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$1
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
 
-                                          CUP_parser_result = new Symbol(2/*package_spec*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-3)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(2/*package_spec*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-3).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1808,7 +1810,7 @@ namespace TUVienna.CS_CUP
                                           /* reset the accumulated multipart name */
                                           multipart_name = "";
     
-                                          CUP_parser_result = new Symbol(44/*NT$1*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(44/*NT$1*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1817,7 +1819,7 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
 
-                                          CUP_parser_result = new Symbol(1/*spec*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-4)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(1/*spec*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-4).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1826,10 +1828,10 @@ namespace TUVienna.CS_CUP
                                       {
                                           object RESULT = null;
                                           // propagate RESULT from NT$0
-                                          if ( ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-7)).value != null )
-                                              RESULT = (object) ((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-7)).value;
+                                          if ( CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-7).value != null )
+                                              RESULT = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-7).value;
 
-                                          CUP_parser_result = new Symbol(1/*spec*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-7)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(1/*spec*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-7).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1844,7 +1846,7 @@ namespace TUVienna.CS_CUP
                                           /* declare start non terminal */
                                           non_terms.Add("$START", non_terminal.START_nt);
     
-                                          CUP_parser_result = new Symbol(43/*NT$0*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(43/*NT$0*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           return CUP_parser_result;
 
@@ -1852,11 +1854,11 @@ namespace TUVienna.CS_CUP
                                       case 0: // $START ::= spec EOF 
                                       {
                                           object RESULT = null;
-                                          int start_valleft = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left;
-                                          int start_valright = ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).right;
-                                          object start_val = (object)((Symbol) CUP_parser_stack.elementAt(CUP_parser_top-1)).value;
+                                          int start_valleft = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left;
+                                          int start_valright = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).right;
+                                          object start_val = CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).value;
                                           RESULT = start_val;
-                                          CUP_parser_result = new Symbol(0/*$START*/, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-1)).left, ((Symbol)CUP_parser_stack.elementAt(CUP_parser_top-0)).right, RESULT);
+                                          CUP_parser_result = new Symbol(0/*$START*/, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top-1).left, CUP_parser_stack.ElementAtFromBottom(CUP_parser_top).right, RESULT);
                                       }
                                           /* ACCEPT */
                                           CUP_parser_parser.done_parsing();

--- a/CSCup/production.cs
+++ b/CSCup/production.cs
@@ -389,11 +389,11 @@ public class production {
 	  emit.pre("stack") + ".elementAt(" + emit.pre("top") +
 	  "-" + offset + ")).right;\n";
       else ret = "";
-
+            string offsetText = offset == 0 ? "" : "-" + offset;
       /* otherwise, just declare label. */
 	return ret + "\t\t" + stack_type + " " + labelname + " = (" + stack_type + 
-	  ")((" + "TUVienna.CS_CUP.Runtime.Symbol) " + emit.pre("stack") + ".elementAt(" + emit.pre("top") 
-	  + "-" + offset + ")).value;\n";
+                   ")( " + emit.pre("stack") + ".ElementAtFromBottom(" + emit.pre("top")
+                   + offsetText + ")).value;\n";
 
     }
   /*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .*/

--- a/CSCupRuntime/CSCupRuntime.csproj
+++ b/CSCupRuntime/CSCupRuntime.csproj
@@ -46,6 +46,7 @@
     <Compile Include="lr_parser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scanner.cs" />
+    <Compile Include="StackList.cs" />
     <Compile Include="Symbol.cs" />
     <Compile Include="virtual_parse_stack.cs" />
   </ItemGroup>

--- a/CSCupRuntime/CSCupRuntime.csproj
+++ b/CSCupRuntime/CSCupRuntime.csproj
@@ -1,6 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  
+    <Import Project="..\TypeCobol\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -14,39 +16,22 @@
     <DoNotCopyLocalIfInGac>true</DoNotCopyLocalIfInGac>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>..\bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
     <OutputPath>..\bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'EI_Debug|AnyCPU'">
     <OutputPath>..\bin\EI_Debug\</OutputPath>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'EI_Debug_Net40|AnyCPU'">
     <OutputPath>..\bin\EI_Debug_Net40\</OutputPath>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'EI_Release|AnyCPU'">
     <OutputPath>..\bin\EI_Release\</OutputPath>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'EI_Release_Net40|AnyCPU'">
     <OutputPath>..\bin\EI_Release_Net40\</OutputPath>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/CSCupRuntime/StackList.cs
+++ b/CSCupRuntime/StackList.cs
@@ -1,0 +1,352 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+// ==++==
+// 
+//   Copyright (c) Microsoft Corporation.  All rights reserved.
+// 
+// ==--==
+/*=============================================================================
+**
+** Class: Stack
+**
+** Purpose: An array implementation of a generic stack.
+**
+** Date: January 28, 2003
+**
+=============================================================================*/
+namespace CSCupRuntime
+{
+    using System;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+
+    // A simple stack of objects.  Internally it is implemented as an array,
+    // so Push can be O(n).  Pop is O(1).
+
+    [DebuggerDisplay("Count = {Count}")]
+    [System.Runtime.InteropServices.ComVisible(false)]
+    public class StackList<T> : IEnumerable<T>,
+        System.Collections.ICollection,
+        IReadOnlyCollection<T>
+    {
+        private T[] _array;     // Storage for stack elements
+        private int _version;        // Used to keep enumerator in sync w/ collection.
+
+        private Object _syncRoot;
+
+        private const int _defaultCapacity = 4;
+        static T[] _emptyArray = new T[0];
+
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.Stack"]/*' />
+        public StackList()
+        {
+            _array = _emptyArray;
+            Count = 0;
+            _version = 0;
+        }
+
+        // Create a stack with a specific initial capacity.  The initial capacity
+        // must be a non-negative number.
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.Stack1"]/*' />
+        public StackList(int capacity)
+        {
+            Contract.Assert(capacity >= 0);
+            _array = new T[capacity];
+            Count = 0;
+            _version = 0;
+        }
+
+        // Fills a Stack with the contents of a particular collection.  The items are
+        // pushed onto the stack in the same order they are read by the enumerator.
+        //
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.Stack2"]/*' />
+        public StackList(IEnumerable<T> collection)
+        {
+            Contract.Assert(collection != null, "collection null");
+            
+
+            ICollection<T> c = collection as ICollection<T>;
+            if (c != null)
+            {
+                int count = c.Count;
+                _array = new T[count];
+                c.CopyTo(_array, 0);
+                Count = count;
+            }
+            else
+            {
+                Count = 0;
+                _array = new T[_defaultCapacity];
+
+                using (IEnumerator<T> en = collection.GetEnumerator())
+                {
+                    while (en.MoveNext())
+                    {
+                        Push(en.Current);
+                    }
+                }
+            }
+        }
+
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.Count"]/*' />
+        public int Count { get; private set; }
+
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.IsSynchronized"]/*' />
+        bool System.Collections.ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.SyncRoot"]/*' />
+        Object System.Collections.ICollection.SyncRoot
+        {
+            get
+            {
+                if (_syncRoot == null)
+                {
+                    System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new Object(), null);
+                }
+                return _syncRoot;
+            }
+        }
+
+        // Removes all Objects from the Stack.
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.Clear"]/*' />
+        public void Clear()
+        {
+            Array.Clear(_array, 0, Count); // Don't need to doc this but we clear the elements so that the gc can reclaim the references.
+            Count = 0;
+            _version++;
+        }
+
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.Contains"]/*' />
+        public bool Contains(T item)
+        {
+            int count = Count;
+
+            EqualityComparer<T> c = EqualityComparer<T>.Default;
+            while (count-- > 0)
+            {
+                if (item == null)
+                {
+                    if (_array[count] == null)
+                        return true;
+                }
+                else if (_array[count] != null && c.Equals(_array[count], item))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Copies the stack into an array.
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.CopyTo"]/*' />
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            Contract.Assert(array != null, "array null");
+            Contract.Assert(arrayIndex >= 0 && arrayIndex < array.Length, "ArgumentOutOfRange_NeedNonNegNum");
+            Contract.Assert(array.Length - arrayIndex >= Count, "Argument_InvalidOffLen");
+            
+
+            Array.Copy(_array, 0, array, arrayIndex, Count);
+            Array.Reverse(array, arrayIndex, Count);
+        }
+
+        void System.Collections.ICollection.CopyTo(Array array, int arrayIndex)
+        {
+            Contract.Assert(array!=null, "array null");
+            Contract.Assert(array.Rank == 1, "Arg_RankMultiDimNotSupported");
+            Contract.Assert(array.GetLowerBound(0) == 0, "Arg_NonZeroLowerBound");
+            Contract.Assert(arrayIndex >= 0 && arrayIndex < array.Length, "ArgumentOutOfRange_NeedNonNegNum");
+            Contract.Assert(array.Length - arrayIndex >= Count, "Argument_InvalidOffLen");
+
+
+                Array.Copy(_array, 0, array, arrayIndex, Count);
+                Array.Reverse(array, arrayIndex, Count);
+
+        }
+
+        // Returns an IEnumerator for this Stack.
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.GetEnumerator"]/*' />
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.IEnumerable.GetEnumerator"]/*' />
+        /// <internalonly/>
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        public void TrimExcess()
+        {
+            int threshold = (int)(((double)_array.Length) * 0.9);
+            if (Count < threshold)
+            {
+                T[] newarray = new T[Count];
+                Array.Copy(_array, 0, newarray, 0, Count);
+                _array = newarray;
+                _version++;
+            }
+        }
+
+        public T ElementAtFromBottom(int index)
+        {
+            Contract.Assert(Count != 0, "InvalidOperation_EmptyStack");
+            Contract.Assert(index >= 0 && index < _array.Length, "ArgumentOutOfRange_NeedNonNegNum");
+
+            return _array[index];
+        }
+        public T ElementAtFromTop(int index)
+        {
+            Contract.Assert(Count != 0, "InvalidOperation_EmptyStack");
+            Contract.Assert(index >= 0 && index < _array.Length, "ArgumentOutOfRange_NeedNonNegNum");
+
+            return _array[Count - index - 1];
+        }
+
+        // Returns the top object on the stack without removing it.  If the stack
+        // is empty, Peek throws an InvalidOperationException.
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.Peek"]/*' />
+        public T Peek()
+        {
+            Contract.Assert(Count != 0, "InvalidOperation_EmptyStack");
+            return _array[Count - 1];
+        }
+
+        // Pops an item from the top of the stack.  If the stack is empty, Pop
+        // throws an InvalidOperationException.
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.Pop"]/*' />
+        public T Pop()
+        {
+            Contract.Assert(Count!=0, "InvalidOperation_EmptyStack");
+
+            _version++;
+            T item = _array[--Count];
+            _array[Count] = default(T);     // Free memory quicker.
+            return item;
+        }
+
+        // Pushes an item to the top of the stack.
+        // 
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="Stack.Push"]/*' />
+        public void Push(T item)
+        {
+            if (Count == _array.Length)
+            {
+                T[] newArray = new T[(_array.Length == 0) ? _defaultCapacity : 2 * _array.Length];
+                Array.Copy(_array, 0, newArray, 0, Count);
+                _array = newArray;
+            }
+            _array[Count++] = item;
+            _version++;
+        }
+
+        // Copies the Stack to an array, in the same order Pop would return the items.
+        public T[] ToArray()
+        {
+            T[] objArray = new T[Count];
+            int i = 0;
+            while (i < Count)
+            {
+                objArray[i] = _array[Count - i - 1];
+                i++;
+            }
+            return objArray;
+        }
+
+        /// <include file='doc\Stack.uex' path='docs/doc[@for="StackEnumerator"]/*' />
+
+        [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "not an expected scenario")]
+        public struct Enumerator : IEnumerator<T>,
+            System.Collections.IEnumerator
+        {
+            private StackList<T> _stack;
+            private int _index;
+            private int _version;
+            private T currentElement;
+
+            internal Enumerator(StackList<T> stack)
+            {
+                _stack = stack;
+                _version = _stack._version;
+                _index = -2;
+                currentElement = default(T);
+            }
+
+            /// <include file='doc\Stack.uex' path='docs/doc[@for="StackEnumerator.Dispose"]/*' />
+            public void Dispose()
+            {
+                _index = -1;
+            }
+
+            /// <include file='doc\Stack.uex' path='docs/doc[@for="StackEnumerator.MoveNext"]/*' />
+            public bool MoveNext()
+            {
+                bool retval;
+                Contract.Assert(_version == _stack._version, "InvalidOperation_EnumFailedVersion");
+                if (_index == -2)
+                {  // First call to enumerator.
+                    _index = _stack.Count - 1;
+                    retval = (_index >= 0);
+                    if (retval)
+                        currentElement = _stack._array[_index];
+                    return retval;
+                }
+                if (_index == -1)
+                {  // End of enumeration.
+                    return false;
+                }
+
+                retval = (--_index >= 0);
+                if (retval)
+                    currentElement = _stack._array[_index];
+                else
+                    currentElement = default(T);
+                return retval;
+            }
+
+            /// <include file='doc\Stack.uex' path='docs/doc[@for="StackEnumerator.Current"]/*' />
+            public T Current
+            {
+                get {
+                    Contract.Assert(_index != -2, "Enum not started");
+                    Contract.Assert(_index != -1, "Enum ended");
+                    return currentElement;
+                }
+            }
+
+            Object System.Collections.IEnumerator.Current
+            {
+                get {
+                    Contract.Assert(_index != -2, "Enum not started");
+                    Contract.Assert(_index != -1, "Enum ended");
+                    return currentElement;
+                }
+            }
+
+            void System.Collections.IEnumerator.Reset() {
+                Contract.Assert(_version == _stack._version);
+                _index = -2;
+                currentElement = default(T);
+            }
+        }
+    }
+   
+}

--- a/CSCupRuntime/virtual_parse_stack.cs
+++ b/CSCupRuntime/virtual_parse_stack.cs
@@ -1,8 +1,10 @@
 
+using CSCupRuntime;
+
 namespace TUVienna.CS_CUP.Runtime
 {
 
-	using System.Collections;
+	using System.Collections.Generic;
 
 	/** This class implements a temporary or "virtual" parse stack that 
 	 *  replaces the top portion of the actual parse stack (the part that 
@@ -28,7 +30,7 @@ namespace TUVienna.CS_CUP.Runtime
 		/*-----------------------------------------------------------*/
 
 		/** Constructor to build a virtual stack out of a real stack. */
-		public virtual_parse_stack(Stack shadowing_stack) 
+		public virtual_parse_stack(StackList<Symbol> shadowing_stack) 
 														  {
 															  /* sanity check */
 															  if (shadowing_stack == null)
@@ -37,7 +39,7 @@ namespace TUVienna.CS_CUP.Runtime
 
 		/* Set up our internals */
 		real_stack = shadowing_stack;
-		vstack     = new Stack();
+		vstack     = new Stack<int>();
 		real_next  = 0;
 
 		/* get one element onto the virtual portion of the stack */
@@ -52,7 +54,7 @@ namespace TUVienna.CS_CUP.Runtime
 	 *  the bottom of the virtual portion of the stack, but is always left
 	 *  unmodified.
 	 */
-	protected Stack real_stack;
+	protected StackList<Symbol> real_stack;
 
 	/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .*/
 
@@ -70,7 +72,7 @@ namespace TUVienna.CS_CUP.Runtime
 	 *  on the virtual stack).  When this portion of the stack becomes empty we 
 	 *  transfer elements from the underlying stack onto this stack. 
 	 */
-	protected Stack vstack;
+	protected Stack<int> vstack;
 
 	/*-----------------------------------------------------------*/
 	/*--- General Methods ---------------------------------------*/
@@ -90,10 +92,10 @@ namespace TUVienna.CS_CUP.Runtime
     //CSCupRuntime: Error Recovery mechanism has a Bug, it does not work.  #926
     //https://github.com/TypeCobolTeam/TypeCobol/issues/926
     //stack_sym = (Symbol)real_stack.ToArray()[real_stack.Count-1-real_next]; 
-    stack_sym = (Symbol)real_stack.ToArray()[real_next];
+    stack_sym = real_stack.ElementAtFromTop(real_next);
 
-	/* record the transfer */
-	real_next++;
+            /* record the transfer */
+            real_next++;
 
 	/* put the state number from the Symbol onto the virtual stack */
 	vstack.Push(stack_sym.parse_state);
@@ -118,7 +120,7 @@ namespace TUVienna.CS_CUP.Runtime
 	throw new System.Exception(
 	"Internal parser error: top() called on empty virtual stack");
 
-	return (System.Int32)vstack.Peek();
+	return vstack.Peek();
 }
 
 	/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .*/

--- a/TypeCobol.Test/Parser/Performance/Performance.cs
+++ b/TypeCobol.Test/Parser/Performance/Performance.cs
@@ -55,7 +55,7 @@ namespace TypeCobol.Test.Parser.Performance
             ExecuteInceremental(compiler, stats);
 
             // Display a performance report
-            TestUtils.CreateRunReport(TestUtils.GetReportDirectoryPath(), compiler.CobolFile.Name + "-Incremental", compiler.CompilationResultsForProgram, stats);
+            TestUtils.CreateRunReport(TestUtils.GetReportDirectoryPath(), compiler.CobolFile.Name + "-Incremental", stats, compiler.CompilationResultsForProgram);
         }
 
         public static void ExecuteInceremental(FileCompiler compiler, TestUtils.CompilationStats stats)
@@ -63,8 +63,8 @@ namespace TypeCobol.Test.Parser.Performance
             // Execute a first (complete) compilation
             compiler.CompileOnce();
             //Iterate multiple times over an incremental change
-            int incrementalIterationNumber = 20;
-            for (int i = 0; i < incrementalIterationNumber; i++)
+            stats.IterationNumber= 20;
+            for (int i = 0; i < stats.IterationNumber; i++)
             {
                 // Append one line in the middle of the program
                 ITextLine newLine = new TextLineSnapshot(9211, "094215D    DISPLAY '-ICLAUA      = ' ICLAUA.                            0000000", null);
@@ -83,12 +83,12 @@ namespace TypeCobol.Test.Parser.Performance
                 stats.AverageCrossCheckerParserTime         += compiler.CompilationResultsForProgram.PerfStatsForProgramCrossCheck.LastRefreshTime;
             }
             //Compute average time needed for each phase
-            stats.AverageTextUpdateTime                 = (int) stats.AverageTextUpdateTime / incrementalIterationNumber;
-            stats.AverageScannerTime                    = (int) stats.AverageScannerTime / incrementalIterationNumber;
-            stats.AveragePreprocessorTime               = (int) stats.AveragePreprocessorTime / incrementalIterationNumber;
-            stats.AverageCodeElementParserTime          = (int) stats.AverageCodeElementParserTime / incrementalIterationNumber;
-            stats.AverateTemporarySemanticsParserTime   = (int) stats.AverateTemporarySemanticsParserTime / incrementalIterationNumber;
-            stats.AverageCrossCheckerParserTime         = (int) stats.AverageCrossCheckerParserTime / incrementalIterationNumber;
+            stats.AverageTextUpdateTime                 = (int) stats.AverageTextUpdateTime / stats.IterationNumber;
+            stats.AverageScannerTime                    = (int) stats.AverageScannerTime / stats.IterationNumber;
+            stats.AveragePreprocessorTime               = (int) stats.AveragePreprocessorTime / stats.IterationNumber;
+            stats.AverageCodeElementParserTime          = (int) stats.AverageCodeElementParserTime / stats.IterationNumber;
+            stats.AverateTemporarySemanticsParserTime   = (int) stats.AverateTemporarySemanticsParserTime / stats.IterationNumber;
+            stats.AverageCrossCheckerParserTime         = (int) stats.AverageCrossCheckerParserTime / stats.IterationNumber;
             stats.AverageTotalProcessingTime = stats.AverageCodeElementParserTime +
                                                stats.AverageCrossCheckerParserTime +
                                                stats.AveragePreprocessorTime +
@@ -115,7 +115,7 @@ namespace TypeCobol.Test.Parser.Performance
             string path = Path.Combine(rootFolder, filename);
 
             TestUtils.CompilationStats stats = new TestUtils.CompilationStats();
-            int iterationNumber = 20;
+            stats.IterationNumber = 20;
             //Warmup before measurement
             var documentWarmup = new TypeCobol.Parser();
             var optionsWarmup = new TypeCobolOptions
@@ -128,7 +128,7 @@ namespace TypeCobol.Test.Parser.Performance
             documentWarmup.Init(path, optionsWarmup, format, copiesFolder);
             documentWarmup.Parse(path);
 
-            for (int i = 0; i < iterationNumber; i++)
+            for (int i = 0; i < stats.IterationNumber; i++)
             {
                 var document = new TypeCobol.Parser();
                 var options = new TypeCobolOptions
@@ -150,12 +150,12 @@ namespace TypeCobol.Test.Parser.Performance
             }
 
             //Compute average time needed for each phase
-            stats.AverageTextUpdateTime = (int)stats.AverageTextUpdateTime / iterationNumber;
-            stats.AverageScannerTime = (int)stats.AverageScannerTime / iterationNumber;
-            stats.AveragePreprocessorTime = (int)stats.AveragePreprocessorTime / iterationNumber;
-            stats.AverageCodeElementParserTime = (int)stats.AverageCodeElementParserTime / iterationNumber;
-            stats.AverateTemporarySemanticsParserTime = (int)stats.AverateTemporarySemanticsParserTime / iterationNumber;
-            stats.AverageCrossCheckerParserTime = (int)stats.AverageCrossCheckerParserTime / iterationNumber;
+            stats.AverageTextUpdateTime = (int)stats.AverageTextUpdateTime / stats.IterationNumber;
+            stats.AverageScannerTime = (int)stats.AverageScannerTime / stats.IterationNumber;
+            stats.AveragePreprocessorTime = (int)stats.AveragePreprocessorTime / stats.IterationNumber;
+            stats.AverageCodeElementParserTime = (int)stats.AverageCodeElementParserTime / stats.IterationNumber;
+            stats.AverateTemporarySemanticsParserTime = (int)stats.AverateTemporarySemanticsParserTime / stats.IterationNumber;
+            stats.AverageCrossCheckerParserTime = (int)stats.AverageCrossCheckerParserTime / stats.IterationNumber;
 
             stats.AverageTotalProcessingTime = stats.AverageCodeElementParserTime +
                                                stats.AverageCrossCheckerParserTime +
@@ -166,7 +166,7 @@ namespace TypeCobol.Test.Parser.Performance
             stats.Line = documentWarmup.Results.CobolTextLines.Count;
             stats.TotalCodeElements = documentWarmup.Results.CodeElementsDocumentSnapshot.CodeElements.Count();
 
-            TestUtils.CreateRunReport(TestUtils.GetReportDirectoryPath(), filename + "-FullParsing", null, stats);
+            TestUtils.CreateRunReport(TestUtils.GetReportDirectoryPath(), filename + "-FullParsing", stats, null);
         }
     }
 }

--- a/TypeCobol.Test/Parser/Performance/Performance.cs
+++ b/TypeCobol.Test/Parser/Performance/Performance.cs
@@ -125,11 +125,15 @@ namespace TypeCobol.Test.Parser.Performance
                 AutoRemarksEnable = true
 #endif
             };
-            documentWarmup.Init(path, optionsWarmup, format, copiesFolder);
-            documentWarmup.Parse(path);
+            
 
             for (int i = 0; i < stats.IterationNumber; i++)
             {
+
+                documentWarmup = new TypeCobol.Parser();
+                documentWarmup.Init(path, optionsWarmup, format, copiesFolder);
+                documentWarmup.Parse(path);
+
                 var document = new TypeCobol.Parser();
                 var options = new TypeCobolOptions
                 {

--- a/TypeCobol.Test/TestUtils.cs
+++ b/TypeCobol.Test/TestUtils.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Antlr4.Runtime.Misc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TypeCobol.Compiler;
 
@@ -89,15 +90,18 @@ namespace TypeCobol.Test
         }
 
         public static void CreateRunReport(string localDirectoryFullName, string cobolFileName,
-            CompilationUnit compiler = null, CompilationStats stats = null)
+            [NotNull] CompilationStats stats, CompilationUnit compiler = null)
         {
 
             // Display a performance report
             StringBuilder report = new StringBuilder();
             report.AppendLine("Program properties :");
 
-            report.AppendLine("- " + (compiler?.CobolTextLines.Count ?? stats?.Line) + " lines");
-            report.AppendLine("- " + (compiler?.CodeElementsDocumentSnapshot.CodeElements.Count() ?? stats?.TotalCodeElements) + " code elements");
+            report.AppendLine("- " + (compiler?.CobolTextLines.Count ?? stats.Line) + " lines");
+            report.AppendLine("- " + (compiler?.CodeElementsDocumentSnapshot.CodeElements.Count() ?? stats.TotalCodeElements) + " code elements");
+
+            report.AppendLine(" Iteration : " + stats.IterationNumber); 
+
             if (compiler != null)
             {
                 var totalTime = compiler.PerfStatsForText.FirstCompilationTime +
@@ -131,34 +135,30 @@ namespace TypeCobol.Test
                 report.AppendLine("*TAT - Total average time");
             }
 
-            if (stats != null)
-            {
-
-                report.AppendLine("");
-                report.AppendLine(compiler != null
-                    ? "Incremental compilation performance (average time)"
-                    : "Full compilation performance (average time)");
-                report.AppendLine("- " + stats.AverageTextUpdateTime + " ms " +
-                                  FormatPrecentage(stats.AverageTextUpdateTime, stats.AverageTotalProcessingTime) +
-                                  " : text update");
-                report.AppendLine("- " + stats.AverageScannerTime + " ms " +
-                                  FormatPrecentage(stats.AverageScannerTime, stats.AverageTotalProcessingTime) +
-                                  " : scanner");
-                report.AppendLine("- " + stats.AveragePreprocessorTime + " ms" +
-                                  FormatPrecentage(stats.AveragePreprocessorTime, stats.AverageTotalProcessingTime) +
-                                  " : preprocessor");
-                report.AppendLine("- " + stats.AverageCodeElementParserTime + " ms" +
-                                  FormatPrecentage(stats.AverageCodeElementParserTime,
-                                      stats.AverageTotalProcessingTime) + " : code elements parser");
-                report.AppendLine("- " + stats.AverateTemporarySemanticsParserTime + " ms " +
-                                  FormatPrecentage(stats.AverateTemporarySemanticsParserTime,
-                                      stats.AverageTotalProcessingTime) + " : temporary semantic class parser");
-                report.AppendLine("- " + stats.AverageCrossCheckerParserTime + " ms " +
-                                  FormatPrecentage(stats.AverageCrossCheckerParserTime,
-                                      stats.AverageTotalProcessingTime) + " : cross check class parser");
-                report.AppendLine("TAT " + stats.AverageTotalProcessingTime + " - ms");
-                report.AppendLine("*TAT - Total average time");
-            }
+            report.AppendLine("");
+            report.AppendLine(compiler != null
+                ? "Incremental compilation performance (average time)"
+                : "Full compilation performance (average time)");
+            report.AppendLine("- " + stats.AverageTextUpdateTime + " ms " +
+                              FormatPrecentage(stats.AverageTextUpdateTime, stats.AverageTotalProcessingTime) +
+                              " : text update");
+            report.AppendLine("- " + stats.AverageScannerTime + " ms " +
+                              FormatPrecentage(stats.AverageScannerTime, stats.AverageTotalProcessingTime) +
+                              " : scanner");
+            report.AppendLine("- " + stats.AveragePreprocessorTime + " ms" +
+                              FormatPrecentage(stats.AveragePreprocessorTime, stats.AverageTotalProcessingTime) +
+                              " : preprocessor");
+            report.AppendLine("- " + stats.AverageCodeElementParserTime + " ms" +
+                              FormatPrecentage(stats.AverageCodeElementParserTime,
+                                  stats.AverageTotalProcessingTime) + " : code elements parser");
+            report.AppendLine("- " + stats.AverateTemporarySemanticsParserTime + " ms " +
+                              FormatPrecentage(stats.AverateTemporarySemanticsParserTime,
+                                  stats.AverageTotalProcessingTime) + " : temporary semantic class parser");
+            report.AppendLine("- " + stats.AverageCrossCheckerParserTime + " ms " +
+                              FormatPrecentage(stats.AverageCrossCheckerParserTime,
+                                  stats.AverageTotalProcessingTime) + " : cross check class parser");
+            report.AppendLine("TAT " + stats.AverageTotalProcessingTime + " - ms");
+            report.AppendLine("*TAT - Total average time");
 
             var reportFile = "Report_" + cobolFileName.Split('.')[0] + "_" +
                                 DateTime.Now.ToString("dd_MM_yyyy_H_mm_ss_fff") + ".txt";
@@ -182,6 +182,7 @@ namespace TypeCobol.Test
         {
             public CompilationStats()
             {
+                IterationNumber = 0;
                 AverageCodeElementParserTime = 0;
                 AverageCrossCheckerParserTime = 0;
                 AveragePreprocessorTime = 0;
@@ -192,6 +193,7 @@ namespace TypeCobol.Test
                 Line = 0;
                 TotalCodeElements = 0;
             }
+            public float IterationNumber { get; set; }
             public float AverageTextUpdateTime { get; set; }
             public float AverageScannerTime { get; set; }
             public float AveragePreprocessorTime { get; set; }

--- a/TypeCobol/Compiler/CupCommon/CupCobolErrorStrategy.cs
+++ b/TypeCobol/Compiler/CupCommon/CupCobolErrorStrategy.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Antlr4.Runtime;
+using CSCupRuntime;
 using TUVienna.CS_CUP.Runtime;
 using TypeCobol.Compiler.Diagnostics;
 using TypeCobol.Compiler.Scanner;
@@ -37,12 +38,12 @@ namespace TypeCobol.Compiler.CupCommon
             Diagnostics.Add(diag);
         }
 
-        public virtual bool ReportFatalError(lr_parser parser, Stack stack, string message, object info)
+        public virtual bool ReportFatalError(lr_parser parser, StackList<Symbol> stack, string message, object info)
         {
             return true;
         }
 
-        public virtual bool ReportError(lr_parser parser, Stack stack, string message, object info)
+        public virtual bool ReportError(lr_parser parser, StackList<Symbol> stack, string message, object info)
         {
             return true;
         }
@@ -53,7 +54,7 @@ namespace TypeCobol.Compiler.CupCommon
         /// <param name="parser">The parser stack</param>
         /// <param name="curToken">The current Symbol</param>
         /// <returns>The first valid symbol if any, null otherwise</returns>
-        protected virtual Symbol GetParserValidStackSymbol(lr_parser parser, Stack stack, Symbol curToken)
+        protected virtual Symbol GetParserValidStackSymbol(lr_parser parser, StackList<Symbol> stack, Symbol curToken)
         {
             if (curToken != null && curToken.value != null)
                 return curToken;
@@ -78,7 +79,7 @@ namespace TypeCobol.Compiler.CupCommon
         /// <param name="stack">The parser stack</param>
         /// <param name="curToken">The Token to check</param>
         /// <returns>true if the token is consumed, false otherwise</returns>
-        public bool IsTokenConsumed(lr_parser parser, Stack stack, Symbol curToken)
+        public bool IsTokenConsumed(lr_parser parser, StackList<Symbol> stack, Symbol curToken)
         {
             if (curToken?.value == null)
                 return false;
@@ -93,7 +94,7 @@ namespace TypeCobol.Compiler.CupCommon
             get; set;
         }
 
-        public virtual bool SyntaxError(lr_parser parser, Stack stack, Symbol curToken)
+        public virtual bool SyntaxError(lr_parser parser, StackList<Symbol> stack, Symbol curToken)
         {
             curToken = GetParserValidStackSymbol(parser, stack, curToken);
             string input = "<unknown input>";
@@ -131,7 +132,7 @@ namespace TypeCobol.Compiler.CupCommon
             return true;
         }
 
-        public virtual bool UnrecoveredSyntaxError(lr_parser parser, Stack stack, Symbol curToken)
+        public virtual bool UnrecoveredSyntaxError(lr_parser parser, StackList<Symbol> stack, Symbol curToken)
         {
             return true;
         }
@@ -165,7 +166,7 @@ namespace TypeCobol.Compiler.CupCommon
         /// <param name="parser">The parser</param>
         /// <param name="curToken">The Symbol</param>
         /// <returns>The array of expected symbols</returns>
-        protected internal static List<string> ExpectedSymbols(lr_parser parser, Stack stack, Symbol curToken)
+        protected internal static List<string> ExpectedSymbols(lr_parser parser, StackList<Symbol> stack, Symbol curToken)
         {
             var actionTab = parser.action_table();
             int state = ((Symbol)stack.Peek()).parse_state;

--- a/TypeCobol/Compiler/CupCommon/ICupParserErrorReporter.cs
+++ b/TypeCobol/Compiler/CupCommon/ICupParserErrorReporter.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using CSCupRuntime;
+using TUVienna.CS_CUP.Runtime;
 
 namespace TypeCobol.Compiler.CupCommon
 {
@@ -24,7 +26,7 @@ namespace TypeCobol.Compiler.CupCommon
         /// if false is returned then a very simple implementation 
         /// is provided which reports the error then throws an exception. 
         /// </returns>
-        bool ReportFatalError(TUVienna.CS_CUP.Runtime.lr_parser parser, Stack stack, string message, object info);
+        bool ReportFatalError(TUVienna.CS_CUP.Runtime.lr_parser parser, StackList<Symbol> stack, string message, object info);
 
         /// <summary>
         /// Report a non fatal error (or warning).  This method takes a message 
@@ -39,7 +41,7 @@ namespace TypeCobol.Compiler.CupCommon
         /// if false is returned then a very simple 
         /// implementation is provided which simply prints the message to System.err. 
         /// </returns>
-        bool ReportError(TUVienna.CS_CUP.Runtime.lr_parser parser, Stack stack, string message, object info);
+        bool ReportError(TUVienna.CS_CUP.Runtime.lr_parser parser, StackList<Symbol> stack, string message, object info);
 
         /// <summary>
         /// This method is called when a syntax error has been detected and recovery 
@@ -52,7 +54,7 @@ namespace TypeCobol.Compiler.CupCommon
         /// <returns>true if the error has been handle, false otherwise.
         /// if false is returned then we just emit a "Syntax error" error message.  
         /// </returns>
-        bool SyntaxError(TUVienna.CS_CUP.Runtime.lr_parser parser, Stack stack, TUVienna.CS_CUP.Runtime.Symbol curToken);
+        bool SyntaxError(TUVienna.CS_CUP.Runtime.lr_parser parser, StackList<Symbol> stack, TUVienna.CS_CUP.Runtime.Symbol curToken);
 
         /// <summary>
         /// This method is called if it is determined that syntax error recovery 
@@ -64,6 +66,6 @@ namespace TypeCobol.Compiler.CupCommon
         /// <returns>true if the error has been handle, false otherwise.
         /// if false is returned then we report a fatal error.   
         /// </returns>
-        bool UnrecoveredSyntaxError(TUVienna.CS_CUP.Runtime.lr_parser parser, Stack stack, TUVienna.CS_CUP.Runtime.Symbol curToken);
+        bool UnrecoveredSyntaxError(TUVienna.CS_CUP.Runtime.lr_parser parser, StackList<Symbol> stack, TUVienna.CS_CUP.Runtime.Symbol curToken);
     }
 }

--- a/TypeCobol/Compiler/CupParser/NodeBuilder/CupParserTypeCobolProgramDiagnosticErrorReporter.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/CupParserTypeCobolProgramDiagnosticErrorReporter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using CSCupRuntime;
 using TUVienna.CS_CUP.Runtime;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.Diagnostics;
@@ -78,7 +79,7 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
             if (curToken.value != null)
                 return curToken;
             //lookback in the stack to find a Symbol having a valid value.
-            System.Collections.Stack stack = ((TypeCobolProgramParser)parser).getParserStack();
+            StackList<Symbol> stack = ((TypeCobolProgramParser)parser).getParserStack();
             Symbol lastValid = null;
             foreach (Symbol s in stack)
             {
@@ -104,14 +105,12 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
             CupParserDiagnostic diagnostic = new CupParserDiagnostic(msg, validSymbol, null);
             AddDiagnostic(diagnostic);
             //Try to add the last encountered statement in the stack if it is not already entered. 
-            System.Collections.Stack stack = tcpParser.getParserStack();
-            object[] items = stack.ToArray();
-            foreach (var item in items)
+            StackList<Symbol> stack = tcpParser.getParserStack();
+            foreach (var symbol in stack)
             {
-                Symbol symbol = item as Symbol;
                 if (symbol.value is StatementElement)
                 {
-                    lr_parser stmtParser = CloneParser(parser, (int)TypeCobolProgramSymbols.StatementEntryPoint,
+                    lr_parser stmtParser = CloneParser(parser, TypeCobolProgramSymbols.StatementEntryPoint,
                         symbol.value as CodeElement, true);
                     stmtParser.parse();
                     break;

--- a/TypeCobol/Compiler/CupParser/TypeCobolProgram.cup
+++ b/TypeCobol/Compiler/CupParser/TypeCobolProgram.cup
@@ -4,7 +4,6 @@ namespace TypeCobol.Compiler.CupParser;
 
 using TUVienna.CS_CUP.Runtime;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.CupParser.NodeBuilder;
@@ -40,11 +39,11 @@ parser code {:
   // get the current state of the parser.
   public int getParserState() 
   {
-	return ((Symbol)stack.Peek()).parse_state;	
+	return stack.Peek().parse_state;	
   }
 
   //get the parser stack.
-  public Stack getParserStack() 
+  public StackList<Symbol> getParserStack() 
   {
 	return stack;	
   }

--- a/TypeCobol/Compiler/CupParser/TypeCobolProgramParser.cs
+++ b/TypeCobol/Compiler/CupParser/TypeCobolProgramParser.cs
@@ -9,9 +9,9 @@ namespace TypeCobol.Compiler.CupParser
 using TypeCobol.Compiler.CupParser.NodeBuilder;
 using TypeCobol.Compiler.CodeElements;
 using System.Collections.Generic;
-using System.Collections;
 using System;
 using TUVienna.CS_CUP.Runtime;
+using CSCupRuntime;
 
 /** C# CUP v0.1 generated parser.
   */
@@ -1383,10 +1383,9 @@ new short[457][] {
   public override TUVienna.CS_CUP.Runtime.Symbol do_action(
     int                        act_num,
     TUVienna.CS_CUP.Runtime.lr_parser parser,
-    System.Collections.Stack            xstack1,
+    StackList<Symbol>            CUP_parser_stack,
     int                        top)
   {
-  mStack CUP_parser_stack= new mStack(xstack1);
     /* call code in generated class */
     return action_obj.CUP_TypeCobolProgramParser_do_action(act_num, parser, stack, top);
   }
@@ -1427,11 +1426,11 @@ new short[457][] {
   // get the current state of the parser.
   public int getParserState() 
   {
-	return ((Symbol)stack.Peek()).parse_state;	
+	return stack.Peek().parse_state;	
   }
 
   //get the parser stack.
-  public Stack getParserStack() 
+  public StackList<Symbol> getParserStack() 
   {
 	return stack;	
   }
@@ -1504,11 +1503,11 @@ public class CUP_TypeCobolProgramParser_actions {
   public   TUVienna.CS_CUP.Runtime.Symbol CUP_TypeCobolProgramParser_do_action(
     int                        CUP_TypeCobolProgramParser_act_num,
     TUVienna.CS_CUP.Runtime.lr_parser CUP_TypeCobolProgramParser_parser,
-    System.Collections.Stack            xstack1,
+    StackList<Symbol>            xstack1,
     int                        CUP_TypeCobolProgramParser_top)
     {
       /* Symbol object for return from actions */
-      mStack CUP_TypeCobolProgramParser_stack =new mStack(xstack1);
+      StackList<Symbol> CUP_TypeCobolProgramParser_stack =  xstack1;
       TUVienna.CS_CUP.Runtime.Symbol CUP_TypeCobolProgramParser_result;
 
       /* select the action based on the action number */
@@ -1554,7 +1553,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 404: // notOnSizeErrorCondition ::= NotOnSizeErrorCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.NotOnSizeErrorCondition cond = (TypeCobol.Compiler.CodeElements.NotOnSizeErrorCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.NotOnSizeErrorCondition cond = (TypeCobol.Compiler.CodeElements.NotOnSizeErrorCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartNoSizeError(cond); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(169/*notOnSizeErrorCondition*/, RESULT);
             }
@@ -1573,7 +1572,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 402: // onSizeErrorCondition ::= OnSizeErrorCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.OnSizeErrorCondition cond = (TypeCobol.Compiler.CodeElements.OnSizeErrorCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.OnSizeErrorCondition cond = (TypeCobol.Compiler.CodeElements.OnSizeErrorCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartOnSizeError(cond); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(168/*onSizeErrorCondition*/, RESULT);
             }
@@ -1628,7 +1627,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 396: // notOnOverflowCondition ::= NotOnOverflowCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.NotOnOverflowCondition cond = (TypeCobol.Compiler.CodeElements.NotOnOverflowCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.NotOnOverflowCondition cond = (TypeCobol.Compiler.CodeElements.NotOnOverflowCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartNoOverflow(cond); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(167/*notOnOverflowCondition*/, RESULT);
             }
@@ -1647,7 +1646,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 394: // onOverflowCondition ::= OnOverflowCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.OnOverflowCondition cond = (TypeCobol.Compiler.CodeElements.OnOverflowCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.OnOverflowCondition cond = (TypeCobol.Compiler.CodeElements.OnOverflowCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartOnOverflow(cond); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(166/*onOverflowCondition*/, RESULT);
             }
@@ -1702,7 +1701,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 388: // notInvalidKeyCondition ::= NotInvalidKeyCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.NotInvalidKeyCondition cond = (TypeCobol.Compiler.CodeElements.NotInvalidKeyCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.NotInvalidKeyCondition cond = (TypeCobol.Compiler.CodeElements.NotInvalidKeyCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartNoInvalidKey(cond); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(165/*notInvalidKeyCondition*/, RESULT);
             }
@@ -1721,7 +1720,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 386: // invalidKeyCondition ::= InvalidKeyCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.InvalidKeyCondition cond = (TypeCobol.Compiler.CodeElements.InvalidKeyCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.InvalidKeyCondition cond = (TypeCobol.Compiler.CodeElements.InvalidKeyCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartOnInvalidKey(cond); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(164/*invalidKeyCondition*/, RESULT);
             }
@@ -1776,7 +1775,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 380: // notOnExceptionCondition ::= NotOnExceptionCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.NotOnExceptionCondition cond = (TypeCobol.Compiler.CodeElements.NotOnExceptionCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.NotOnExceptionCondition cond = (TypeCobol.Compiler.CodeElements.NotOnExceptionCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartNoException(cond); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(163/*notOnExceptionCondition*/, RESULT);
             }
@@ -1795,7 +1794,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 378: // onExceptionCondition ::= OnExceptionCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.OnExceptionCondition cond = (TypeCobol.Compiler.CodeElements.OnExceptionCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.OnExceptionCondition cond = (TypeCobol.Compiler.CodeElements.OnExceptionCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartOnException(cond); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(162/*onExceptionCondition*/, RESULT);
             }
@@ -1850,7 +1849,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 372: // notAtEndCondition ::= NotAtEndCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.NotAtEndCondition cond = (TypeCobol.Compiler.CodeElements.NotAtEndCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.NotAtEndCondition cond = (TypeCobol.Compiler.CodeElements.NotAtEndCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartNoAtEnd(cond); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(161/*notAtEndCondition*/, RESULT);
             }
@@ -1869,7 +1868,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 370: // atEndCondition ::= AtEndCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.AtEndCondition cond = (TypeCobol.Compiler.CodeElements.AtEndCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.AtEndCondition cond = (TypeCobol.Compiler.CodeElements.AtEndCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartOnAtEnd(cond); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(160/*atEndCondition*/, RESULT);
             }
@@ -1888,7 +1887,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 368: // xmlParseStatement ::= XmlParseStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.XmlParseStatement stmt = (TypeCobol.Compiler.CodeElements.XmlParseStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.XmlParseStatement stmt = (TypeCobol.Compiler.CodeElements.XmlParseStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartXmlParseStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(159/*xmlParseStatement*/, RESULT);
             }
@@ -1898,7 +1897,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 367: // xmlParseStatementConditional ::= xmlParseStatement exceptionConditions XmlStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.XmlStatementEnd end = (TypeCobol.Compiler.CodeElements.XmlStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.XmlStatementEnd end = (TypeCobol.Compiler.CodeElements.XmlStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndXmlParseStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(129/*xmlParseStatementConditional*/, RESULT);
             }
@@ -1917,7 +1916,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 365: // xmlParseStatementConditional ::= xmlParseStatement XmlStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.XmlStatementEnd end = (TypeCobol.Compiler.CodeElements.XmlStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.XmlStatementEnd end = (TypeCobol.Compiler.CodeElements.XmlStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndXmlParseStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(129/*xmlParseStatementConditional*/, RESULT);
             }
@@ -1936,7 +1935,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 363: // xmlGenerateStatement ::= XmlGenerateStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.XmlGenerateStatement stmt = (TypeCobol.Compiler.CodeElements.XmlGenerateStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.XmlGenerateStatement stmt = (TypeCobol.Compiler.CodeElements.XmlGenerateStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartXmlGenerateStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(158/*xmlGenerateStatement*/, RESULT);
             }
@@ -1946,7 +1945,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 362: // xmlGenerateStatementConditional ::= xmlGenerateStatement exceptionConditions XmlStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.XmlStatementEnd end = (TypeCobol.Compiler.CodeElements.XmlStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.XmlStatementEnd end = (TypeCobol.Compiler.CodeElements.XmlStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndXmlGenerateStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(128/*xmlGenerateStatementConditional*/, RESULT);
             }
@@ -1965,7 +1964,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 360: // xmlGenerateStatementConditional ::= xmlGenerateStatement XmlStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.XmlStatementEnd end = (TypeCobol.Compiler.CodeElements.XmlStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.XmlStatementEnd end = (TypeCobol.Compiler.CodeElements.XmlStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndXmlGenerateStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(128/*xmlGenerateStatementConditional*/, RESULT);
             }
@@ -1984,7 +1983,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 358: // writeStatement ::= WriteStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.WriteStatement stmt = (TypeCobol.Compiler.CodeElements.WriteStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.WriteStatement stmt = (TypeCobol.Compiler.CodeElements.WriteStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartWriteStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(157/*writeStatement*/, RESULT);
             }
@@ -1994,7 +1993,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 357: // writeStatementConditional ::= writeStatement rwStatementConditions WriteStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.WriteStatementEnd end = (TypeCobol.Compiler.CodeElements.WriteStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.WriteStatementEnd end = (TypeCobol.Compiler.CodeElements.WriteStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndWriteStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(127/*writeStatementConditional*/, RESULT);
             }
@@ -2013,7 +2012,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 355: // writeStatementConditional ::= writeStatement WriteStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.WriteStatementEnd end = (TypeCobol.Compiler.CodeElements.WriteStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.WriteStatementEnd end = (TypeCobol.Compiler.CodeElements.WriteStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndWriteStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(127/*writeStatementConditional*/, RESULT);
             }
@@ -2032,7 +2031,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 353: // unstringStatement ::= UnstringStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.UnstringStatement stmt = (TypeCobol.Compiler.CodeElements.UnstringStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.UnstringStatement stmt = (TypeCobol.Compiler.CodeElements.UnstringStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartUnstringStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(156/*unstringStatement*/, RESULT);
             }
@@ -2042,7 +2041,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 352: // unstringStatementConditional ::= unstringStatement overflowConditions UnstringStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.UnstringStatementEnd end = (TypeCobol.Compiler.CodeElements.UnstringStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.UnstringStatementEnd end = (TypeCobol.Compiler.CodeElements.UnstringStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndUnstringStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(125/*unstringStatementConditional*/, RESULT);
             }
@@ -2061,7 +2060,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 350: // unstringStatementConditional ::= unstringStatement UnstringStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.UnstringStatementEnd end = (TypeCobol.Compiler.CodeElements.UnstringStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.UnstringStatementEnd end = (TypeCobol.Compiler.CodeElements.UnstringStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndUnstringStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(125/*unstringStatementConditional*/, RESULT);
             }
@@ -2080,7 +2079,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 348: // subtractStatement ::= SubtractStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SubtractStatement stmt = (TypeCobol.Compiler.CodeElements.SubtractStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SubtractStatement stmt = (TypeCobol.Compiler.CodeElements.SubtractStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartSubtractStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(155/*subtractStatement*/, RESULT);
             }
@@ -2090,7 +2089,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 347: // subtractStatementConditional ::= subtractStatement sizeErrorConditions SubtractStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SubtractStatementEnd end = (TypeCobol.Compiler.CodeElements.SubtractStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SubtractStatementEnd end = (TypeCobol.Compiler.CodeElements.SubtractStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndSubtractStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(124/*subtractStatementConditional*/, RESULT);
             }
@@ -2109,7 +2108,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 345: // subtractStatementConditional ::= subtractStatement SubtractStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SubtractStatementEnd end = (TypeCobol.Compiler.CodeElements.SubtractStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SubtractStatementEnd end = (TypeCobol.Compiler.CodeElements.SubtractStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndSubtractStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(124/*subtractStatementConditional*/, RESULT);
             }
@@ -2128,7 +2127,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 343: // stringStatement ::= StringStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.StringStatement stmt = (TypeCobol.Compiler.CodeElements.StringStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.StringStatement stmt = (TypeCobol.Compiler.CodeElements.StringStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartStringStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(154/*stringStatement*/, RESULT);
             }
@@ -2138,7 +2137,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 342: // stringStatementConditional ::= stringStatement overflowConditions StringStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.StringStatementEnd end = (TypeCobol.Compiler.CodeElements.StringStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.StringStatementEnd end = (TypeCobol.Compiler.CodeElements.StringStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndStringStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(123/*stringStatementConditional*/, RESULT);
             }
@@ -2157,7 +2156,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 340: // stringStatementConditional ::= stringStatement StringStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.StringStatementEnd end = (TypeCobol.Compiler.CodeElements.StringStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.StringStatementEnd end = (TypeCobol.Compiler.CodeElements.StringStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndStringStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(123/*stringStatementConditional*/, RESULT);
             }
@@ -2176,7 +2175,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 338: // startStatement ::= StartStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.StartStatement stmt = (TypeCobol.Compiler.CodeElements.StartStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.StartStatement stmt = (TypeCobol.Compiler.CodeElements.StartStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartStartStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(153/*startStatement*/, RESULT);
             }
@@ -2186,7 +2185,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 337: // startStatementConditional ::= startStatement keyConditions StartStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.StartStatementEnd end = (TypeCobol.Compiler.CodeElements.StartStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.StartStatementEnd end = (TypeCobol.Compiler.CodeElements.StartStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndStartStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(122/*startStatementConditional*/, RESULT);
             }
@@ -2205,7 +2204,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 335: // startStatementConditional ::= startStatement StartStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.StartStatementEnd end = (TypeCobol.Compiler.CodeElements.StartStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.StartStatementEnd end = (TypeCobol.Compiler.CodeElements.StartStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndStartStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(122/*startStatementConditional*/, RESULT);
             }
@@ -2242,7 +2241,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 331: // whenSearchCondition ::= WhenSearchCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.WhenSearchCondition wsc = (TypeCobol.Compiler.CodeElements.WhenSearchCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.WhenSearchCondition wsc = (TypeCobol.Compiler.CodeElements.WhenSearchCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartWhenSearchConditionClause(wsc); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(150/*whenSearchCondition*/, RESULT);
             }
@@ -2270,7 +2269,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 328: // searchStatement ::= SearchStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SearchStatement stmt = (TypeCobol.Compiler.CodeElements.SearchStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SearchStatement stmt = (TypeCobol.Compiler.CodeElements.SearchStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartSearchStatementWithBody(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(149/*searchStatement*/, RESULT);
             }
@@ -2280,7 +2279,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 327: // searchStatementWithBody ::= searchStatement onAtEnd whenSearchConditionClauses SearchStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SearchStatementEnd end = (TypeCobol.Compiler.CodeElements.SearchStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SearchStatementEnd end = (TypeCobol.Compiler.CodeElements.SearchStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndSearchStatementWithBody(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(126/*searchStatementWithBody*/, RESULT);
             }
@@ -2290,7 +2289,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 326: // searchStatementWithBody ::= searchStatement onAtEnd whenSearchConditionClauses 
             {
               object RESULT = null;
-		object wsccs = (object)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		object wsccs = (object)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndSearchStatementWithBody(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(126/*searchStatementWithBody*/, RESULT);
             }
@@ -2300,7 +2299,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 325: // searchStatementWithBody ::= searchStatement whenSearchConditionClauses SearchStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SearchStatementEnd end = (TypeCobol.Compiler.CodeElements.SearchStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SearchStatementEnd end = (TypeCobol.Compiler.CodeElements.SearchStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndSearchStatementWithBody(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(126/*searchStatementWithBody*/, RESULT);
             }
@@ -2319,7 +2318,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 323: // rewriteStatement ::= RewriteStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.RewriteStatement stmt = (TypeCobol.Compiler.CodeElements.RewriteStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.RewriteStatement stmt = (TypeCobol.Compiler.CodeElements.RewriteStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartRewriteStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(148/*rewriteStatement*/, RESULT);
             }
@@ -2329,7 +2328,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 322: // rewriteStatementConditional ::= rewriteStatement keyConditions RewriteStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.RewriteStatementEnd end = (TypeCobol.Compiler.CodeElements.RewriteStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.RewriteStatementEnd end = (TypeCobol.Compiler.CodeElements.RewriteStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndRewriteStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(121/*rewriteStatementConditional*/, RESULT);
             }
@@ -2348,7 +2347,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 320: // rewriteStatementConditional ::= rewriteStatement RewriteStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.RewriteStatementEnd end = (TypeCobol.Compiler.CodeElements.RewriteStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.RewriteStatementEnd end = (TypeCobol.Compiler.CodeElements.RewriteStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndRewriteStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(121/*rewriteStatementConditional*/, RESULT);
             }
@@ -2367,7 +2366,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 318: // returnStatement ::= ReturnStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ReturnStatement stmt = (TypeCobol.Compiler.CodeElements.ReturnStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ReturnStatement stmt = (TypeCobol.Compiler.CodeElements.ReturnStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EnterReturnStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(147/*returnStatement*/, RESULT);
             }
@@ -2377,7 +2376,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 317: // returnStatementConditional ::= returnStatement endConditions ReturnStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ReturnStatementEnd end = (TypeCobol.Compiler.CodeElements.ReturnStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ReturnStatementEnd end = (TypeCobol.Compiler.CodeElements.ReturnStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndReturnStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(120/*returnStatementConditional*/, RESULT);
             }
@@ -2396,7 +2395,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 315: // returnStatementConditional ::= returnStatement ReturnStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ReturnStatementEnd end = (TypeCobol.Compiler.CodeElements.ReturnStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ReturnStatementEnd end = (TypeCobol.Compiler.CodeElements.ReturnStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndReturnStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(120/*returnStatementConditional*/, RESULT);
             }
@@ -2469,7 +2468,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 307: // readStatement ::= ReadStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ReadStatement stmt = (TypeCobol.Compiler.CodeElements.ReadStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ReadStatement stmt = (TypeCobol.Compiler.CodeElements.ReadStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EnterReadStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(146/*readStatement*/, RESULT);
             }
@@ -2479,7 +2478,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 306: // readStatementConditional ::= readStatement rwStatementConditions ReadStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ReadStatementEnd end = (TypeCobol.Compiler.CodeElements.ReadStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ReadStatementEnd end = (TypeCobol.Compiler.CodeElements.ReadStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndReadStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(117/*readStatementConditional*/, RESULT);
             }
@@ -2498,7 +2497,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 304: // readStatementConditional ::= readStatement ReadStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ReadStatementEnd end = (TypeCobol.Compiler.CodeElements.ReadStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ReadStatementEnd end = (TypeCobol.Compiler.CodeElements.ReadStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndReadStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(117/*readStatementConditional*/, RESULT);
             }
@@ -2517,7 +2516,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 302: // performStatement ::= PerformStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.PerformStatement stmt = (TypeCobol.Compiler.CodeElements.PerformStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.PerformStatement stmt = (TypeCobol.Compiler.CodeElements.PerformStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartPerformStatementWithBody(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(145/*performStatement*/, RESULT);
             }
@@ -2527,7 +2526,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 301: // performStatementWithBody ::= performStatement statements PerformStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.PerformStatementEnd end = (TypeCobol.Compiler.CodeElements.PerformStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.PerformStatementEnd end = (TypeCobol.Compiler.CodeElements.PerformStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndPerformStatementWithBody(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(116/*performStatementWithBody*/, RESULT);
             }
@@ -2546,7 +2545,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 299: // performStatementWithBody ::= performStatement PerformStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.PerformStatementEnd end = (TypeCobol.Compiler.CodeElements.PerformStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.PerformStatementEnd end = (TypeCobol.Compiler.CodeElements.PerformStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndPerformStatementWithBody(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(116/*performStatementWithBody*/, RESULT);
             }
@@ -2565,7 +2564,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 297: // multiplyStatement ::= MultiplyStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.MultiplyStatement stmt = (TypeCobol.Compiler.CodeElements.MultiplyStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.MultiplyStatement stmt = (TypeCobol.Compiler.CodeElements.MultiplyStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartMultiplyStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(144/*multiplyStatement*/, RESULT);
             }
@@ -2575,7 +2574,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 296: // multiplyStatementConditional ::= multiplyStatement sizeErrorConditions MultiplyStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.MultiplyStatementEnd end = (TypeCobol.Compiler.CodeElements.MultiplyStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.MultiplyStatementEnd end = (TypeCobol.Compiler.CodeElements.MultiplyStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndMultiplyStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(115/*multiplyStatementConditional*/, RESULT);
             }
@@ -2594,7 +2593,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 294: // multiplyStatementConditional ::= multiplyStatement MultiplyStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.MultiplyStatementEnd end = (TypeCobol.Compiler.CodeElements.MultiplyStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.MultiplyStatementEnd end = (TypeCobol.Compiler.CodeElements.MultiplyStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndMultiplyStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(115/*multiplyStatementConditional*/, RESULT);
             }
@@ -2613,7 +2612,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 292: // invokeStatement ::= InvokeStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.InvokeStatement stmt = (TypeCobol.Compiler.CodeElements.InvokeStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.InvokeStatement stmt = (TypeCobol.Compiler.CodeElements.InvokeStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartInvokeStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(143/*invokeStatement*/, RESULT);
             }
@@ -2623,7 +2622,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 291: // invokeStatementConditional ::= invokeStatement exceptionConditions InvokeStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.InvokeStatementEnd end = (TypeCobol.Compiler.CodeElements.InvokeStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.InvokeStatementEnd end = (TypeCobol.Compiler.CodeElements.InvokeStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndInvokeStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(114/*invokeStatementConditional*/, RESULT);
             }
@@ -2642,7 +2641,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 289: // invokeStatementConditional ::= invokeStatement InvokeStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.InvokeStatementEnd end = (TypeCobol.Compiler.CodeElements.InvokeStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.InvokeStatementEnd end = (TypeCobol.Compiler.CodeElements.InvokeStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndInvokeStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(114/*invokeStatementConditional*/, RESULT);
             }
@@ -2661,7 +2660,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 287: // nextSentenceStatement ::= NextSentenceStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.NextSentenceStatement next = (TypeCobol.Compiler.CodeElements.NextSentenceStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.NextSentenceStatement next = (TypeCobol.Compiler.CodeElements.NextSentenceStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.AddNextSentenceStatement(next); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(136/*nextSentenceStatement*/, RESULT);
             }
@@ -2671,7 +2670,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 286: // elseCondition ::= ElseCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ElseCondition ec = (TypeCobol.Compiler.CodeElements.ElseCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ElseCondition ec = (TypeCobol.Compiler.CodeElements.ElseCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EnterElseClause(ec); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(135/*elseCondition*/, RESULT);
             }
@@ -2681,7 +2680,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 285: // ifstatement ::= IfStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.IfStatement ifs = (TypeCobol.Compiler.CodeElements.IfStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.IfStatement ifs = (TypeCobol.Compiler.CodeElements.IfStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartIfStatementWithBody(ifs); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(134/*ifstatement*/, RESULT);
             }
@@ -2691,7 +2690,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 284: // ifStatementWithBody ::= ifstatement nextSentenceStatement elseCondition nextSentenceStatement IfStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.IfStatementEnd end = (TypeCobol.Compiler.CodeElements.IfStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.IfStatementEnd end = (TypeCobol.Compiler.CodeElements.IfStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndIfStatementWithBody(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(113/*ifStatementWithBody*/, RESULT);
             }
@@ -2701,7 +2700,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 283: // ifStatementWithBody ::= ifstatement nextSentenceStatement elseCondition statements IfStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.IfStatementEnd end = (TypeCobol.Compiler.CodeElements.IfStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.IfStatementEnd end = (TypeCobol.Compiler.CodeElements.IfStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndIfStatementWithBody(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(113/*ifStatementWithBody*/, RESULT);
             }
@@ -2729,7 +2728,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 280: // ifStatementWithBody ::= ifstatement statements elseCondition nextSentenceStatement IfStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.IfStatementEnd end = (TypeCobol.Compiler.CodeElements.IfStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.IfStatementEnd end = (TypeCobol.Compiler.CodeElements.IfStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndIfStatementWithBody(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(113/*ifStatementWithBody*/, RESULT);
             }
@@ -2739,7 +2738,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 279: // ifStatementWithBody ::= ifstatement statements elseCondition statements IfStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.IfStatementEnd end = (TypeCobol.Compiler.CodeElements.IfStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.IfStatementEnd end = (TypeCobol.Compiler.CodeElements.IfStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndIfStatementWithBody(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(113/*ifStatementWithBody*/, RESULT);
             }
@@ -2767,7 +2766,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 276: // ifStatementWithBody ::= ifstatement nextSentenceStatement IfStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.IfStatementEnd end = (TypeCobol.Compiler.CodeElements.IfStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.IfStatementEnd end = (TypeCobol.Compiler.CodeElements.IfStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndIfStatementWithBody(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(113/*ifStatementWithBody*/, RESULT);
             }
@@ -2786,7 +2785,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 274: // ifStatementWithBody ::= ifstatement statements IfStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.IfStatementEnd end = (TypeCobol.Compiler.CodeElements.IfStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.IfStatementEnd end = (TypeCobol.Compiler.CodeElements.IfStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndIfStatementWithBody(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(113/*ifStatementWithBody*/, RESULT);
             }
@@ -2805,7 +2804,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 272: // whenOtherCondition ::= WhenOtherCondition 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.WhenOtherCondition woc = (TypeCobol.Compiler.CodeElements.WhenOtherCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.WhenOtherCondition woc = (TypeCobol.Compiler.CodeElements.WhenOtherCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartWhenOtherClause(woc); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(152/*whenOtherCondition*/, RESULT);
             }
@@ -2815,7 +2814,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 271: // whenOtherClause ::= whenOtherCondition statements 
             {
               object RESULT = null;
-		object woc = (object)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
+		object woc = (object)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
 		 my_parser.Builder.EndWhenOtherClause(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(108/*whenOtherClause*/, RESULT);
             }
@@ -2825,7 +2824,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 270: // whenEvaluateConditionsStart ::= whenEvaluateConditions 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CupParser.NodeBuilder.CodeElementList wecs = (TypeCobol.Compiler.CupParser.NodeBuilder.CodeElementList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CupParser.NodeBuilder.CodeElementList wecs = (TypeCobol.Compiler.CupParser.NodeBuilder.CodeElementList)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartWhenConditionClause(wecs); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(151/*whenEvaluateConditionsStart*/, RESULT);
             }
@@ -2835,8 +2834,8 @@ public class CUP_TypeCobolProgramParser_actions {
           case 269: // whenEvaluateConditions ::= whenEvaluateConditions whenEvaluateCondition 
             {
               TypeCobol.Compiler.CupParser.NodeBuilder.CodeElementList RESULT = null;
-		TypeCobol.Compiler.CupParser.NodeBuilder.CodeElementList wecs = (TypeCobol.Compiler.CupParser.NodeBuilder.CodeElementList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.CodeElement wec = (TypeCobol.Compiler.CodeElements.CodeElement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CupParser.NodeBuilder.CodeElementList wecs = (TypeCobol.Compiler.CupParser.NodeBuilder.CodeElementList)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.CodeElement wec = (TypeCobol.Compiler.CodeElements.CodeElement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 wecs.Add(wec); RESULT = wecs; 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(111/*whenEvaluateConditions*/, RESULT);
             }
@@ -2846,7 +2845,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 268: // whenEvaluateConditions ::= whenEvaluateCondition 
             {
               TypeCobol.Compiler.CupParser.NodeBuilder.CodeElementList RESULT = null;
-		TypeCobol.Compiler.CodeElements.CodeElement wec = (TypeCobol.Compiler.CodeElements.CodeElement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.CodeElement wec = (TypeCobol.Compiler.CodeElements.CodeElement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 RESULT = new CodeElementList(){wec}; 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(111/*whenEvaluateConditions*/, RESULT);
             }
@@ -2856,7 +2855,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 267: // whenEvaluateCondition ::= WhenCondition 
             {
               TypeCobol.Compiler.CodeElements.CodeElement RESULT = null;
-		TypeCobol.Compiler.CodeElements.WhenCondition wec = (TypeCobol.Compiler.CodeElements.WhenCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.WhenCondition wec = (TypeCobol.Compiler.CodeElements.WhenCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 RESULT = wec; 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(110/*whenEvaluateCondition*/, RESULT);
             }
@@ -2866,7 +2865,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 266: // whenEvaluateCondition ::= WhenSearchCondition 
             {
               TypeCobol.Compiler.CodeElements.CodeElement RESULT = null;
-		TypeCobol.Compiler.CodeElements.WhenSearchCondition wec = (TypeCobol.Compiler.CodeElements.WhenSearchCondition)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.WhenSearchCondition wec = (TypeCobol.Compiler.CodeElements.WhenSearchCondition)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 RESULT = wec; 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(110/*whenEvaluateCondition*/, RESULT);
             }
@@ -2921,7 +2920,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 260: // evaluateStatement ::= EvaluateStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.EvaluateStatement est = (TypeCobol.Compiler.CodeElements.EvaluateStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.EvaluateStatement est = (TypeCobol.Compiler.CodeElements.EvaluateStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartEvaluateStatementWithBody(est); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(142/*evaluateStatement*/, RESULT);
             }
@@ -2931,7 +2930,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 259: // evaluateStatementWithBody ::= evaluateStatement whenConditionClauses error whenOtherClause EvaluateStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.EvaluateStatementEnd ese = (TypeCobol.Compiler.CodeElements.EvaluateStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.EvaluateStatementEnd ese = (TypeCobol.Compiler.CodeElements.EvaluateStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndEvaluateStatementWithBody(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(112/*evaluateStatementWithBody*/, RESULT);
             }
@@ -2950,7 +2949,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 257: // evaluateStatementWithBody ::= evaluateStatement whenConditionClauses error EvaluateStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.EvaluateStatementEnd ese = (TypeCobol.Compiler.CodeElements.EvaluateStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.EvaluateStatementEnd ese = (TypeCobol.Compiler.CodeElements.EvaluateStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndEvaluateStatementWithBody(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(112/*evaluateStatementWithBody*/, RESULT);
             }
@@ -2960,7 +2959,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 256: // evaluateStatementWithBody ::= evaluateStatement whenConditionClauses whenOtherClause EvaluateStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.EvaluateStatementEnd ese = (TypeCobol.Compiler.CodeElements.EvaluateStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.EvaluateStatementEnd ese = (TypeCobol.Compiler.CodeElements.EvaluateStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndEvaluateStatementWithBody(ese); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(112/*evaluateStatementWithBody*/, RESULT);
             }
@@ -2979,7 +2978,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 254: // evaluateStatementWithBody ::= evaluateStatement whenOtherClause EvaluateStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.EvaluateStatementEnd ese = (TypeCobol.Compiler.CodeElements.EvaluateStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.EvaluateStatementEnd ese = (TypeCobol.Compiler.CodeElements.EvaluateStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndEvaluateStatementWithBody(ese); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(112/*evaluateStatementWithBody*/, RESULT);
             }
@@ -2998,7 +2997,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 252: // evaluateStatementWithBody ::= evaluateStatement whenConditionClauses EvaluateStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.EvaluateStatementEnd ese = (TypeCobol.Compiler.CodeElements.EvaluateStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.EvaluateStatementEnd ese = (TypeCobol.Compiler.CodeElements.EvaluateStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndEvaluateStatementWithBody(ese); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(112/*evaluateStatementWithBody*/, RESULT);
             }
@@ -3017,7 +3016,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 250: // evaluateStatementWithBody ::= evaluateStatement EvaluateStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.EvaluateStatementEnd ese = (TypeCobol.Compiler.CodeElements.EvaluateStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.EvaluateStatementEnd ese = (TypeCobol.Compiler.CodeElements.EvaluateStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndEvaluateStatementWithBody(ese); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(112/*evaluateStatementWithBody*/, RESULT);
             }
@@ -3036,7 +3035,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 248: // divideStatement ::= DivideStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.DivideStatement stmt = (TypeCobol.Compiler.CodeElements.DivideStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DivideStatement stmt = (TypeCobol.Compiler.CodeElements.DivideStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartDivideStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(141/*divideStatement*/, RESULT);
             }
@@ -3046,7 +3045,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 247: // divideStatementConditional ::= divideStatement sizeErrorConditions DivideStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.DivideStatementEnd end = (TypeCobol.Compiler.CodeElements.DivideStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DivideStatementEnd end = (TypeCobol.Compiler.CodeElements.DivideStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndDivideStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(104/*divideStatementConditional*/, RESULT);
             }
@@ -3065,7 +3064,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 245: // divideStatementConditional ::= divideStatement DivideStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.DivideStatementEnd end = (TypeCobol.Compiler.CodeElements.DivideStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DivideStatementEnd end = (TypeCobol.Compiler.CodeElements.DivideStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndDivideStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(104/*divideStatementConditional*/, RESULT);
             }
@@ -3084,7 +3083,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 243: // deleteStatement ::= DeleteStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.DeleteStatement stmt = (TypeCobol.Compiler.CodeElements.DeleteStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DeleteStatement stmt = (TypeCobol.Compiler.CodeElements.DeleteStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartDeleteStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(140/*deleteStatement*/, RESULT);
             }
@@ -3094,7 +3093,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 242: // deleteStatementConditional ::= deleteStatement keyConditions DeleteStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.DeleteStatementEnd end = (TypeCobol.Compiler.CodeElements.DeleteStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DeleteStatementEnd end = (TypeCobol.Compiler.CodeElements.DeleteStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndDeleteStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(103/*deleteStatementConditional*/, RESULT);
             }
@@ -3113,7 +3112,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 240: // deleteStatementConditional ::= deleteStatement DeleteStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.DeleteStatementEnd end = (TypeCobol.Compiler.CodeElements.DeleteStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DeleteStatementEnd end = (TypeCobol.Compiler.CodeElements.DeleteStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndDeleteStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(103/*deleteStatementConditional*/, RESULT);
             }
@@ -3132,7 +3131,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 238: // computeStatement ::= ComputeStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ComputeStatement stmt = (TypeCobol.Compiler.CodeElements.ComputeStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ComputeStatement stmt = (TypeCobol.Compiler.CodeElements.ComputeStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartComputeStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(139/*computeStatement*/, RESULT);
             }
@@ -3142,7 +3141,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 237: // computeStatementConditional ::= computeStatement sizeErrorConditions ComputeStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ComputeStatementEnd end = (TypeCobol.Compiler.CodeElements.ComputeStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ComputeStatementEnd end = (TypeCobol.Compiler.CodeElements.ComputeStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndComputeStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(102/*computeStatementConditional*/, RESULT);
             }
@@ -3161,7 +3160,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 235: // computeStatementConditional ::= computeStatement ComputeStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ComputeStatementEnd end = (TypeCobol.Compiler.CodeElements.ComputeStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ComputeStatementEnd end = (TypeCobol.Compiler.CodeElements.ComputeStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndComputeStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(102/*computeStatementConditional*/, RESULT);
             }
@@ -3207,7 +3206,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 230: // callStatement ::= CallStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.CallStatement stmt = (TypeCobol.Compiler.CodeElements.CallStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.CallStatement stmt = (TypeCobol.Compiler.CodeElements.CallStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartCallStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(138/*callStatement*/, RESULT);
             }
@@ -3217,7 +3216,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 229: // callStatementConditional ::= callStatement callStatementConditions CallStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.CallStatementEnd end = (TypeCobol.Compiler.CodeElements.CallStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.CallStatementEnd end = (TypeCobol.Compiler.CodeElements.CallStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		  my_parser.Builder.EndCallStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(101/*callStatementConditional*/, RESULT);
             }
@@ -3236,7 +3235,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 227: // callStatementConditional ::= callStatement CallStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.CallStatementEnd end = (TypeCobol.Compiler.CodeElements.CallStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.CallStatementEnd end = (TypeCobol.Compiler.CodeElements.CallStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndCallStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(101/*callStatementConditional*/, RESULT);
             }
@@ -3255,7 +3254,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 225: // addStatement ::= AddStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.AddStatement stmt = (TypeCobol.Compiler.CodeElements.AddStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.AddStatement stmt = (TypeCobol.Compiler.CodeElements.AddStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartAddStatementConditional(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(137/*addStatement*/, RESULT);
             }
@@ -3265,7 +3264,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 224: // addStatementConditional ::= addStatement sizeErrorConditions AddStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.AddStatementEnd end = (TypeCobol.Compiler.CodeElements.AddStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.AddStatementEnd end = (TypeCobol.Compiler.CodeElements.AddStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		  my_parser.Builder.EndAddStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(99/*addStatementConditional*/, RESULT);
             }
@@ -3284,7 +3283,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 222: // addStatementConditional ::= addStatement AddStatementEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.AddStatementEnd end = (TypeCobol.Compiler.CodeElements.AddStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.AddStatementEnd end = (TypeCobol.Compiler.CodeElements.AddStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndAddStatementConditional(end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(99/*addStatementConditional*/, RESULT);
             }
@@ -3492,7 +3491,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 199: // singleStatement ::= ExecStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.ExecStatement stmt = (TypeCobol.Compiler.CodeElements.ExecStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ExecStatement stmt = (TypeCobol.Compiler.CodeElements.ExecStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnExecStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3502,7 +3501,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 198: // singleStatement ::= CancelStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.CancelStatement stmt = (TypeCobol.Compiler.CodeElements.CancelStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.CancelStatement stmt = (TypeCobol.Compiler.CodeElements.CancelStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnCancelStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3512,8 +3511,8 @@ public class CUP_TypeCobolProgramParser_actions {
           case 197: // singleStatement ::= ProcedureStyleCall CallStatementEnd 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.ProcedureStyleCallStatement stmt = (TypeCobol.Compiler.CodeElements.ProcedureStyleCallStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.CallStatementEnd end = (TypeCobol.Compiler.CodeElements.CallStatementEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ProcedureStyleCallStatement stmt = (TypeCobol.Compiler.CodeElements.ProcedureStyleCallStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.CallStatementEnd end = (TypeCobol.Compiler.CodeElements.CallStatementEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnProcedureStyleCall(stmt, end); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3523,7 +3522,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 196: // singleStatement ::= ProcedureStyleCall 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.ProcedureStyleCallStatement stmt = (TypeCobol.Compiler.CodeElements.ProcedureStyleCallStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ProcedureStyleCallStatement stmt = (TypeCobol.Compiler.CodeElements.ProcedureStyleCallStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnProcedureStyleCall(stmt, null); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3533,7 +3532,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 195: // singleStatement ::= PerformProcedureStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.PerformProcedureStatement stmt = (TypeCobol.Compiler.CodeElements.PerformProcedureStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.PerformProcedureStatement stmt = (TypeCobol.Compiler.CodeElements.PerformProcedureStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnPerformProcedureStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3543,7 +3542,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 194: // singleStatement ::= GotoStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.GotoStatement stmt = (TypeCobol.Compiler.CodeElements.GotoStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.GotoStatement stmt = (TypeCobol.Compiler.CodeElements.GotoStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnGotoStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3553,7 +3552,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 193: // singleStatement ::= ExitStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.ExitStatement stmt = (TypeCobol.Compiler.CodeElements.ExitStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ExitStatement stmt = (TypeCobol.Compiler.CodeElements.ExitStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnExitStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3563,7 +3562,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 192: // singleStatement ::= AlterStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.AlterStatement stmt = (TypeCobol.Compiler.CodeElements.AlterStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.AlterStatement stmt = (TypeCobol.Compiler.CodeElements.AlterStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnAlterStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3573,7 +3572,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 191: // singleStatement ::= SortStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.SortStatement stmt = (TypeCobol.Compiler.CodeElements.SortStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SortStatement stmt = (TypeCobol.Compiler.CodeElements.SortStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnSortStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3583,7 +3582,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 190: // singleStatement ::= ReleaseStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.ReleaseStatement stmt = (TypeCobol.Compiler.CodeElements.ReleaseStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ReleaseStatement stmt = (TypeCobol.Compiler.CodeElements.ReleaseStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnReleaseStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3593,7 +3592,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 189: // singleStatement ::= MergeStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.MergeStatement stmt = (TypeCobol.Compiler.CodeElements.MergeStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.MergeStatement stmt = (TypeCobol.Compiler.CodeElements.MergeStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnMergeStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3603,7 +3602,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 188: // singleStatement ::= OpenStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.OpenStatement stmt = (TypeCobol.Compiler.CodeElements.OpenStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.OpenStatement stmt = (TypeCobol.Compiler.CodeElements.OpenStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnOpenStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3613,7 +3612,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 187: // singleStatement ::= DisplayStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.DisplayStatement stmt = (TypeCobol.Compiler.CodeElements.DisplayStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DisplayStatement stmt = (TypeCobol.Compiler.CodeElements.DisplayStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnDisplayStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3623,7 +3622,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 186: // singleStatement ::= CloseStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.CloseStatement stmt = (TypeCobol.Compiler.CodeElements.CloseStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.CloseStatement stmt = (TypeCobol.Compiler.CodeElements.CloseStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnCloseStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3633,7 +3632,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 185: // singleStatement ::= GobackStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.GobackStatement stmt = (TypeCobol.Compiler.CodeElements.GobackStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.GobackStatement stmt = (TypeCobol.Compiler.CodeElements.GobackStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnGobackStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3643,7 +3642,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 184: // singleStatement ::= ExitProgramStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.ExitProgramStatement stmt = (TypeCobol.Compiler.CodeElements.ExitProgramStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ExitProgramStatement stmt = (TypeCobol.Compiler.CodeElements.ExitProgramStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnExitProgramStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3653,7 +3652,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 183: // singleStatement ::= ExitMethodStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.ExitMethodStatement stmt = (TypeCobol.Compiler.CodeElements.ExitMethodStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ExitMethodStatement stmt = (TypeCobol.Compiler.CodeElements.ExitMethodStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnExitMethodStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3663,7 +3662,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 182: // singleStatement ::= StopStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.StopStatement stmt = (TypeCobol.Compiler.CodeElements.StopStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.StopStatement stmt = (TypeCobol.Compiler.CodeElements.StopStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnStopStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3673,7 +3672,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 181: // singleStatement ::= SetStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.SetStatement stmt = (TypeCobol.Compiler.CodeElements.SetStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SetStatement stmt = (TypeCobol.Compiler.CodeElements.SetStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnSetStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3683,7 +3682,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 180: // singleStatement ::= MoveStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.MoveStatement stmt = (TypeCobol.Compiler.CodeElements.MoveStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.MoveStatement stmt = (TypeCobol.Compiler.CodeElements.MoveStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnMoveStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3693,7 +3692,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 179: // singleStatement ::= InspectStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.InspectStatement stmt = (TypeCobol.Compiler.CodeElements.InspectStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.InspectStatement stmt = (TypeCobol.Compiler.CodeElements.InspectStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnInspectStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3703,7 +3702,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 178: // singleStatement ::= InitializeStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.InitializeStatement stmt = (TypeCobol.Compiler.CodeElements.InitializeStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.InitializeStatement stmt = (TypeCobol.Compiler.CodeElements.InitializeStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnInitializeStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3713,7 +3712,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 177: // singleStatement ::= AcceptStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.AcceptStatement stmt = (TypeCobol.Compiler.CodeElements.AcceptStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.AcceptStatement stmt = (TypeCobol.Compiler.CodeElements.AcceptStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnAcceptStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3723,7 +3722,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 176: // singleStatement ::= EntryStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.EntryStatement stmt = (TypeCobol.Compiler.CodeElements.EntryStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.EntryStatement stmt = (TypeCobol.Compiler.CodeElements.EntryStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnEntryStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3733,7 +3732,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 175: // singleStatement ::= ContinueStatement 
             {
               TypeCobol.Compiler.Nodes.Node RESULT = null;
-		TypeCobol.Compiler.CodeElements.ContinueStatement stmt = (TypeCobol.Compiler.CodeElements.ContinueStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ContinueStatement stmt = (TypeCobol.Compiler.CodeElements.ContinueStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.OnContinueStatement(stmt); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(64/*singleStatement*/, RESULT);
             }
@@ -3806,7 +3805,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 167: // sentence ::= error statements SentenceEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SentenceEnd send = (TypeCobol.Compiler.CodeElements.SentenceEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SentenceEnd send = (TypeCobol.Compiler.CodeElements.SentenceEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndSentence(send, true); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(67/*sentence*/, RESULT);
             }
@@ -3816,7 +3815,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 166: // sentence ::= error SentenceEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SentenceEnd send = (TypeCobol.Compiler.CodeElements.SentenceEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SentenceEnd send = (TypeCobol.Compiler.CodeElements.SentenceEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndSentence(send, true); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(67/*sentence*/, RESULT);
             }
@@ -3826,7 +3825,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 165: // sentence ::= ExecStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ExecStatement stmt = (TypeCobol.Compiler.CodeElements.ExecStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ExecStatement stmt = (TypeCobol.Compiler.CodeElements.ExecStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartExecStatement(stmt); my_parser.Builder.EndExecStatement(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(67/*sentence*/, RESULT);
             }
@@ -3836,7 +3835,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 164: // sentence ::= statements SentenceEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SentenceEnd send = (TypeCobol.Compiler.CodeElements.SentenceEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SentenceEnd send = (TypeCobol.Compiler.CodeElements.SentenceEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndSentence(send, true); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(67/*sentence*/, RESULT);
             }
@@ -3846,7 +3845,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 163: // sentence ::= SentenceEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SentenceEnd send = (TypeCobol.Compiler.CodeElements.SentenceEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SentenceEnd send = (TypeCobol.Compiler.CodeElements.SentenceEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartSentence(); my_parser.Builder.EndSentence(send); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(67/*sentence*/, RESULT);
             }
@@ -3919,7 +3918,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 155: // paragraphHeader ::= ParagraphHeader 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ParagraphHeader ph = (TypeCobol.Compiler.CodeElements.ParagraphHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ParagraphHeader ph = (TypeCobol.Compiler.CodeElements.ParagraphHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartParagraph(ph); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(133/*paragraphHeader*/, RESULT);
             }
@@ -3929,7 +3928,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 154: // sectionHeader ::= SectionHeader 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SectionHeader sh = (TypeCobol.Compiler.CodeElements.SectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SectionHeader sh = (TypeCobol.Compiler.CodeElements.SectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartSection(sh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(132/*sectionHeader*/, RESULT);
             }
@@ -3994,9 +3993,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$16
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.UseStatement us = (TypeCobol.Compiler.CodeElements.UseStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.UseStatement us = (TypeCobol.Compiler.CodeElements.UseStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
 		 my_parser.Builder.EndSection(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(75/*declarativesSection*/, RESULT);
             }
@@ -4006,7 +4005,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 146: // NT$16 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.UseStatement us = (TypeCobol.Compiler.CodeElements.UseStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.UseStatement us = (TypeCobol.Compiler.CodeElements.UseStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.EnterUseStatement(us); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(186/*NT$16*/, RESULT);
             }
@@ -4016,7 +4015,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 145: // declarativesSection ::= sectionHeader UseStatement 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.UseStatement us = (TypeCobol.Compiler.CodeElements.UseStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.UseStatement us = (TypeCobol.Compiler.CodeElements.UseStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EnterUseStatement(us);
 	  my_parser.Builder.EndSection(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(75/*declarativesSection*/, RESULT);
@@ -4046,10 +4045,10 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$15
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
-		TypeCobol.Compiler.CodeElements.DeclarativesHeader dh = (TypeCobol.Compiler.CodeElements.DeclarativesHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-3)).value;
-		TypeCobol.Compiler.CodeElements.DeclarativesEnd de = (TypeCobol.Compiler.CodeElements.DeclarativesEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
+		TypeCobol.Compiler.CodeElements.DeclarativesHeader dh = (TypeCobol.Compiler.CodeElements.DeclarativesHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-3)).value;
+		TypeCobol.Compiler.CodeElements.DeclarativesEnd de = (TypeCobol.Compiler.CodeElements.DeclarativesEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndDeclaratives(de); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(76/*declaratives*/, RESULT);
             }
@@ -4059,7 +4058,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 141: // NT$15 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.DeclarativesHeader dh = (TypeCobol.Compiler.CodeElements.DeclarativesHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DeclarativesHeader dh = (TypeCobol.Compiler.CodeElements.DeclarativesHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartDeclaratives(dh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(185/*NT$15*/, RESULT);
             }
@@ -4088,9 +4087,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$14
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.ProcedureDivisionHeader pdh = (TypeCobol.Compiler.CodeElements.ProcedureDivisionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.ProcedureDivisionHeader pdh = (TypeCobol.Compiler.CodeElements.ProcedureDivisionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(131/*functionProcedureDivisionHeader*/, RESULT);
             }
@@ -4100,7 +4099,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 137: // NT$14 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ProcedureDivisionHeader pdh = (TypeCobol.Compiler.CodeElements.ProcedureDivisionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ProcedureDivisionHeader pdh = (TypeCobol.Compiler.CodeElements.ProcedureDivisionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartFunctionProcedureDivision(pdh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(184/*NT$14*/, RESULT);
             }
@@ -4147,10 +4146,10 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$13
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-3)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-3)).value;
-		TypeCobol.Compiler.CodeElements.FunctionDeclarationHeader fdh = (TypeCobol.Compiler.CodeElements.FunctionDeclarationHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-4)).value;
-		TypeCobol.Compiler.CodeElements.FunctionDeclarationEnd fe = (TypeCobol.Compiler.CodeElements.FunctionDeclarationEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-3)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-3)).value;
+		TypeCobol.Compiler.CodeElements.FunctionDeclarationHeader fdh = (TypeCobol.Compiler.CodeElements.FunctionDeclarationHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-4)).value;
+		TypeCobol.Compiler.CodeElements.FunctionDeclarationEnd fe = (TypeCobol.Compiler.CodeElements.FunctionDeclarationEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndFunctionDeclaration(fe); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(78/*functionDeclaration*/, RESULT);
             }
@@ -4160,7 +4159,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 131: // NT$13 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.FunctionDeclarationHeader fdh = (TypeCobol.Compiler.CodeElements.FunctionDeclarationHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.FunctionDeclarationHeader fdh = (TypeCobol.Compiler.CodeElements.FunctionDeclarationHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartFunctionDeclaration(fdh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(183/*NT$13*/, RESULT);
             }
@@ -4206,7 +4205,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 126: // procedureDivisionHeader ::= ProcedureDivisionHeader 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ProcedureDivisionHeader pdh = (TypeCobol.Compiler.CodeElements.ProcedureDivisionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ProcedureDivisionHeader pdh = (TypeCobol.Compiler.CodeElements.ProcedureDivisionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartProcedureDivision(pdh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(130/*procedureDivisionHeader*/, RESULT);
             }
@@ -4244,9 +4243,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$12
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.LinkageSectionHeader lsh = (TypeCobol.Compiler.CodeElements.LinkageSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.LinkageSectionHeader lsh = (TypeCobol.Compiler.CodeElements.LinkageSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
 		 my_parser.Builder.EndLinkageSection(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(58/*linkageSection*/, RESULT);
             }
@@ -4256,7 +4255,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 121: // NT$12 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.LinkageSectionHeader lsh = (TypeCobol.Compiler.CodeElements.LinkageSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.LinkageSectionHeader lsh = (TypeCobol.Compiler.CodeElements.LinkageSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartLinkageSection(lsh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(182/*NT$12*/, RESULT);
             }
@@ -4275,7 +4274,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 119: // dataDefinitionEntry ::= DataConditionEntry 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.DataConditionEntry dce = (TypeCobol.Compiler.CodeElements.DataConditionEntry)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DataConditionEntry dce = (TypeCobol.Compiler.CodeElements.DataConditionEntry)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartDataConditionEntry(dce); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(45/*dataDefinitionEntry*/, RESULT);
             }
@@ -4285,7 +4284,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 118: // dataDefinitionEntry ::= DataRenamesEntry 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.DataRenamesEntry dre = (TypeCobol.Compiler.CodeElements.DataRenamesEntry)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DataRenamesEntry dre = (TypeCobol.Compiler.CodeElements.DataRenamesEntry)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartDataRenamesEntry(dre); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(45/*dataDefinitionEntry*/, RESULT);
             }
@@ -4295,7 +4294,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 117: // dataDefinitionEntry ::= DataRedefinesEntry 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.DataRedefinesEntry dre = (TypeCobol.Compiler.CodeElements.DataRedefinesEntry)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DataRedefinesEntry dre = (TypeCobol.Compiler.CodeElements.DataRedefinesEntry)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartDataRedefinesEntry(dre); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(45/*dataDefinitionEntry*/, RESULT);
             }
@@ -4305,7 +4304,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 116: // dataDefinitionEntry ::= DataDescriptionEntry 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.DataDescriptionEntry dde = (TypeCobol.Compiler.CodeElements.DataDescriptionEntry)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DataDescriptionEntry dde = (TypeCobol.Compiler.CodeElements.DataDescriptionEntry)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartDataDescriptionEntry(dde); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(45/*dataDefinitionEntry*/, RESULT);
             }
@@ -4352,9 +4351,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$11
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.LocalStorageSectionHeader lsh = (TypeCobol.Compiler.CodeElements.LocalStorageSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.LocalStorageSectionHeader lsh = (TypeCobol.Compiler.CodeElements.LocalStorageSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
 		 my_parser.Builder.EndLocalStorageSection(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(57/*localStorageSection*/, RESULT);
             }
@@ -4364,7 +4363,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 110: // NT$11 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.LocalStorageSectionHeader lsh = (TypeCobol.Compiler.CodeElements.LocalStorageSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.LocalStorageSectionHeader lsh = (TypeCobol.Compiler.CodeElements.LocalStorageSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartLocalStorageSection(lsh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(181/*NT$11*/, RESULT);
             }
@@ -4384,9 +4383,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$10
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.ExecStatement stmt = (TypeCobol.Compiler.CodeElements.ExecStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.ExecStatement stmt = (TypeCobol.Compiler.CodeElements.ExecStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
 		  
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(48/*execSqlStatement*/, RESULT);
             }
@@ -4396,7 +4395,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 107: // NT$10 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ExecStatement stmt = (TypeCobol.Compiler.CodeElements.ExecStatement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ExecStatement stmt = (TypeCobol.Compiler.CodeElements.ExecStatement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartExecStatement(stmt); my_parser.Builder.EndExecStatement(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(180/*NT$10*/, RESULT);
             }
@@ -4452,9 +4451,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$9
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.GlobalStorageSectionHeader gssh = (TypeCobol.Compiler.CodeElements.GlobalStorageSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.GlobalStorageSectionHeader gssh = (TypeCobol.Compiler.CodeElements.GlobalStorageSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
 		 my_parser.Builder.EndGlobalStorageSection(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(55/*globalStorageSection*/, RESULT);
             }
@@ -4464,7 +4463,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 100: // NT$9 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.GlobalStorageSectionHeader gssh = (TypeCobol.Compiler.CodeElements.GlobalStorageSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.GlobalStorageSectionHeader gssh = (TypeCobol.Compiler.CodeElements.GlobalStorageSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartGlobalStorageSection(gssh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(179/*NT$9*/, RESULT);
             }
@@ -4484,9 +4483,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$8
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.WorkingStorageSectionHeader wssh = (TypeCobol.Compiler.CodeElements.WorkingStorageSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.WorkingStorageSectionHeader wssh = (TypeCobol.Compiler.CodeElements.WorkingStorageSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
 		 my_parser.Builder.EndWorkingStorageSection(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(56/*workingStorageSection*/, RESULT);
             }
@@ -4496,7 +4495,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 97: // NT$8 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.WorkingStorageSectionHeader wssh = (TypeCobol.Compiler.CodeElements.WorkingStorageSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.WorkingStorageSectionHeader wssh = (TypeCobol.Compiler.CodeElements.WorkingStorageSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartWorkingStorageSection(wssh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(178/*NT$8*/, RESULT);
             }
@@ -4516,9 +4515,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$7
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.FileDescriptionEntry fde = (TypeCobol.Compiler.CodeElements.FileDescriptionEntry)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.FileDescriptionEntry fde = (TypeCobol.Compiler.CodeElements.FileDescriptionEntry)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
 		  
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(51/*fileDescriptionEntry*/, RESULT);
             }
@@ -4528,7 +4527,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 94: // NT$7 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.FileDescriptionEntry fde = (TypeCobol.Compiler.CodeElements.FileDescriptionEntry)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.FileDescriptionEntry fde = (TypeCobol.Compiler.CodeElements.FileDescriptionEntry)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartFileDescriptionEntry(fde); my_parser.Builder.EndFileDescriptionEntry(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(177/*NT$7*/, RESULT);
             }
@@ -4584,9 +4583,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$6
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.FileSectionHeader feh = (TypeCobol.Compiler.CodeElements.FileSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.FileSectionHeader feh = (TypeCobol.Compiler.CodeElements.FileSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
 		 my_parser.Builder.EndFileSection(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(54/*fileSection*/, RESULT);
             }
@@ -4596,7 +4595,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 87: // NT$6 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.FileSectionHeader feh = (TypeCobol.Compiler.CodeElements.FileSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.FileSectionHeader feh = (TypeCobol.Compiler.CodeElements.FileSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartFileSection(feh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(176/*NT$6*/, RESULT);
             }
@@ -4616,9 +4615,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$5
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-5)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-5)).value;
-		TypeCobol.Compiler.CodeElements.DataDivisionHeader ddh = (TypeCobol.Compiler.CodeElements.DataDivisionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-6)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-5)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-5)).value;
+		TypeCobol.Compiler.CodeElements.DataDivisionHeader ddh = (TypeCobol.Compiler.CodeElements.DataDivisionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-6)).value;
 		 my_parser.Builder.EndDataDivision(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(60/*dataDivision*/, RESULT);
             }
@@ -4628,7 +4627,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 84: // NT$5 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.DataDivisionHeader ddh = (TypeCobol.Compiler.CodeElements.DataDivisionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.DataDivisionHeader ddh = (TypeCobol.Compiler.CodeElements.DataDivisionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartDataDivision(ddh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(175/*NT$5*/, RESULT);
             }
@@ -4719,8 +4718,8 @@ public class CUP_TypeCobolProgramParser_actions {
           case 74: // fileControlEntries ::= fileControlEntries FileControlEntry 
             {
               object RESULT = null;
-		object fces = (object)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.FileControlEntry fce = (TypeCobol.Compiler.CodeElements.FileControlEntry)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		object fces = (object)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.FileControlEntry fce = (TypeCobol.Compiler.CodeElements.FileControlEntry)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartFileControlEntry(fce); my_parser.Builder.EndFileControlEntry(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(40/*fileControlEntries*/, RESULT);
             }
@@ -4730,7 +4729,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 73: // fileControlEntries ::= FileControlEntry 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.FileControlEntry fce = (TypeCobol.Compiler.CodeElements.FileControlEntry)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.FileControlEntry fce = (TypeCobol.Compiler.CodeElements.FileControlEntry)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartFileControlEntry(fce); my_parser.Builder.EndFileControlEntry(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(40/*fileControlEntries*/, RESULT);
             }
@@ -4759,9 +4758,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$4
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.FileControlParagraphHeader fcph = (TypeCobol.Compiler.CodeElements.FileControlParagraphHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.FileControlParagraphHeader fcph = (TypeCobol.Compiler.CodeElements.FileControlParagraphHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
 		 my_parser.Builder.EndFileControlParagraph(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(38/*fileControlParagraph*/, RESULT);
             }
@@ -4771,7 +4770,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 69: // NT$4 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.FileControlParagraphHeader fcph = (TypeCobol.Compiler.CodeElements.FileControlParagraphHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.FileControlParagraphHeader fcph = (TypeCobol.Compiler.CodeElements.FileControlParagraphHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartFileControlParagraph(fcph); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(174/*NT$4*/, RESULT);
             }
@@ -4800,9 +4799,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$3
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
-		TypeCobol.Compiler.CodeElements.InputOutputSectionHeader iosh = (TypeCobol.Compiler.CodeElements.InputOutputSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-3)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
+		TypeCobol.Compiler.CodeElements.InputOutputSectionHeader iosh = (TypeCobol.Compiler.CodeElements.InputOutputSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-3)).value;
 		 my_parser.Builder.EndInputOutputSection(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(34/*inputOutputSection*/, RESULT);
             }
@@ -4812,7 +4811,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 65: // NT$3 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.InputOutputSectionHeader iosh = (TypeCobol.Compiler.CodeElements.InputOutputSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.InputOutputSectionHeader iosh = (TypeCobol.Compiler.CodeElements.InputOutputSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartInputOutputSection(iosh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(173/*NT$3*/, RESULT);
             }
@@ -4840,7 +4839,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 62: // configurationParagraph ::= RepositoryParagraph 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.RepositoryParagraph rp = (TypeCobol.Compiler.CodeElements.RepositoryParagraph)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.RepositoryParagraph rp = (TypeCobol.Compiler.CodeElements.RepositoryParagraph)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartRepositoryParagraph(rp); my_parser.Builder.EndRepositoryParagraph(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(36/*configurationParagraph*/, RESULT);
             }
@@ -4850,7 +4849,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 61: // configurationParagraph ::= SpecialNamesParagraph 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SpecialNamesParagraph snp = (TypeCobol.Compiler.CodeElements.SpecialNamesParagraph)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SpecialNamesParagraph snp = (TypeCobol.Compiler.CodeElements.SpecialNamesParagraph)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartSpecialNamesParagraph(snp); my_parser.Builder.EndSpecialNamesParagraph(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(36/*configurationParagraph*/, RESULT);
             }
@@ -4860,7 +4859,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 60: // configurationParagraph ::= ObjectComputerParagraph 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ObjectComputerParagraph ocp = (TypeCobol.Compiler.CodeElements.ObjectComputerParagraph)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ObjectComputerParagraph ocp = (TypeCobol.Compiler.CodeElements.ObjectComputerParagraph)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartObjectComputerParagraph(ocp); my_parser.Builder.EndObjectComputerParagraph(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(36/*configurationParagraph*/, RESULT);
             }
@@ -4870,7 +4869,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 59: // configurationParagraph ::= SourceComputerParagraph 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.SourceComputerParagraph scp = (TypeCobol.Compiler.CodeElements.SourceComputerParagraph)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.SourceComputerParagraph scp = (TypeCobol.Compiler.CodeElements.SourceComputerParagraph)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartSourceComputerParagraph(scp); my_parser.Builder.EndSourceComputerParagraph(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(36/*configurationParagraph*/, RESULT);
             }
@@ -4898,7 +4897,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 56: // configurationSectionHeader ::= ConfigurationSectionHeader 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ConfigurationSectionHeader csh = (TypeCobol.Compiler.CodeElements.ConfigurationSectionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ConfigurationSectionHeader csh = (TypeCobol.Compiler.CodeElements.ConfigurationSectionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.StartConfigurationSection(csh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(83/*configurationSectionHeader*/, RESULT);
             }
@@ -4945,9 +4944,9 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               TypeCobol.Compiler.CodeElements.EnvironmentDivisionHeader RESULT = null;
               // propagate RESULT from NT$2
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value != null )
-                RESULT = (TypeCobol.Compiler.CodeElements.EnvironmentDivisionHeader) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-2)).value;
-		TypeCobol.Compiler.CodeElements.EnvironmentDivisionHeader edh = (TypeCobol.Compiler.CodeElements.EnvironmentDivisionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-3)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value != null )
+                RESULT = (TypeCobol.Compiler.CodeElements.EnvironmentDivisionHeader) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-2)).value;
+		TypeCobol.Compiler.CodeElements.EnvironmentDivisionHeader edh = (TypeCobol.Compiler.CodeElements.EnvironmentDivisionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-3)).value;
 		 my_parser.Builder.EndEnvironmentDivision(); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(30/*environmentDivision*/, RESULT);
             }
@@ -4957,7 +4956,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 50: // NT$2 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.EnvironmentDivisionHeader edh = (TypeCobol.Compiler.CodeElements.EnvironmentDivisionHeader)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.EnvironmentDivisionHeader edh = (TypeCobol.Compiler.CodeElements.EnvironmentDivisionHeader)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
  my_parser.Builder.StartEnvironmentDivision(edh); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(172/*NT$2*/, RESULT);
             }
@@ -5003,7 +5002,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 45: // nestedProgram ::= cobolProgramBase nestedProgramOpt ProgramEnd 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ProgramEnd pe = (TypeCobol.Compiler.CodeElements.ProgramEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ProgramEnd pe = (TypeCobol.Compiler.CodeElements.ProgramEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndCobolProgram(pe); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(8/*nestedProgram*/, RESULT);
             }
@@ -5013,7 +5012,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 44: // programEndOpt ::= ProgramEnd 
             {
               TypeCobol.Compiler.CodeElements.ProgramEnd RESULT = null;
-		TypeCobol.Compiler.CodeElements.ProgramEnd pe = (TypeCobol.Compiler.CodeElements.ProgramEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ProgramEnd pe = (TypeCobol.Compiler.CodeElements.ProgramEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		  RESULT = pe; 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(27/*programEndOpt*/, RESULT);
             }
@@ -5032,7 +5031,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 42: // libraryCopyOpt ::= LibraryCopy 
             {
               TypeCobol.Compiler.CodeElements.LibraryCopyCodeElement RESULT = null;
-		TypeCobol.Compiler.CodeElements.LibraryCopyCodeElement lc = (TypeCobol.Compiler.CodeElements.LibraryCopyCodeElement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.LibraryCopyCodeElement lc = (TypeCobol.Compiler.CodeElements.LibraryCopyCodeElement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		  RESULT = lc; 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(26/*libraryCopyOpt*/, RESULT);
             }
@@ -5051,8 +5050,8 @@ public class CUP_TypeCobolProgramParser_actions {
           case 40: // programAttributes ::= ProgramIdentification libraryCopyOpt 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ProgramIdentification pid = (TypeCobol.Compiler.CodeElements.ProgramIdentification)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
-		TypeCobol.Compiler.CodeElements.LibraryCopyCodeElement lc = (TypeCobol.Compiler.CodeElements.LibraryCopyCodeElement)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ProgramIdentification pid = (TypeCobol.Compiler.CodeElements.ProgramIdentification)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
+		TypeCobol.Compiler.CodeElements.LibraryCopyCodeElement lc = (TypeCobol.Compiler.CodeElements.LibraryCopyCodeElement)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		  programIdentification = pid; libraryCopy = lc; 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(25/*programAttributes*/, RESULT);
             }
@@ -5306,8 +5305,8 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$1
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-3)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-3)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-3)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-3)).value;
 		  
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(7/*cobolProgramBase*/, RESULT);
             }
@@ -5326,7 +5325,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 10: // cobolProgram ::= cobolProgramBase nestedProgramOpt programEndOpt 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CodeElements.ProgramEnd pe = (TypeCobol.Compiler.CodeElements.ProgramEnd)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-0)).value;
+		TypeCobol.Compiler.CodeElements.ProgramEnd pe = (TypeCobol.Compiler.CodeElements.ProgramEnd)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top)).value;
 		 my_parser.Builder.EndCobolProgram(pe); 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(5/*cobolProgram*/, RESULT);
             }
@@ -5382,8 +5381,8 @@ public class CUP_TypeCobolProgramParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$0
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
+              if ( (CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value != null )
+                RESULT = (object) ( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
 
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(3/*compilationUnit*/, RESULT);
             }
@@ -5420,7 +5419,7 @@ public class CUP_TypeCobolProgramParser_actions {
           case 0: // $START ::= starts EOF 
             {
               object RESULT = null;
-		object start_val = (object)((TUVienna.CS_CUP.Runtime.Symbol) CUP_TypeCobolProgramParser_stack.elementAt(CUP_TypeCobolProgramParser_top-1)).value;
+		object start_val = (object)( CUP_TypeCobolProgramParser_stack.ElementAtFromBottom(CUP_TypeCobolProgramParser_top-1)).value;
 		RESULT = start_val;
               CUP_TypeCobolProgramParser_result = new TUVienna.CS_CUP.Runtime.Symbol(0/*$START*/, RESULT);
             }

--- a/TypeCobol/Compiler/CupPreprocessor/CobolCompilerDirectives.cup
+++ b/TypeCobol/Compiler/CupPreprocessor/CobolCompilerDirectives.cup
@@ -2,7 +2,6 @@
 
 using TUVienna.CS_CUP.Runtime;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using TypeCobol.Compiler.CupCommon;
 using TypeCobol.Compiler.Scanner;
@@ -35,11 +34,11 @@ parser code {:
   // get the current state of the parser.
   public int getParserState() 
   {
-	return ((Symbol)stack.Peek()).parse_state;	
+	return stack.Peek().parse_state;	
   }
 
   //get the parser stack.
-  public Stack getParserStack() 
+  public StackList<Symbol> getParserStack() 
   {
 	return stack;	
   }

--- a/TypeCobol/Compiler/CupPreprocessor/CobolCompilerDirectivesParser.cs
+++ b/TypeCobol/Compiler/CupPreprocessor/CobolCompilerDirectivesParser.cs
@@ -10,9 +10,9 @@ using TypeCobol.Compiler.Directives;
 using TypeCobol.Compiler.Scanner;
 using TypeCobol.Compiler.CupCommon;
 using System.Collections.Generic;
-using System.Collections;
 using System;
 using TUVienna.CS_CUP.Runtime;
+using CSCupRuntime;
 
 /** C# CUP v0.1 generated parser.
   */
@@ -637,10 +637,9 @@ new short[173][] {
   public override TUVienna.CS_CUP.Runtime.Symbol do_action(
     int                        act_num,
     TUVienna.CS_CUP.Runtime.lr_parser parser,
-    System.Collections.Stack            xstack1,
+    StackList<Symbol>            CUP_parser_stack,
     int                        top)
   {
-  mStack CUP_parser_stack= new mStack(xstack1);
     /* call code in generated class */
     return action_obj.CUP_CobolCompilerDirectivesParser_do_action(act_num, parser, stack, top);
   }
@@ -681,11 +680,11 @@ new short[173][] {
   // get the current state of the parser.
   public int getParserState() 
   {
-	return ((Symbol)stack.Peek()).parse_state;	
+	return stack.Peek().parse_state;	
   }
 
   //get the parser stack.
-  public Stack getParserStack() 
+  public StackList<Symbol> getParserStack() 
   {
 	return stack;	
   }
@@ -759,11 +758,11 @@ public class CUP_CobolCompilerDirectivesParser_actions {
   public   TUVienna.CS_CUP.Runtime.Symbol CUP_CobolCompilerDirectivesParser_do_action(
     int                        CUP_CobolCompilerDirectivesParser_act_num,
     TUVienna.CS_CUP.Runtime.lr_parser CUP_CobolCompilerDirectivesParser_parser,
-    System.Collections.Stack            xstack1,
+    StackList<Symbol>            xstack1,
     int                        CUP_CobolCompilerDirectivesParser_top)
     {
       /* Symbol object for return from actions */
-      mStack CUP_CobolCompilerDirectivesParser_stack =new mStack(xstack1);
+      StackList<Symbol> CUP_CobolCompilerDirectivesParser_stack =  xstack1;
       TUVienna.CS_CUP.Runtime.Symbol CUP_CobolCompilerDirectivesParser_result;
 
       /* select the action based on the action number */
@@ -774,13 +773,13 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$33
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
               // propagate RESULT from NT$34
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TypeCobol.Compiler.Scanner.Token a = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TypeCobol.Compiler.Scanner.Token a = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 		
 		my_parser.Builder.EnterTitleCompilerStatement(t, a);
 	
@@ -792,7 +791,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 228: // NT$34 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  ((CobolWordsTokenizer)my_parser.getScanner()).ConsumeNextTokenOnTheSameLineAndStop(TokenType.PeriodSeparator);  
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(209/*NT$34*/, RESULT);
             }
@@ -811,7 +810,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 226: // skipCompilerStatement ::= skipTokens 
             {
               object RESULT = null;
-		Token t = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		Token t = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 		
 		my_parser.Builder.EnterSkipCompilerStatement(t);
 	
@@ -824,9 +823,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               Token RESULT = null;
               // propagate RESULT from NT$32
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (Token) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (Token) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = t; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(169/*skipTokens*/, RESULT);
             }
@@ -847,9 +846,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               Token RESULT = null;
               // propagate RESULT from NT$31
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (Token) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (Token) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = t; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(169/*skipTokens*/, RESULT);
             }
@@ -870,9 +869,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               Token RESULT = null;
               // propagate RESULT from NT$30
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (Token) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (Token) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = t; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(169/*skipTokens*/, RESULT);
             }
@@ -893,14 +892,14 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$28
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
               // propagate RESULT from NT$29
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token s = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-4)).value;
-		TypeCobol.Compiler.Scanner.Token l = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TypeCobol.Compiler.Scanner.Token w = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token s = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-4)).value;
+		TypeCobol.Compiler.Scanner.Token l = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TypeCobol.Compiler.Scanner.Token w = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 my_parser.Builder.EnterServiceReloadCompilerStatement(s, l, w); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(168/*serviceReloadCompilerStatement*/, RESULT);
             }
@@ -910,8 +909,8 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 218: // NT$29 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.Scanner.Token s = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TypeCobol.Compiler.Scanner.Token l = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token s = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TypeCobol.Compiler.Scanner.Token l = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  ((CobolWordsTokenizer)my_parser.getScanner()).EnterStopScanningMode(); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(204/*NT$29*/, RESULT);
             }
@@ -921,7 +920,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 217: // NT$28 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.Scanner.Token s = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token s = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  my_parser.Builder.StartServiceReloadCompilerStatement(); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(203/*NT$28*/, RESULT);
             }
@@ -932,10 +931,10 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$27
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token s = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TypeCobol.Compiler.Scanner.Token l = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token s = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TypeCobol.Compiler.Scanner.Token l = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 my_parser.Builder.EnterServiceLabelCompilerStatement(s, l); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(167/*serviceLabelCompilerStatement*/, RESULT);
             }
@@ -945,7 +944,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 215: // NT$27 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.Scanner.Token s = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token s = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  
 		my_parser.Builder.StartServiceLabelCompilerStatement();
 		((CobolWordsTokenizer)my_parser.getScanner()).EnterStopScanningMode(); 
@@ -958,9 +957,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 214: // pseudoTextReplaces ::= pseudoTextReplaces pseudoText BY pseudoText 
             {
               PairTokenListList RESULT = null;
-		PairTokenListList replaces = (PairTokenListList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
-		TokenList from = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TokenList by = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		PairTokenListList replaces = (PairTokenListList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
+		TokenList from = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TokenList by = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 replaces.Add(new Tuple<List<Token>, List<Token>>(from,by)); RESULT = replaces; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(166/*pseudoTextReplaces*/, RESULT);
             }
@@ -970,8 +969,8 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 213: // pseudoTextReplaces ::= pseudoText BY pseudoText 
             {
               PairTokenListList RESULT = null;
-		TokenList from = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TokenList by = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TokenList from = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TokenList by = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = new PairTokenListList() {new Tuple<List<Token>, List<Token>>(from,by)}; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(166/*pseudoTextReplaces*/, RESULT);
             }
@@ -982,13 +981,13 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$25
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
               // propagate RESULT from NT$26
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		Token r = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-4)).value;
-		TypeCobol.Compiler.Scanner.Token o = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		Token r = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-4)).value;
+		TypeCobol.Compiler.Scanner.Token o = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
 		 my_parser.Builder.EnterReplaceCompilerStatement(r, o, null); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(165/*replaceCompilerStatement*/, RESULT);
             }
@@ -998,8 +997,8 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 211: // NT$26 ::= 
             {
               object RESULT = null;
-		Token r = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TypeCobol.Compiler.Scanner.Token o = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		Token r = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TypeCobol.Compiler.Scanner.Token o = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  ((CobolWordsTokenizer)my_parser.getScanner()).EnterStopScanningMode(); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(201/*NT$26*/, RESULT);
             }
@@ -1009,7 +1008,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 210: // NT$25 ::= 
             {
               object RESULT = null;
-		Token r = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		Token r = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  my_parser.Builder.StartReplaceCompilerStatement(CompilerDirectiveType.REPLACE_OFF); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(200/*NT$25*/, RESULT);
             }
@@ -1020,10 +1019,10 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$24
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		Token r = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
-		PairTokenListList replaces = (PairTokenListList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		Token r = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
+		PairTokenListList replaces = (PairTokenListList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
 		 my_parser.Builder.EnterReplaceCompilerStatement(r, null, replaces); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(165/*replaceCompilerStatement*/, RESULT);
             }
@@ -1033,8 +1032,8 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 208: // NT$24 ::= 
             {
               object RESULT = null;
-		Token r = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		PairTokenListList replaces = (PairTokenListList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		Token r = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		PairTokenListList replaces = (PairTokenListList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  		
 		((CobolWordsTokenizer)my_parser.getScanner()).EnterStopScanningMode();
 	
@@ -1047,9 +1046,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               Token RESULT = null;
               // propagate RESULT from NT$23
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (Token) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token r = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (Token) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token r = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 
 		RESULT = r;
 	
@@ -1071,9 +1070,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$22
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		Token rt = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		Token rt = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
 		 my_parser.Builder.EnterReadyOrResetTraceCompilerStatement(rt); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(163/*readyOrResetTraceCompilerStatement*/, RESULT);
             }
@@ -1083,7 +1082,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 204: // NT$22 ::= 
             {
               object RESULT = null;
-		Token rt = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		Token rt = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
  ((CobolWordsTokenizer)my_parser.getScanner()).EnterStopScanningMode(); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(197/*NT$22*/, RESULT);
             }
@@ -1094,9 +1093,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               Token RESULT = null;
               // propagate RESULT from NT$21
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (Token) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (Token) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = t; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(162/*readyOrReset*/, RESULT);
             }
@@ -1116,9 +1115,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               Token RESULT = null;
               // propagate RESULT from NT$20
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (Token) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (Token) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = t; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(162/*readyOrReset*/, RESULT);
             }
@@ -1137,7 +1136,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 199: // sequenceNumber ::= IntegerLiteral 
             {
               Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token il = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token il = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = il; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(161/*sequenceNumber*/, RESULT);
             }
@@ -1148,13 +1147,13 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$18
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
               // propagate RESULT from NT$19
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token tins = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		Token sn = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token tins = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		Token sn = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 my_parser.Builder.EnterInsertCompilerStatement(tins,sn); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(160/*insertCompilerStatement*/, RESULT);
             }
@@ -1164,7 +1163,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 197: // NT$19 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.Scanner.Token tins = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token tins = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  ((CobolWordsTokenizer)my_parser.getScanner()).EnterStopScanningMode(); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(194/*NT$19*/, RESULT);
             }
@@ -1186,12 +1185,12 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$16
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-6)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-6)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-6)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-6)).value;
               // propagate RESULT from NT$17
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		Token t = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-7)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		Token t = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-7)).value;
 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(159/*execSqlIncludeStatement*/, RESULT);
             }
@@ -1201,7 +1200,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 194: // NT$17 ::= 
             {
               object RESULT = null;
-		Token t = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-5)).value;
+		Token t = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-5)).value;
  ((CobolWordsTokenizer)my_parser.getScanner()).EnterStopScanningMode(); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(192/*NT$17*/, RESULT);
             }
@@ -1211,7 +1210,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 193: // NT$16 ::= 
             {
               object RESULT = null;
-		Token t = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		Token t = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  my_parser.Builder.EnterExecSqlIncludeStatement(t); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(191/*NT$16*/, RESULT);
             }
@@ -1239,7 +1238,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 190: // execToken ::= EXECUTE 
             {
               Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = t; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(158/*execToken*/, RESULT);
             }
@@ -1249,7 +1248,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 189: // execToken ::= EXEC 
             {
               Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = t; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(158/*execToken*/, RESULT);
             }
@@ -1259,7 +1258,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 188: // routineName ::= UserDefinedWord 
             {
               Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token w = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token w = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = w; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(157/*routineName*/, RESULT);
             }
@@ -1278,7 +1277,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 186: // languageName ::= UserDefinedWord 
             {
               Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token w = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token w = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = w; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(156/*languageName*/, RESULT);
             }
@@ -1289,14 +1288,14 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$14
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-5)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-5)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-5)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-5)).value;
               // propagate RESULT from NT$15
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token e = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-4)).value;
-		Token ln = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
-		Token rn = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token e = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-4)).value;
+		Token ln = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
+		Token rn = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
 		 my_parser.Builder.EnterEnterCompilerStatement(e, ln, rn); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(155/*enterCompilerStatement*/, RESULT);
             }
@@ -1306,9 +1305,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 184: // NT$15 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.Scanner.Token e = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		Token ln = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		Token rn = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token e = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		Token ln = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		Token rn = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  ((CobolWordsTokenizer)my_parser.getScanner()).EnterStopScanningMode(); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(190/*NT$15*/, RESULT);
             }
@@ -1328,9 +1327,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$13
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token e = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token e = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 		
 		my_parser.Builder.EnterEjectCompilerStatement(e);
 	
@@ -1355,10 +1354,10 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               TokenList RESULT = null;
               // propagate RESULT from NT$12
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (TokenList) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TokenList snf = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TypeCobol.Compiler.Scanner.Token il = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (TokenList) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TokenList snf = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TypeCobol.Compiler.Scanner.Token il = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 snf.Add(il); RESULT = snf; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(153/*deleteSequenceNumberField*/, RESULT);
             }
@@ -1368,7 +1367,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 179: // NT$12 ::= 
             {
               object RESULT = null;
-		TokenList snf = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TokenList snf = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  ((CobolWordsTokenizer)my_parser.getScanner()).EnterStopScanningModeIfNextNotToken(TokenType.IntegerLiteral); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(187/*NT$12*/, RESULT);
             }
@@ -1379,9 +1378,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               TokenList RESULT = null;
               // propagate RESULT from NT$11
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (TokenList) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token il = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (TokenList) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token il = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = new TokenList() {il}; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(153/*deleteSequenceNumberField*/, RESULT);
             }
@@ -1401,10 +1400,10 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$10
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TokenList fields = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TokenList fields = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 my_parser.Builder.EnterDeleteCompilerStatement(t); my_parser.Builder.EnterSequenceNumberField(fields); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(152/*deleteCompilerStatement*/, RESULT);
             }
@@ -1424,9 +1423,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               TokenList RESULT = null;
               // propagate RESULT from NT$9
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
-                RESULT = (TokenList) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
-		TokenList tokens = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
+                RESULT = (TokenList) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
+		TokenList tokens = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
 		 RESULT = tokens; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(150/*pseudoText*/, RESULT);
             }
@@ -1445,7 +1444,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 172: // copyReplacingOperand ::= CUP_LiteralOrUserDefinedWordOReservedWordExceptCopy 
             {
               TokenList RESULT = null;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = new TokenList(){t}; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(149/*copyReplacingOperand*/, RESULT);
             }
@@ -1455,7 +1454,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 171: // copyReplacingOperand ::= pseudoText 
             {
               TokenList RESULT = null;
-		TokenList tokens = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TokenList tokens = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = tokens; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(149/*copyReplacingOperand*/, RESULT);
             }
@@ -1465,9 +1464,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 170: // copyReplacingOperands ::= copyReplacingOperands copyReplacingOperand replacing_by copyReplacingOperand 
             {
               PairTokenListList RESULT = null;
-		PairTokenListList operands = (PairTokenListList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
-		TokenList from = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TokenList by = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		PairTokenListList operands = (PairTokenListList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
+		TokenList from = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TokenList by = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 operands.Add(new Tuple<List<Token>, List<Token>>(from,by)); RESULT = operands; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(148/*copyReplacingOperands*/, RESULT);
             }
@@ -1477,8 +1476,8 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 169: // copyReplacingOperands ::= copyReplacingOperand replacing_by copyReplacingOperand 
             {
               PairTokenListList RESULT = null;
-		TokenList from = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TokenList by = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TokenList from = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TokenList by = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = new PairTokenListList() {new Tuple<List<Token>, List<Token>>(from,by)}; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(148/*copyReplacingOperands*/, RESULT);
             }
@@ -1507,9 +1506,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               PairTokenListList RESULT = null;
               // propagate RESULT from NT$8
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value != null )
-                RESULT = (PairTokenListList) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		PairTokenListList operands = (PairTokenListList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value != null )
+                RESULT = (PairTokenListList) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		PairTokenListList operands = (PairTokenListList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = operands; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(147/*replacingCopyReplacingOperandOpts*/, RESULT);
             }
@@ -1537,9 +1536,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 163: // copyCompilerStatementBody ::= qualifiedTextName SUPPRESS replacingCopyReplacingOperandOpts 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CupCommon.QualifiedTextName name = (TypeCobol.Compiler.CupCommon.QualifiedTextName)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TypeCobol.Compiler.Scanner.Token s = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		PairTokenListList operands = (PairTokenListList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.CupCommon.QualifiedTextName name = (TypeCobol.Compiler.CupCommon.QualifiedTextName)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TypeCobol.Compiler.Scanner.Token s = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		PairTokenListList operands = (PairTokenListList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 my_parser.Builder.EnterCopyCompilerStatementBody(name, s, operands); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(146/*copyCompilerStatementBody*/, RESULT);
             }
@@ -1549,8 +1548,8 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 162: // copyCompilerStatementBody ::= qualifiedTextName replacingCopyReplacingOperandOpts 
             {
               object RESULT = null;
-		TypeCobol.Compiler.CupCommon.QualifiedTextName name = (TypeCobol.Compiler.CupCommon.QualifiedTextName)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		PairTokenListList operands = (PairTokenListList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.CupCommon.QualifiedTextName name = (TypeCobol.Compiler.CupCommon.QualifiedTextName)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		PairTokenListList operands = (PairTokenListList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 my_parser.Builder.EnterCopyCompilerStatementBody(name, null, operands); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(146/*copyCompilerStatementBody*/, RESULT);
             }
@@ -1561,12 +1560,12 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$6
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
               // propagate RESULT from NT$7
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token c = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-4)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token c = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-4)).value;
 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(145/*copyCompilerStatement*/, RESULT);
             }
@@ -1576,7 +1575,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 160: // NT$7 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.Scanner.Token c = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TypeCobol.Compiler.Scanner.Token c = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
  ((CobolWordsTokenizer)my_parser.getScanner()).EnterStopScanningMode(); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(182/*NT$7*/, RESULT);
             }
@@ -1586,7 +1585,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 159: // NT$6 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.Scanner.Token c = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token c = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  my_parser.Builder.EnterCopyCompilerStatement(c); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(181/*NT$6*/, RESULT);
             }
@@ -1597,9 +1596,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$5
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		Token t = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		Token t = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
 		 my_parser.Builder.EnterControlCblCompilerStatement(t); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(144/*controlCblCompilerStatement*/, RESULT);
             }
@@ -1609,7 +1608,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 157: // NT$5 ::= 
             {
               object RESULT = null;
-		Token t = (Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		Token t = (Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  ((CobolWordsTokenizer)my_parser.getScanner()).EnterControlCblCompilerStatementMode();  
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(180/*NT$5*/, RESULT);
             }
@@ -1638,9 +1637,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               Token RESULT = null;
               // propagate RESULT from NT$4
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (Token) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (Token) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 
 	RESULT = t; 
 
@@ -1664,9 +1663,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               Token RESULT = null;
               // propagate RESULT from NT$3
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (Token) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (Token) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 
 	RESULT = t; 
 
@@ -1689,7 +1688,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 150: // controlCblOptions ::= controlCblOptions controlCblOption 
             {
               object RESULT = null;
-		TypeCobol.Compiler.Scanner.Token o = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token o = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 my_parser.Builder.EnterControlCblOption(o); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(141/*controlCblOptions*/, RESULT);
             }
@@ -1699,7 +1698,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 149: // controlCblOptions ::= controlCblOption 
             {
               object RESULT = null;
-		TypeCobol.Compiler.Scanner.Token o = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token o = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 my_parser.Builder.EnterControlCblOption(o); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(141/*controlCblOptions*/, RESULT);
             }
@@ -1710,8 +1709,8 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$2
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(137/*compilerOption*/, RESULT);
             }
@@ -1739,8 +1738,8 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 145: // anyTokens ::= anyTokens CUP_ANY_TOKEN 
             {
               TokenList RESULT = null;
-		TokenList tokens = (TokenList)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TokenList tokens = (TokenList)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 tokens.Add(t); RESULT = tokens; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(139/*anyTokens*/, RESULT);
             }
@@ -1750,7 +1749,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 144: // anyTokens ::= CUP_ANY_TOKEN 
             {
               TokenList RESULT = null;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = new TokenList(); RESULT.Add(t); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(139/*anyTokens*/, RESULT);
             }
@@ -1851,13 +1850,13 @@ public class CUP_CobolCompilerDirectivesParser_actions {
             {
               object RESULT = null;
               // propagate RESULT from NT$0
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-3)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-3)).value;
               // propagate RESULT from NT$1
-              if ( ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
-                RESULT = (object) ((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TypeCobol.Compiler.Scanner.Token n = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+              if ( (CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value != null )
+                RESULT = (object) ( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TypeCobol.Compiler.Scanner.Token n = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 my_parser.Builder.EnterBasisCompilerStatement(n); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(134/*basisCompilerStatement*/, RESULT);
             }
@@ -1867,7 +1866,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 132: // NT$1 ::= 
             {
               object RESULT = null;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
  		
 		((CobolWordsTokenizer)my_parser.getScanner()).EnterStopScanningMode(); 
     
@@ -2889,7 +2888,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 19: // controlCblOption ::= enumeratedValue1 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token v = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token v = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = v; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(129/*controlCblOption*/, RESULT);
             }
@@ -2899,9 +2898,9 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 18: // qualifiedTextName ::= textName in_of libraryName 
             {
               TypeCobol.Compiler.CupCommon.QualifiedTextName RESULT = null;
-		TypeCobol.Compiler.Scanner.Token n = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-2)).value;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
-		TypeCobol.Compiler.Scanner.Token ln = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token n = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-2)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		TypeCobol.Compiler.Scanner.Token ln = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = new QualifiedTextName(n, t, ln); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(125/*qualifiedTextName*/, RESULT);
             }
@@ -2911,7 +2910,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 17: // qualifiedTextName ::= textName 
             {
               TypeCobol.Compiler.CupCommon.QualifiedTextName RESULT = null;
-		TypeCobol.Compiler.Scanner.Token n = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token n = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = new QualifiedTextName(n); 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(125/*qualifiedTextName*/, RESULT);
             }
@@ -2921,7 +2920,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 16: // in_of ::= OF 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = t; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(105/*in_of*/, RESULT);
             }
@@ -2931,7 +2930,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 15: // in_of ::= IN 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token t = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = t; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(105/*in_of*/, RESULT);
             }
@@ -2941,7 +2940,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 14: // libraryName ::= externalName5 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token n = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token n = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = n; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(124/*libraryName*/, RESULT);
             }
@@ -2951,7 +2950,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 13: // textName ::= externalName5 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token n = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token n = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = n; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(123/*textName*/, RESULT);
             }
@@ -2961,7 +2960,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 12: // externalName5 ::= alphanumericValue5 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token v = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token v = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = v; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(49/*externalName5*/, RESULT);
             }
@@ -2971,7 +2970,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 11: // alphanumericValue5 ::= alphanumericLiteralToken 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token v = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token v = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = v; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(24/*alphanumericValue5*/, RESULT);
             }
@@ -2981,7 +2980,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 10: // alphanumericValue5 ::= UserDefinedWord 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token v = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token v = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = v; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(24/*alphanumericValue5*/, RESULT);
             }
@@ -2991,7 +2990,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 9: // alphanumericValue2 ::= alphanumericOrNationalLiteralToken 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token v = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token v = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = v; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(22/*alphanumericValue2*/, RESULT);
             }
@@ -3001,7 +3000,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 8: // alphanumericOrNationalLiteralToken ::= HexadecimalNationalLiteral 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = lit; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(5/*alphanumericOrNationalLiteralToken*/, RESULT);
             }
@@ -3011,7 +3010,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 7: // alphanumericOrNationalLiteralToken ::= NationalLiteral 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = lit; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(5/*alphanumericOrNationalLiteralToken*/, RESULT);
             }
@@ -3021,7 +3020,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 6: // alphanumericOrNationalLiteralToken ::= DBCSLiteral 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = lit; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(5/*alphanumericOrNationalLiteralToken*/, RESULT);
             }
@@ -3031,7 +3030,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 5: // alphanumericOrNationalLiteralToken ::= alphanumericLiteralToken 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = lit; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(5/*alphanumericOrNationalLiteralToken*/, RESULT);
             }
@@ -3041,7 +3040,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 4: // alphanumericLiteralToken ::= NullTerminatedAlphanumericLiteral 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = lit; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(4/*alphanumericLiteralToken*/, RESULT);
             }
@@ -3051,7 +3050,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 3: // alphanumericLiteralToken ::= HexadecimalAlphanumericLiteral 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = lit; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(4/*alphanumericLiteralToken*/, RESULT);
             }
@@ -3061,7 +3060,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 2: // alphanumericLiteralToken ::= AlphanumericLiteral 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token lit = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = lit; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(4/*alphanumericLiteralToken*/, RESULT);
             }
@@ -3071,7 +3070,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 1: // enumeratedValue1 ::= UserDefinedWord 
             {
               TypeCobol.Compiler.Scanner.Token RESULT = null;
-		TypeCobol.Compiler.Scanner.Token v = (TypeCobol.Compiler.Scanner.Token)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-0)).value;
+		TypeCobol.Compiler.Scanner.Token v = (TypeCobol.Compiler.Scanner.Token)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top)).value;
 		 RESULT = v; 
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(28/*enumeratedValue1*/, RESULT);
             }
@@ -3081,7 +3080,7 @@ public class CUP_CobolCompilerDirectivesParser_actions {
           case 0: // $START ::= starts EOF 
             {
               object RESULT = null;
-		object start_val = (object)((TUVienna.CS_CUP.Runtime.Symbol) CUP_CobolCompilerDirectivesParser_stack.elementAt(CUP_CobolCompilerDirectivesParser_top-1)).value;
+		object start_val = (object)( CUP_CobolCompilerDirectivesParser_stack.ElementAtFromBottom(CUP_CobolCompilerDirectivesParser_top-1)).value;
 		RESULT = start_val;
               CUP_CobolCompilerDirectivesParser_result = new TUVienna.CS_CUP.Runtime.Symbol(0/*$START*/, RESULT);
             }

--- a/TypeCobol/Compiler/CupPreprocessor/CompilerDirectiveErrorStrategy.cs
+++ b/TypeCobol/Compiler/CupPreprocessor/CompilerDirectiveErrorStrategy.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using CSCupRuntime;
 using TUVienna.CS_CUP.Runtime;
 using TypeCobol.Compiler.CupCommon;
 
@@ -14,7 +15,7 @@ namespace TypeCobol.Compiler.CupPreprocessor
     /// </summary>
     public class CompilerDirectiveErrorStrategy : CupCobolErrorStrategy
     {
-        public override bool SyntaxError(lr_parser parser, Stack stack, Symbol curToken)
+        public override bool SyntaxError(lr_parser parser, StackList<Symbol> stack, Symbol curToken)
         {
             LastMismatchedSymbol = null;
             bool bResult = base.SyntaxError(parser, stack, curToken);


### PR DESCRIPTION
Make CUP runtime 25% faster by using :
- Generics in the internal stack of the runtime
- Implemented method to access an element in the middle of the stack. This avoid to copy the stack to an array.
   - The Stack has been duplicated from source code of .Net framework

As node phase (which use CUP runtime) is already fast, the global gain is only 3% for full parsing and 7% for incremental parsing.