### PR TITLE
WI #1303 Move check picture to CodeElement phase

### DIFF
--- a/TypeCobol.Test/Parser/Programs/Cobol85/TypoParentheses.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/TypoParentheses.rdzMix.txt
@@ -1,4 +1,4 @@
-﻿       IDENTIFICATION DIVISION.
+       IDENTIFICATION DIVISION.
        PROGRAM-ID. DependOnPgm.
        ENVIRONMENT DIVISION.
        CONFIGURATION SECTION.
@@ -9,184 +9,184 @@
 
       * OK
        01 pic X(5).
-Line 12[8,18] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 12[15,17] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic X5).
-Line 13[8,19] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 13[15,18] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic X)5).
-Line 14[8,18] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 14[15,17] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic X(5.
       * OK
        01 pic X5.
-Line 17[8,18] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 17[15,17] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic X)5.
-Line 18[8,19] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 18[15,18] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic X(5(.
-Line 19[8,18] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 19[15,17] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic X5(.
-Line 20[8,19] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 20[15,18] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic X)5(.
 
       * OK
        01 pic S9(5)V9(5).
-Line 24[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 24[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95)V9(5).
-Line 25[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 25[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5)V9(5).
-Line 26[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 26[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5V9(5).
       * OK
        01 pic S95V9(5).
-Line 29[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 29[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5V9(5).
-Line 30[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 30[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5(V9(5).
-Line 31[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 31[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95(V9(5).
-Line 32[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 32[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5(V9(5).
-Line 33[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 33[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5)V95).
-Line 34[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 34[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95)V95).
-Line 35[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 35[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5)V95).
-Line 36[8,23] <27, Error, Syntax> - Syntax error : Given value is not correct : (5V95) expected numerical value only
+Line 36[15,22] <27, Error, Syntax> - Syntax error : Given value is not correct : (5V95) expected numerical value only
        01 pic S9(5V95).
-Line 37[8,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 37[15,21] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95V95).
-Line 38[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 38[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5V95).
-Line 39[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 39[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5(V95).
-Line 40[8,23] <27, Error, Syntax> - Syntax error : Given value is not correct : (V95) expected numerical value only
+Line 40[15,22] <27, Error, Syntax> - Syntax error : Given value is not correct : (V95) expected numerical value only
        01 pic S95(V95).
-Line 41[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 41[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5(V95).
-Line 42[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 42[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5)V9)5).
-Line 43[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 43[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95)V9)5).
-Line 44[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 44[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5)V9)5).
-Line 45[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 45[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5V9)5).
-Line 46[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 46[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95V9)5).
-Line 47[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 47[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5V9)5).
-Line 48[8,25] <27, Error, Syntax> - Syntax error : Given value is not correct : (5(V9) expected numerical value only
+Line 48[15,24] <27, Error, Syntax> - Syntax error : Given value is not correct : (5(V9) expected numerical value only
        01 pic S9(5(V9)5).
-Line 49[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 49[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95(V9)5).
-Line 50[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 50[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5(V9)5).
-Line 51[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 51[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5)V9(5.
-Line 52[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 52[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95)V9(5.
-Line 53[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 53[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5)V9(5.
-Line 54[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 54[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5V9(5.
-Line 55[8,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 55[15,21] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95V9(5.
-Line 56[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 56[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5V9(5.
-Line 57[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 57[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5(V9(5.
-Line 58[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 58[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95(V9(5.
-Line 59[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 59[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5(V9(5.
       * OK
        01 pic S9(5)V95.
-Line 62[8,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 62[15,21] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95)V95.
-Line 63[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 63[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5)V95.
-Line 64[8,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 64[15,21] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5V95.
       * OK
        01 pic S95V95.
-Line 67[8,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 67[15,21] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5V95.
-Line 68[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 68[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5(V95.
-Line 69[8,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 69[15,21] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95(V95.
-Line 70[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 70[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5(V95.
-Line 71[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 71[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5)V9)5.
-Line 72[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 72[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95)V9)5.
-Line 73[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 73[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5)V9)5.
-Line 74[8,23] <27, Error, Syntax> - Syntax error : Given value is not correct : (5V9) expected numerical value only
+Line 74[15,22] <27, Error, Syntax> - Syntax error : Given value is not correct : (5V9) expected numerical value only
        01 pic S9(5V9)5.
-Line 75[8,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 75[15,21] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95V9)5.
-Line 76[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 76[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5V9)5.
-Line 77[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 77[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5(V9)5.
-Line 78[8,23] <27, Error, Syntax> - Syntax error : Given value is not correct : (V9) expected numerical value only
+Line 78[15,22] <27, Error, Syntax> - Syntax error : Given value is not correct : (V9) expected numerical value only
        01 pic S95(V9)5.
-Line 79[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 79[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5(V9)5.
-Line 80[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 80[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5)V9(5(.
-Line 81[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 81[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95)V9(5(.
-Line 82[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 82[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5)V9(5(.
-Line 83[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 83[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5V9(5(.
-Line 84[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 84[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95V9(5(.
-Line 85[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 85[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5V9(5(.
-Line 86[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 86[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5(V9(5(.
-Line 87[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 87[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95(V9(5(.
-Line 88[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 88[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5(V9(5(.
-Line 89[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 89[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5)V95(.
-Line 90[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 90[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95)V95(.
-Line 91[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 91[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5)V95(.
-Line 92[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 92[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5V95(.
-Line 93[8,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 93[15,21] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95V95(.
-Line 94[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 94[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5V95(.
-Line 95[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 95[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5(V95(.
-Line 96[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 96[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95(V95(.
-Line 97[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 97[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5(V95(.
-Line 98[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 98[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5)V9)5(.
-Line 99[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 99[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95)V9)5(.
-Line 100[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 100[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5)V9)5(.
-Line 101[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 101[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5V9)5(.
-Line 102[8,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 102[15,22] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95V9)5(.
-Line 103[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 103[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5V9)5(.
-Line 104[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 104[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9(5(V9)5(.
-Line 105[8,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 105[15,23] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S95(V9)5(.
-Line 106[8,25] <27, Error, Syntax> - Syntax error : missing '(' or ')'
+Line 106[15,24] <27, Error, Syntax> - Syntax error : missing '(' or ')'
        01 pic S9)5(V9)5(.
 
        PROCEDURE DIVISION.

--- a/TypeCobol.Test/Parser/Programs/TypeCobol/ProcedureCall.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/ProcedureCall.rdzPGM.txt
@@ -1,5 +1,5 @@
 --- Diagnostics ---
-Line 15[12,15] <27, Error, Syntax> - Syntax error : Given value is not correct : (00ABC100) expected numerical value only OffendingSymbol=[12,15:varD]<UserDefinedWord>
+Line 15[29,39] <27, Error, Syntax> - Syntax error : Given value is not correct : (00ABC100) expected numerical value only OffendingSymbol=[29,39:X(00ABC100)]<PictureCharacterString>
 Line 27[37,39] <27, Error, Syntax> - Syntax error : mismatched input 'PIC' expecting {user defined word, CURRENCY, DATE} RuleStack=codeElement>tcCodeElement>functionDeclarationHeader>inputPhrase>parameterDescription>functionDataParameter>cobol2002TypeClause,  OffendingSymbol=[37,39:PIC]<PIC>
 Line 36[21,26] <27, Error, Syntax> - Syntax error : Parameter with name 'format' declared multiple times OffendingSymbol=[21,26:format]<UserDefinedWord>
 Line 37[21,26] <27, Error, Syntax> - Syntax error : Parameter with name 'format' declared multiple times OffendingSymbol=[21,26:format]<UserDefinedWord>

--- a/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
@@ -272,12 +272,8 @@ namespace TypeCobol.Compiler.Diagnostics
 
         public override bool Visit(DataDefinition dataDefinition)
         {
-            var commonDataDataDefinitionCodeElement = dataDefinition.CodeElement as CommonDataDescriptionAndDataRedefines;
-            if (commonDataDataDefinitionCodeElement!=null)
-            {
-                CheckPicture(dataDefinition);
-            }
-
+            var commonDataDataDefinitionCodeElement =
+                dataDefinition.CodeElement as CommonDataDescriptionAndDataRedefines;
 
             DataDefinitionEntry dataDefinitionEntry = dataDefinition.CodeElement;
             
@@ -379,38 +375,6 @@ namespace TypeCobol.Compiler.Diagnostics
                     "An index named '" + indexDefinition.Name + "' is already defined.", MessageCode.Warning);
             }
             return true;
-        }
-
-        public static void CheckPicture(Node node, CommonDataDescriptionAndDataRedefines customCodeElement = null)
-        {
-            var codeElement = customCodeElement ?? node.CodeElement as CommonDataDescriptionAndDataRedefines;
-            if (codeElement?.Picture == null) return;
-
-
-            // if there is not the same number of '(' than of ')'
-            if ((codeElement.Picture.Value.Split('(').Length - 1) != (codeElement.Picture.Value.Split(')').Length - 1))
-            {
-                DiagnosticUtils.AddError(node, "missing '(' or ')'");
-            }
-            // if the first '(' is after first ')' OR last '(' is after last ')'
-            else if (codeElement.Picture.Value.IndexOf("(", StringComparison.Ordinal) > codeElement.Picture.Value.IndexOf(")", StringComparison.Ordinal) ||
-                     codeElement.Picture.Value.LastIndexOf("(", StringComparison.Ordinal) > codeElement.Picture.Value.LastIndexOf(")", StringComparison.Ordinal))
-                DiagnosticUtils.AddError(node, "missing '(' or ')'");
-            else
-            {
-                foreach (Match match in Regex.Matches(codeElement.Picture.Value, @"\(([^)]*)\)"))
-                {
-                    try //Try catch is here because of the risk to parse a non numerical value
-                    {
-                        int.Parse(match.Value, System.Globalization.NumberStyles.AllowParentheses);
-                    }
-                    catch (Exception)
-                    {
-                        var m = "Given value is not correct : " + match.Value + " expected numerical value only";
-                        DiagnosticUtils.AddError(node, m, codeElement);
-                    }
-                }
-            }
         }
 
         public static DataDefinition CheckVariable(Node node, StorageArea storageArea, bool isReadStorageArea)

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
@@ -1115,7 +1115,7 @@ namespace TypeCobol.Compiler.Parser
             Context = context;
 			CodeElement = entry;
 
-		    TypeDefinitionEntryChecker.CheckRedefines(entry, context);
+            DataDescriptionChecker.CheckRedefines(entry, context);
 		}
 
 	    private void EnterCommonDataDescriptionAndDataRedefines(CommonDataDescriptionAndDataRedefines entry, CodeElementsParser.DataDescriptionEntryContext context)

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/TypeCobolCodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/TypeCobolCodeElementBuilder.cs
@@ -327,6 +327,8 @@ namespace TypeCobol.Compiler.Parser
                 parameter.Omittable = new SyntaxProperty<bool>(true, ParseTreeUtils.GetTokenFromTerminalNode(context.QUESTION_MARK()));
             }
 
+            DataDescriptionChecker.CheckPicture(parameter);
+
             return parameter;
         }
 

--- a/TypeCobol/Compiler/Parser/DiagnosticUtils.cs
+++ b/TypeCobol/Compiler/Parser/DiagnosticUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Analytics;
+using Antlr4.Runtime;
 using TypeCobol.Compiler.AntlrUtils;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.Diagnostics;
@@ -18,14 +19,9 @@ namespace TypeCobol.Compiler.Parser
             var parserDiag = new ParserDiagnostic(message, e.StartIndex + 1, e.StopIndex + 1, e.ConsumedTokens[0].Line, null, code);
             e.Diagnostics.Add(parserDiag);    
         }
-		internal static void AddError(CodeElement e, string message, Scanner.Token token, string rulestack = null, MessageCode code = MessageCode.SyntaxErrorInParser) {
+		internal static void AddError(CodeElement e, string message, IToken token, string rulestack = null, MessageCode code = MessageCode.SyntaxErrorInParser) {
             if (e.Diagnostics == null) e.Diagnostics = new List<Diagnostic>();
             var parserDiag = new ParserDiagnostic(message, token, rulestack, code);
-            e.Diagnostics.Add(parserDiag);
-        }
-	    internal static void AddError(CodeElement e, string message, DataDefinitionEntry data, string rulestack = null, MessageCode code = MessageCode.SyntaxErrorInParser) {
-            if (e.Diagnostics == null) e.Diagnostics = new List<Diagnostic>();
-            var parserDiag = new ParserDiagnostic(message, data.DataName.NameLiteral.Token, rulestack, code);
             e.Diagnostics.Add(parserDiag);
         }
 


### PR DESCRIPTION
Check picture on CodeElement phase instead of CrossCheck phase.
This increase performance of incremental mode.

Diagnostics on picture are now set on Picture Token instead of the whole
CodeElement.

Performance gain are:

|                                                       |      | 
|-------------------------------------------------------|------| 
| Test                                                  | Gain | 
| Part1_FullParsing_Cobol85_NoRedefines                 |      | 
| Part1_FullParsing_TC_BigTypesNoProcedure              |      | 
| Part1_FullParsing_TC_BigTypesWithProcedure            |      | 
| Part1_FullParsing_TC_GlobalStorage                    |      | 
| Part1_Incremental_Cobol85_NoRedefines                 | 13%  | 
| Part1_Incremental_TC_BigTypesNoProcedure              | 11%  | 
| Part1_Incremental_TC_BigTypesWithProcedure            | 15%  | 
| Part1_Incremental_TC_GlobaStorage                     | 15%  | 
| Part2_FullParsing_TC_UseALotOfTypes_001Time           |      | 
| Part2_FullParsing_TC_UseALotOfTypes_100Times          |      | 
| Part2_FullParsing_TC_UseALotOfTypes_WithProc_100Times |      | 
| Part2_Incremental_TC_UseALotOfTypes_001Time           | 25%  | 
| Part2_Incremental_TC_UseALotOfTypes_100Times          | 15%   | 
| Part2_Incremental_TC_UseALotOfTypes_WithProc_100Times | 19%  | 
| Part3_FullParsing_Cobol85_DeepVariables               |      | 
| Part3_FullParsing_TC_DeepTypes                        |      | 
| Part3_Incremental_Cobol85_DeepVariables               | 8%   | 
| Part3_Incremental_TC_DeepTypes                        | 5%   | 
