### PR TITLE
WI #1247 Remove useless track of events

### DIFF
--- a/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
@@ -501,8 +501,6 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
             table.AddType(node);
 
             _CurrentTypeDefinition = node;
-
-            AnalyticsWrapper.Telemetry.TrackEvent(EventType.TypeDeclared, node.Name, LogType.TypeCobolUsage);
         }
 
         public virtual void StartWorkingStorageSection(WorkingStorageSectionHeader header)
@@ -653,8 +651,6 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
                 paramNode.SetParent(CurrentNode);
                 CurrentNode.SymbolTable.AddVariable(paramNode);
             }
-
-            AnalyticsWrapper.Telemetry.TrackEvent(EventType.FunctionDeclared, declaration.FunctionName.ToString(), LogType.TypeCobolUsage);
         }
 
         public virtual void EndFunctionDeclaration(FunctionDeclarationEnd end)

--- a/TypeCobol/Compiler/Diagnostics/Cobol2002Checker.cs
+++ b/TypeCobol/Compiler/Diagnostics/Cobol2002Checker.cs
@@ -81,8 +81,6 @@ namespace TypeCobol.Compiler.Diagnostics
     {
         public static void CheckTypeDefinition(TypeDefinition typeDefinition)
         {
-            AnalyticsWrapper.Telemetry.TrackEvent(EventType.TypedUsed, typeDefinition.Name, LogType.TypeCobolUsage);
-
             if (typeDefinition.SymbolTable.GetType(new URI(typeDefinition.DataType.Name)).Any(t => t != typeDefinition))
             {
                 var message = string.Format("TYPE '{0}' has already been declared", typeDefinition.DataType.Name);

--- a/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
@@ -86,9 +86,6 @@ namespace TypeCobol.Compiler.Diagnostics
                 !functionCaller.FunctionCall.NeedDeclaration)
                 return;
 
-            AnalyticsWrapper.Telemetry.TrackEvent(EventType.FunctionCalled, functionCaller.FunctionCall.FunctionName,
-                LogType.TypeCobolUsage);
-
             if (functionCaller.FunctionDeclaration == null)
             {
                 //Get Funtion by name and profile (matches on precise parameters)


### PR DESCRIPTION
On a source that used to take 30 seconds to generate, we win 5 to 8 seconds