### PR TITLE
Fix #1292 ASTVisitor now visit parameters of FunctionDeclaration

### DIFF
--- a/TypeCobol.Test/Parser/Programs/TypeCobol/FunctionsDeclaration.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/FunctionsDeclaration.rdzPGM.txt
@@ -1,4 +1,4 @@
-﻿--- Diagnostics ---
+--- Diagnostics ---
 Line 57[8,22] <27, Error, Syntax> - Syntax error : x is already a parameter.
 Line 58[8,22] <27, Error, Syntax> - Syntax error : y is already a parameter.
 Line 59[11,11] <27, Error, Syntax> - Syntax error : Group item a cannot have a "PICTURE" OffendingSymbol=[11,11:a]<UserDefinedWord>
@@ -25,6 +25,7 @@ Line 92[21,21] <27, Error, Syntax> - Syntax error : Parameter with name 'x' decl
 Line 93[21,21] <27, Error, Syntax> - Syntax error : Parameter with name 'y' declared multiple times OffendingSymbol=[21,21:y]<UserDefinedWord>
 Line 103[11,11] <27, Error, Syntax> - Syntax error : Illegal GLOBAL clause in function data item. OffendingSymbol=[11,11:g]<UserDefinedWord>
 Line 124[23,34] <27, Error, Syntax> - Syntax error : Condition parameter "valid-gender" must be subordinate to another parameter. OffendingSymbol=[23,34:valid-gender]<UserDefinedWord>
+Line 124[23,34] <27, Error, Syntax> - Syntax error : The variable 'valid-gender' can only be of level 01 or 77 OffendingSymbol=[23,34:valid-gender]<UserDefinedWord>
 Line 127[24,27] <27, Error, Syntax> - Syntax error : Condition parameter "male" must be level 88. OffendingSymbol=[24,27:male]<UserDefinedWord>
 
 --- Program ---

--- a/TypeCobol.Test/Parser/Programs/TypeCobol/ProcedureCall.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/ProcedureCall.rdzPGM.txt
@@ -42,7 +42,7 @@ Line 243[12,40] <27, Error, Syntax> - Syntax error : No suitable function signat
 Line 243[12,40] <27, Error, Syntax> - Syntax error : Function 'StrangelyReturnsItsInput' is missing parameter 'x' of type Numeric and length 4
 Line 252[12,20] <27, Error, Syntax> - Syntax error : Warning: Risk of confusion in call of 'varC'
 Line 256[12,39] <27, Error, Syntax> - Syntax error : No suitable function signature found for 'varD' input(DATE)
-Line 265[8,42] <30, Error, Semantics> - Semantic error: TYPE 'Date2' is not referenced
+Line 266[18,41] <30, Error, Semantics> - Semantic error: TYPE 'Date2' is not referenced
 
 --- Program ---
 PROGRAM: ProcedureCall common:False initial:False recursive:False

--- a/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
@@ -726,17 +726,6 @@ namespace TypeCobol.Compiler.Diagnostics
                 }
             }
 
-            if (parameter.Picture != null)
-            {
-                CrossCompleteChecker.CheckPicture(node, parameter);
-            }
-
-            DataDefinitionChecker.OnNode(node, parameter);
-
-            var type = parameter.DataType;
-            TypeDefinition foundedType;
-            TypeDefinitionHelper.Check(node, type, out foundedType); //Check if the type exists and is not ambiguous
-
         }
 
         /// <summary>TCRFUN_DECLARATION_NO_DUPLICATE_NAME</summary>

--- a/TypeCobol/Compiler/Nodes/Procedure.cs
+++ b/TypeCobol/Compiler/Nodes/Procedure.cs
@@ -152,7 +152,8 @@ namespace TypeCobol.Compiler.Nodes {
         {
             return astVisitor.Visit(this) && this.ContinueVisitToChildren(astVisitor, Profile.InputParameters)
                                           && this.ContinueVisitToChildren(astVisitor, Profile.InoutParameters)
-                                          && this.ContinueVisitToChildren(astVisitor, Profile.OutputParameters);
+                                          && this.ContinueVisitToChildren(astVisitor, Profile.OutputParameters)
+                                          && this.ContinueVisitToChildren(astVisitor, Profile.ReturningParameter );
 
         }
 

--- a/TypeCobol/Compiler/Nodes/Procedure.cs
+++ b/TypeCobol/Compiler/Nodes/Procedure.cs
@@ -150,7 +150,10 @@ namespace TypeCobol.Compiler.Nodes {
 
         public override bool VisitNode(IASTVisitor astVisitor)
         {
-            return astVisitor.Visit(this);
+            return astVisitor.Visit(this) && this.ContinueVisitToChildren(astVisitor, Profile.InputParameters)
+                                          && this.ContinueVisitToChildren(astVisitor, Profile.InoutParameters)
+                                          && this.ContinueVisitToChildren(astVisitor, Profile.OutputParameters);
+
         }
 
         public Dictionary<string, Tuple<IList<SymbolReference>, ProcedureStyleCall>> ProcStyleCalls { get; set; }


### PR DESCRIPTION
Checkers don't need to be called for each ParameterDescription.