### PR TITLE
WI #1301 Optimize symbol table

### DIFF
--- a/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdzMix.txt
@@ -1,0 +1,38 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CircularRefCheck.
+
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+       01 ThirdType TYPEDEF STRICT.
+Line 8[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
+            05 renjgrn TYPE myType.
+
+       01 myType TYPEDEF STRICT.
+            05 myVar PIC X(10).
+            05 secondGroup pic X.
+Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
+Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
+Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
+            05 yhrtger    TYPE ThirdType.
+Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
+Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
+Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
+            05 ezgoerk    TYPE MySendType.
+
+       01 MyGroup.
+Line 17[15,20] <30, Error, Semantics> - Semantic error: Variable 'MyVar1' has to be limited to level 47 because of 'myType' maximum estimated children level
+           48 MyVar1 TYPE myType.
+           45 MyVar2 TYPE myType.
+
+
+       01 MySendType TYPEDEF STRICT.
+            05 MyVariable PIC X(10).
+            05 MySecVariable PIC X.
+Line 24[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
+            05 SelfRef    TYPE myType.
+
+
+       PROCEDURE DIVISION.
+            move MyVar1::myVar to MyVar2::secondGroup.
+       END PROGRAM CircularRefCheck.

--- a/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdzPGM.txt
@@ -1,12 +1,8 @@
-﻿--- Diagnostics ---
+--- Diagnostics ---
 Line 8[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:renjgrn]<UserDefinedWord>
 Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:yhrtger]<UserDefinedWord>
 Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:yhrtger]<UserDefinedWord>
 Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:yhrtger]<UserDefinedWord>
-Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:yhrtger]<UserDefinedWord>
-Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:yhrtger]<UserDefinedWord>
-Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:ezgoerk]<UserDefinedWord>
-Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:ezgoerk]<UserDefinedWord>
 Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:ezgoerk]<UserDefinedWord>
 Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:ezgoerk]<UserDefinedWord>
 Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:ezgoerk]<UserDefinedWord>

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -1200,10 +1200,10 @@ namespace TypeCobol.Compiler.CodeModel
                 .Where(fd => fd.Name.StartsWith(filter, StringComparison.OrdinalIgnoreCase));
         }
 
-        public List<Program> GetPrograms()
+        public IEnumerable<Program> GetPrograms()
         {
             return this.GetTableFromScope(Scope.Namespace)
-                .Programs.Values.SelectMany(t => t).ToList();
+                .Programs.Values.SelectMany(t => t);
         }
 
 

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -1246,12 +1246,13 @@ namespace TypeCobol.Compiler.CodeModel
         /// <param name="symbol"></param>
         private void Add<T>([NotNull] IDictionary<string, List<T>> table, [NotNull] T symbol) where T : Node
         {
+            string key = symbol.Name;
             //QualifiedName of symbol can be null - if we have a filler in the type definition
-            if (symbol.QualifiedName == null)
+            if (key == null) 
             {
                 return;
             }
-            string key = symbol.QualifiedName.Head;
+
             List<T> found;
             bool present = table.TryGetValue(key, out found);
             if (!present)

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -72,27 +72,53 @@ namespace TypeCobol.Compiler.CodeModel
                 throw new InvalidOperationException("Only Table of INTRINSIC symbols don't have any enclosing scope.");
         }
 
+        /// <summary>
+        /// GetFromTableAndEnclosing 2 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="head"></param>
+        /// <param name="getTableFunction"></param>
+        /// <param name="maxScope"></param>
+        /// <returns></returns>
+        [NotNull]
         private List<T> GetFromTableAndEnclosing<T>(string head,
             Func<SymbolTable, IDictionary<string, List<T>>> getTableFunction, Scope maxScope = Scope.Intrinsic) where T : Node
         {
-            var table = getTableFunction.Invoke(this);
-            var values = GetFromTable(head, table);
-            if (EnclosingScope != null && EnclosingScope.CurrentScope >= maxScope)
-            {
-                values.AddRange(EnclosingScope.GetFromTableAndEnclosing(head, getTableFunction, maxScope));
-            }
-            return values;
+            System.Diagnostics.Debug.Assert(head != null);
+            var result = new List<T>();
+            this.GetFromTableAndEnclosing2(head, getTableFunction, result, maxScope);
+            
+            return result;
         }
 
+        private void GetFromTableAndEnclosing2<T>([NotNull] string head,
+           Func<SymbolTable, IDictionary<string, List<T>>> getTableFunction, List<T> result, Scope maxScope = Scope.Intrinsic) where T : Node
+        {
+            var table = getTableFunction.Invoke(this);
+            GetFromTable(head, table, result);
+            if (EnclosingScope != null && EnclosingScope.CurrentScope >= maxScope)
+            {
+                EnclosingScope.GetFromTableAndEnclosing2(head, getTableFunction, result, maxScope);
+            }
+        }
+
+
+
+        [NotNull]
         private List<T> GetFromTable<T>(string head, IDictionary<string, List<T>> table) where T : Node
         {
             if (head != null)
             {
-                List<T> values;
-                table.TryGetValue(head, out values);
+                table.TryGetValue(head, out List<T> values);
                 if (values != null) return values.ToList();
             }
             return new List<T>();
+        }
+
+        private void GetFromTable<T>(string head, IDictionary<string, List<T>> table, List<T> result) where T : Node
+        {
+            table.TryGetValue(head, out List<T> values);
+            if (values != null) result.AddRange(values);
         }
 
         #region DATA SYMBOLS

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -714,17 +714,17 @@ namespace TypeCobol.Compiler.CodeModel
         private static IEnumerable<DataDefinition> GetVariablesUnderTypeDefFromTableAndEnclosing(SymbolTable symbolTable, string name)
         {
             var currSymbolTable = symbolTable;
-            var datadefinitions = new List<DataDefinition>();
+            var dataDefinitions = new List<DataDefinition>();
             //Don't search into Intrinsic table because it's shared between all programs
             while (currSymbolTable != null && currSymbolTable.CurrentScope != Scope.Intrinsic) {
                 var result = GetVariablesUnderTypeDefinition(name, currSymbolTable);
                 if (result != null) {
-                    datadefinitions.AddRange(result);
+                    dataDefinitions.AddRange(result);
                 }
                 currSymbolTable = currSymbolTable.EnclosingScope;
             }
 
-            return datadefinitions;
+            return dataDefinitions;
         }
 
         

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -892,20 +892,28 @@ namespace TypeCobol.Compiler.CodeModel
             }
         }
 
+        public IList<TypeDefinition> EmptyTypeDefinitionList = new List<TypeDefinition>();
+        [NotNull]
         public IList<TypeDefinition> GetType(DataDefinition symbol)
         {
             return GetType(symbol.DataType);
         }
 
+        [NotNull]
         public List<TypeDefinition> GetType(SymbolReference symbolReference)
         {
             return GetType(symbolReference.URI);
         }
 
       
-
-        public List<TypeDefinition> GetType(DataType dataType, string pgmName = null)
+        [NotNull]
+        public IList<TypeDefinition> GetType(DataType dataType, string pgmName = null)
         {
+            if (dataType.CobolLanguageLevel == CobolLanguageLevel.Cobol85)
+            {
+                return EmptyTypeDefinitionList;
+            }
+
             var uri = new URI(dataType.Name);
             var types = GetType(uri);
             if (types.Count > 0)

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -307,9 +307,7 @@ namespace TypeCobol.Compiler.CodeModel
             var childrens = redefinesNode.Parent.Children;
             int index = redefinesNode.Parent.IndexOf(redefinesNode);
 
-            bool redefinedVariableFound = false;
-
-            while (!redefinedVariableFound && index >= 0)
+            while (index >= 0)
             {
                 CommonDataDescriptionAndDataRedefines child = childrens[index].CodeElement as CommonDataDescriptionAndDataRedefines;
 
@@ -974,10 +972,7 @@ namespace TypeCobol.Compiler.CodeModel
             return GetFunction(storageArea.SymbolReference, profile);
         }
 
-        public List<FunctionDeclaration> GetFunction(VariableBase variable, ParameterList profile = null)
-        {
-            return GetFunction(new URI(variable.ToString()), profile);
-        }
+        
 
         public List<FunctionDeclaration> GetFunction(SymbolReference symbolReference, ParameterList profile = null)
         {
@@ -1124,43 +1119,10 @@ namespace TypeCobol.Compiler.CodeModel
         public void AddProgram(Program program)
         {
             Add(Programs, program);
-        }
-
-        /// <summary>
-        /// Add Multiple programs to SymbolTable
-        /// </summary>
-        /// <param name="programs"></param>
-        public void AddPrograms(List<Program> programs)
-        {
-            foreach (var program in programs)
-            {
-                AddProgram(program);
-            }
-        }
-
-        public List<Program> GetProgram(StorageArea storageArea, ParameterList profile = null)
-        {
-            return GetProgram(storageArea.SymbolReference, profile);
-        }
-
-        public List<Program> GetProgram(VariableBase variable, ParameterList profile = null)
-        {
-            return GetProgram(new URI(variable.ToString()), profile);
-        }
-
-        public List<Program> GetProgram(SymbolReference symbolReference, ParameterList profile = null)
-        {
-            var uri = new URI(symbolReference.Name);
-            return GetProgram(uri, profile);
-        }
-
-        public List<Program> GetProgram(QualifiedName name, ParameterList profile = null)
-        {
-            var found = GetProgram(name.Head);
-            found = Get(found, name);
-
-            return found;
-        }
+        } 
+        
+        
+        
 
         [NotNull]
         private List<Program> GetProgram(string name)

--- a/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
@@ -147,7 +147,8 @@ namespace TypeCobol.Compiler.Diagnostics
                     var potentialVariables =
                         node.SymbolTable.GetVariablesExplicit(new URI(functionCaller.FunctionCall.FunctionName));
 
-                    if (functionDeclarations.Count == 1 && !potentialVariables.Any())
+                    var potentialVariablesCount = potentialVariables.Count();
+                    if (functionDeclarations.Count == 1 && potentialVariablesCount == 0)
                     {
                         functionCaller.FunctionDeclaration = functionDeclarations.First();
                         return; //Everything seems to be ok, lets continue on the next one
@@ -157,7 +158,7 @@ namespace TypeCobol.Compiler.Diagnostics
                         node.SymbolTable.GetFunction(new URI(functionCaller.FunctionCall.FunctionName), null,
                             functionCaller.FunctionCall.Namespace);
 
-                    if (potentialVariables.Count() > 1)
+                    if (potentialVariablesCount > 1)
                     {
                         //If there is more than one variable with the same name, it's ambiguous
                         message = string.Format("Call to '{0}'(no arguments) is ambigous. '{0}' is defined {1} times",
@@ -167,7 +168,7 @@ namespace TypeCobol.Compiler.Diagnostics
                         return;
                     }
 
-                    if (functionDeclarations.Count > 1 && !potentialVariables.Any())
+                    if (functionDeclarations.Count > 1 && potentialVariablesCount == 0)
                     {
                         message = string.Format("No suitable function signature found for '{0}(no arguments)'",
                             functionCaller.FunctionCall.FunctionName);
@@ -175,7 +176,7 @@ namespace TypeCobol.Compiler.Diagnostics
                         return;
                     }
 
-                    if (functionDeclarations.Count >= 1 && potentialVariables.Count() == 1)
+                    if (functionDeclarations.Count >= 1 && potentialVariablesCount == 1)
                     {
                         message = string.Format("Warning: Risk of confusion in call of '{0}'",
                             functionCaller.FunctionCall.FunctionName);
@@ -183,7 +184,7 @@ namespace TypeCobol.Compiler.Diagnostics
                         return;
                     }
 
-                    if (functionDeclarations.Count == 0 && !potentialVariables.Any())
+                    if (functionDeclarations.Count == 0 && potentialVariablesCount == 0)
                     {
                         message = string.Format("No function or variable found for '{0}'(no arguments)",
                             functionCaller.FunctionCall.FunctionName);
@@ -191,7 +192,7 @@ namespace TypeCobol.Compiler.Diagnostics
                         return; //Do not continue the function/procedure does not exists
                     }
 
-                    if (potentialVariables.Count() == 1)
+                    if (potentialVariablesCount == 1)
                         return; //Stop here, it's a standard Cobol call
                 }
 


### PR DESCRIPTION
Issues : #1294 #1301 #1302 #1114 
Here's a first set of optimization mainly focused on SymbolTable and one commit about TypeCobolLinker.

You can look at each commit separatly to understand the optimization done.

Gain obtained on each performance test:

_Note : One of the major optimization is only valid for unused variables.
So depending on the source file, you won't get the same result._


|                                                       |      | 
|-------------------------------------------------------|------| 
| Test                                                  | Gain | 
| Part1_FullParsing_Cobol85_NoRedefines                 | 6%   | 
| Part1_FullParsing_TC_BigTypesNoProcedure              | 34%  | 
| Part1_FullParsing_TC_BigTypesWithProcedure            | 18%  | 
| Part1_FullParsing_TC_GlobalStorage                    | 12%  | 
| Part1_Incremental_Cobol85_NoRedefines                 | 40%  | 
| Part1_Incremental_TC_BigTypesNoProcedure              | 71%  | 
| Part1_Incremental_TC_BigTypesWithProcedure            | 46%  | 
| Part1_Incremental_TC_GlobaStorage                     | 45%  | 
| Part2_FullParsing_TC_UseALotOfTypes_001Time           | 22%  | 
| Part2_FullParsing_TC_UseALotOfTypes_100Times          | 42%  | 
| Part2_FullParsing_TC_UseALotOfTypes_WithProc_100Times | 57%  | 
| Part2_Incremental_TC_UseALotOfTypes_001Time           | 57%  | 
| Part2_Incremental_TC_UseALotOfTypes_100Times          | 51%  | 
| Part2_Incremental_TC_UseALotOfTypes_WithProc_100Times | 87%  | 
| Part3_FullParsing_Cobol85_DeepVariables               | 22%  | 
| Part3_FullParsing_TC_DeepTypes                        | 51%  | 
| Part3_Incremental_Cobol85_DeepVariables               | 57%  | 
| Part3_Incremental_TC_DeepTypes                        | 73%  | 
