### PR TITLE
WI #1302 TypeCobolLinker refactoring

### DIFF
--- a/CLI/test/CLITest.cs
+++ b/CLI/test/CLITest.cs
@@ -87,6 +87,7 @@ namespace CLI.Test
         [TestMethod]
         public void TestDpendenciesNotLoadedInCorrectOrder() {
             CLITestHelper.Test("dependenciesNotLoadedInCorrectOrder", ReturnCode.ParsingDiagnostics);
+            CLITestHelper.Test("dependenciesNotLoadedInCorrectOrder_2", ReturnCode.Success);
         }
 
 

--- a/CLI/test/CLITest.cs
+++ b/CLI/test/CLITest.cs
@@ -81,6 +81,16 @@ namespace CLI.Test
             CLITestHelper.Test("dependencies_7_bad_call_proc", ReturnCode.ParsingDiagnostics);
         }
 
+        /// <summary>
+        /// Tests with a dependency that depends on a dependency which is loaded after itself.
+        /// </summary>
+        [TestMethod]
+        public void TestDpendenciesNotLoadedInCorrectOrder() {
+            CLITestHelper.Test("dependenciesNotLoadedInCorrectOrder", ReturnCode.ParsingDiagnostics);
+        }
+
+
+
 
         
 

--- a/CLI/test/CLITest.cs
+++ b/CLI/test/CLITest.cs
@@ -72,6 +72,14 @@ namespace CLI.Test
 #endif
         }
 
+        /// <summary>
+        /// Test various case of usage of dependencies that all ends with errors.
+        /// The purpose is also to not have a too big TestDependencies method/
+        /// </summary>
+        [TestMethod]
+        public void TestDependenciesWithErrors() {
+            CLITestHelper.Test("dependencies_7_bad_call_proc", ReturnCode.ParsingDiagnostics);
+        }
 
 
         

--- a/CLI/test/CLITest.cs
+++ b/CLI/test/CLITest.cs
@@ -72,6 +72,17 @@ namespace CLI.Test
 #endif
         }
 
+
+
+        
+
+            [TestMethod]
+        public void TestCircularTypedef_1()
+        {
+            CLITestHelper.Test("CircularTypedef_1", ReturnCode.ParsingDiagnostics);
+        }
+
+
         [TestMethod]
         public void TestEmptyDependency()
         {

--- a/CLI/test/ressources/CircularTypedef_1/CLIArguments.txt
+++ b/CLI/test/ressources/CircularTypedef_1/CLIArguments.txt
@@ -1,0 +1,1 @@
+﻿-1 -i input\MainPgm.tcbl -o output\MainPgm.rdz.cbl -d output\error.txt --dependencies input\DepA.tcbl --dependencies input\DepB.tcbl -e rdz

--- a/CLI/test/ressources/CircularTypedef_1/input/DepA.tcbl
+++ b/CLI/test/ressources/CircularTypedef_1/input/DepA.tcbl
@@ -1,0 +1,46 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DepA.
+
+       DATA DIVISION.
+       Working-STORAGE SECTION.
+
+      *Circular reference from MainType -> DepA -> DepB -> MainType
+      *Will be used by a variable
+       01 Type1 TYPEDEF STRICT PUBLIC.
+            05 DepAvar1-1 pic X.
+            05 DepAvar1-2 type DepB::Type1.
+
+      *Circular reference from MainType -> DepA -> DepB -> MainType
+      *Will be used by a procedure parameter
+       01 Type2 TYPEDEF STRICT PUBLIC.
+            05 DepAvar2-1 pic X.
+            05 DepAvar2-2 type DepB::Type2.
+
+      *Circular reference 
+      *MainType -> DepA -> DepB -> MainType (unused types)
+       01 UnusedType3 TYPEDEF STRICT PUBLIC.
+            05 DepAvar3-1 pic X.
+            05 DepAvar3-2 type DepB::UnusedType3.
+
+
+      *Circular reference from MainType -> DepB -> DepA -> MainType
+      *Will be used by a variable
+       01 Type11 TYPEDEF STRICT PUBLIC.
+            05 DepAvar11-1 pic X.
+            05 DepAvar11-2 type MainPgm::MainType11.
+
+      *Circular reference from MainType -> DepB -> DepA -> MainType
+      *Will be used by a procedure parameter
+       01 Type12 TYPEDEF STRICT PUBLIC.
+            05 DepAvar12-1 pic X.
+            05 DepAvar12-2 type MainPgm::MainType12.
+
+      *Circular reference 
+      *MainType -> DepB -> DepA -> MainType (unused types)
+       01 UnusedType13 TYPEDEF STRICT PUBLIC.
+            05 DepAvar13-1 pic X.
+            05 DepAvar13-2 type MainPgm::UnusedMainType3.
+
+
+       END PROGRAM DepA.
+

--- a/CLI/test/ressources/CircularTypedef_1/input/DepB.tcbl
+++ b/CLI/test/ressources/CircularTypedef_1/input/DepB.tcbl
@@ -1,0 +1,44 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DepB.
+
+       DATA DIVISION.
+       Working-STORAGE SECTION.
+      *Circular reference from MainType -> DepA -> DepB -> MainType
+      *Will be used by a variable
+       01 Type1 TYPEDEF STRICT PUBLIC.
+            05 DepBvar1-1 pic X.
+            05 DepBvar1-2 type MainPgm::MainType1.
+
+      *Circular reference from MainType -> DepA -> DepB -> MainType
+      *Will be used by a procedure parameter
+       01 Type2 TYPEDEF STRICT PUBLIC.
+            05 DepBvar2-1 pic X.
+            05 DepBvar2-2 type MainPgm::MainType2.
+
+      *Circular reference 
+      *MainType -> DepA -> DepB -> MainType (unused types)
+       01 UnusedType3 TYPEDEF STRICT PUBLIC.
+            05 DepBvar3-1 pic X.
+            05 DepBvar3-2 type MainPgm::UnusedMainType3.
+
+
+      *Circular reference from MainType -> DepB -> DepA -> MainType
+      *Will be used by a variable
+       01 Type11 TYPEDEF STRICT PUBLIC.
+            05 DepBvar11-1 pic X.
+            05 DepBvar11-2 type DepA::Type11.
+
+      *Circular reference from MainType -> DepB -> DepA -> MainType
+      *Will be used by a procedure parameter
+       01 Type12 TYPEDEF STRICT PUBLIC.
+            05 DepBvar12-1 pic X.
+            05 DepBvar12-2 type DepA::Type12.
+
+      *Circular reference 
+      *MainType -> DepB -> DepA -> MainType (unused types)
+       01 UnusedType13 TYPEDEF STRICT PUBLIC.
+            05 DepBvar13-1 pic X.
+            05 DepBvar13-2 type DepA::UnusedType13.
+
+       END PROGRAM DepB.
+

--- a/CLI/test/ressources/CircularTypedef_1/input/MainPgm.tcbl
+++ b/CLI/test/ressources/CircularTypedef_1/input/MainPgm.tcbl
@@ -1,0 +1,86 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. MainPgm.
+
+       DATA DIVISION.
+       working-storage section.
+
+
+      *Circular reference from MainType -> DepA -> DepB -> MainType
+      *Will be used by a variable
+       01 MainType1 TYPEDEF STRICT PUBLIC.
+            05 var1-1 pic X.
+            05 var1-2 type DepA::Type1.
+       01 foo1 type DepA::Type1.
+
+      *Circular reference from MainType -> DepA -> DepB -> MainType
+      *Will be used by a procedure parameter
+       01 MainType2 TYPEDEF STRICT PUBLIC.
+            05 var2-1 pic X.
+            05 var2-2 type DepA::Type2.
+
+      *Circular reference
+      *MainType -> DepA -> DepB -> MainType (unused types)
+      *Should be KO, but diagnostics on dependencies are not shown
+      * we except:
+      *Line 22[13,56] <30, Error, Semantics> - Semantic error: 
+      *TYPE 'MainPgm.MainUnusedType3' is not referenced
+       01 UnusedMainType3 TYPEDEF STRICT PUBLIC.
+            05 var3-1 pic X.
+            05 var3-2 type DepA::UnusedType3.
+
+
+      *Circular reference from MainType -> DepB -> DepA -> MainType
+      *Will be used by a variable
+       01 MainType11 TYPEDEF STRICT PUBLIC.
+            05 var11-1 pic X.
+            05 var11-2 type DepB::Type11.
+       01 foo10 type DepB::Type11.
+
+      *Circular reference from MainType -> DepB -> DepA -> MainType
+      *Will be used by a procedure parameter
+       01 MainType12 TYPEDEF STRICT PUBLIC.
+            05 var12-1 pic X.
+            05 var2-2 type DepB::Type12.
+
+      *Circular reference
+      *MainType -> DepB -> DepA -> MainType (unused types)
+      *Should be KO, but diagnostics on dependencies are not shown
+      * we except:
+      *Line 42[13,58] <30, Error, Semantics> - Semantic error: 
+      *TYPE 'MainPgm.MainUnusedType13' is not referenced
+       01 UnusedMainType13 TYPEDEF STRICT PUBLIC.
+            05 var13-1 pic X.
+            05 var13-2 type DepB::UnusedType13.
+
+
+
+       PROCEDURE DIVISION.
+           move foo1::var1-1 to var1-1
+           move foo10::var10-1 to var-10-1
+
+           .
+
+       declare procedure foo private
+      *Reference the type "MainType1" twice but in a different SymbolTable
+      *It's useful to check if TypeCobolLinker don't go in a infinite loop
+          input foo-var1       TYPE MainType1
+         .
+       PROCEDURE DIVISION.
+           move foo-var1::var1-2::DepAvar1-2::DepBvar1-2 to DepBvar1-2.
+       END-DECLARE.
+
+       declare procedure UseMainType2 private
+          input param2-1        TYPE DepA::Type2
+         .
+       PROCEDURE DIVISION.
+           CONTINUE.
+       END-DECLARE.
+
+       declare procedure UseDepBType12 private
+          input param12-1        TYPE DepB::Type12
+         .
+       PROCEDURE DIVISION.
+           CONTINUE.
+       END-DECLARE.
+       
+       END PROGRAM MainPgm.

--- a/CLI/test/ressources/CircularTypedef_1/output_expected/error.txt
+++ b/CLI/test/ressources/CircularTypedef_1/output_expected/error.txt
@@ -1,0 +1,10 @@
+ReturnCode=ParsingDiagnostics_
+8 errors in "input\MainPgm.tcbl":
+Line 12[13,39] <30, Error, Semantics> - Semantic error: Type circular reference detected : MainType1 -> Type1 -> Type1
+Line 19[13,39] <30, Error, Semantics> - Semantic error: Type circular reference detected : MainType2 -> Type2 -> Type2
+Line 36[13,41] <30, Error, Semantics> - Semantic error: Type circular reference detected : MainType11 -> Type11 -> Type11
+Line 43[13,40] <30, Error, Semantics> - Semantic error: Type circular reference detected : MainType12 -> Type12 -> Type12
+Line 59[24,30] <27, Error, Syntax> - Syntax error : Symbol foo10.var10-1 is not referenced
+Line 59[35,42] <27, Error, Syntax> - Syntax error : Symbol var-10-1 is not referenced
+Line 69[47,56] <27, Error, Syntax> - Syntax error : Symbol foo-var1.var1-2.DepAvar1-2.DepBvar1-2 is not referenced
+Line 69[61,70] <27, Error, Syntax> - Syntax error : Symbol DepBvar1-2 is not referenced

--- a/CLI/test/ressources/CircularTypedef_1/readme.txt
+++ b/CLI/test/ressources/CircularTypedef_1/readme.txt
@@ -1,0 +1,3 @@
+﻿Circular reference between MainPgm, DepA and DepB
+
+The output MainPgm must NO be generated

--- a/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder/CLIArguments.txt
+++ b/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder/CLIArguments.txt
@@ -1,0 +1,1 @@
+﻿-1 -i input\MainPgm.rdz.tcbl -o output\MainPgm.rdz.tcbl -d output\error.txt -e rdz --autoremarks --dependencies input\DVZTEST1.rdz.tcbl --dependencies input\DVZTEST2.rdz.tcbl

--- a/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder/input/DVZTEST1.rdz.tcbl
+++ b/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder/input/DVZTEST1.rdz.tcbl
@@ -1,0 +1,12 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DVZTEST1.
+       PROCEDURE DIVISION.
+       declare procedure GetTecMsg public
+           input capt     type DVZTEST2::Span
+           in-out msg     type DVZTEST2::Span
+           .
+       PROCEDURE DIVISION.
+            continue
+            .
+       end-declare.
+       end program DVZTEST1.

--- a/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder/input/DVZTEST2.rdz.tcbl
+++ b/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder/input/DVZTEST2.rdz.tcbl
@@ -1,0 +1,13 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DVZTEST2.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.                                               
+       01 Span typedef strict public.
+           05 ptr    pointer.
+           05 len       pic S9(5) comp-5.
+                88 isEmpty   value 0.
+                88 isEndPack value -1 -2.
+                88 isOverflow value -2.
+       PROCEDURE DIVISION.
+            GOBACK.
+       end program DVZTEST2.

--- a/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder/input/MainPgm.rdz.tcbl
+++ b/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder/input/MainPgm.rdz.tcbl
@@ -1,0 +1,33 @@
+﻿       identification division.
+       program-id. TCOSMPL2.
+       data division.
+       working-storage section.
+       01 type1 typedef strict private.
+       05 blabla pic X.
+      
+       01 s1 type DVZTEST2::Span.
+       01 dat type date.
+       01 t1 type type1.
+      
+       procedure division.
+       INIT-LIBRARY.
+      
+           call DVZTEST1::GetTecMsg INPUT t1
+           in-out s1
+      
+           call GetTecMsg input t1
+           in-out s1
+      
+      
+           goback.
+      *----------------------------------------------------------------
+       declare procedure GetTecMsg public
+           input capt     type DVZTEST2::Span
+           in-out msg     type DVZTEST2::Span
+           .
+       procedure division.
+           continue
+           .
+       end-declare.
+      
+       end program TCOSMPL2.

--- a/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder/output_expected/error.txt
+++ b/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder/output_expected/error.txt
@@ -1,0 +1,4 @@
+﻿ReturnCode=ParsingDiagnostics_
+2 errors in "input\MainPgm.rdz.tcbl":
+Line 15[12,20] <27, Error, Syntax> - Syntax error : Function 'DVZTEST1.GetTecMsg' expected parameter 'Span' of type Span and received 't1' of type type1 
+Line 18[12,20] <27, Error, Syntax> - Syntax error : Function 'GetTecMsg' expected parameter 'Span' of type Span and received 't1' of type type1 

--- a/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder_2/CLIArguments.txt
+++ b/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder_2/CLIArguments.txt
@@ -1,0 +1,1 @@
+﻿-1 -i input\MainPgm.rdz.tcbl -o output\MainPgm.rdz.tcbl -d output\error.txt -e rdz --autoremarks --dependencies input\DVZTEST1.rdz.tcbl --dependencies input\DVZTEST2.rdz.tcbl

--- a/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder_2/input/DVZTEST1.rdz.tcbl
+++ b/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder_2/input/DVZTEST1.rdz.tcbl
@@ -1,0 +1,21 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DVZTEST1.
+       data division.
+       working-storage section.
+       01 NamedSpan typedef strict public.
+           05 name      pic X(10).
+           05 group1.
+               10 span      type DVZTEST2::Span.
+        
+       01 NamedSpanArray typedef strict public.
+           05 namedSpan type DVZTEST1::NamedSpan
+       PROCEDURE DIVISION.
+       declare procedure GetTecMsg public
+           input capt     type DVZTEST2::Span
+           in-out msg     type DVZTEST2::Span
+           .
+       PROCEDURE DIVISION.
+            continue
+            .
+       end-declare.
+       end program DVZTEST1.

--- a/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder_2/input/DVZTEST2.rdz.tcbl
+++ b/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder_2/input/DVZTEST2.rdz.tcbl
@@ -1,0 +1,13 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DVZTEST2.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.                                               
+       01 Span typedef strict public.
+           05 ptr    pointer.
+           05 len       pic S9(5) comp-5.
+                88 isEmpty   value 0.
+                88 isEndPack value -1 -2.
+                88 isOverflow value -2.
+       PROCEDURE DIVISION.
+            GOBACK.
+       end program DVZTEST2.

--- a/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder_2/input/MainPgm.rdz.tcbl
+++ b/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder_2/input/MainPgm.rdz.tcbl
@@ -1,0 +1,34 @@
+﻿       identification division.
+       program-id. TCOSMPL2.
+       data division.
+       working-storage section.
+       01 type1 typedef strict private.
+       05 blabla pic X.
+       01 NSpan     TYPE DVZTEST1::NamedSpanArray.
+      
+       01 s1 type DVZTEST2::Span.
+       01 dat type date.
+       01 t1 type DVZTEST2::Span.
+      
+       procedure division.
+       INIT-LIBRARY.
+      
+           call DVZTEST1::GetTecMsg INPUT t1
+           in-out s1
+      
+           call GetTecMsg input t1
+           in-out s1
+      
+      
+           goback.
+      *----------------------------------------------------------------
+       declare procedure GetTecMsg public
+           input capt     type DVZTEST2::Span
+           in-out msg     type DVZTEST2::Span
+           .
+       procedure division.
+           continue
+           .
+       end-declare.
+      
+       end program TCOSMPL2.

--- a/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder_2/output_expected/MainPgm.rdz.tcbl
+++ b/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder_2/output_expected/MainPgm.rdz.tcbl
@@ -1,0 +1,213 @@
+      *TypeCobol_Version:0.1(alpha)
+       identification division.
+       program-id. TCOSMPL2.
+       data division.
+       working-storage section.
+       01 TC-DVZTEST1 pic X(08) value 'DVZTEST1'.
+       01 TC-Call          PIC X VALUE 'T'.
+           88 TC-FirstCall  VALUE 'T'.
+           88 TC-NthCall    VALUE 'F'
+                            X'00' thru 'S'
+                            'U' thru X'FF'.
+
+                               
+      *01 type1 typedef strict private.
+      *05 blabla pic X.
+      *01 NSpan     TYPE DVZTEST1::NamedSpanArray.
+       01 NSpan.
+           02 namedSpan.
+             03 name pic X(10).
+             03 group1.
+               04 span.
+                05  ptr Pointer.
+                05  redefines ptr.
+                    06  ptrdbef1f3d pic S9(05) comp-5.
+                 05 len pic S9(5) comp-5.
+                    88 isEmpty value 0.
+                    88 isEndPack value -1 -2.
+                    88 isOverflow value -2.
+                                                  
+      
+      *01 s1 type DVZTEST2::Span.
+       01 s1.
+          02  ptr Pointer.
+          02  redefines ptr.
+              03  ptrdbef1f3d pic S9(05) comp-5.
+           02 len pic S9(5) comp-5.
+              88 isEmpty value 0.
+              88 isEndPack value -1 -2.
+              88 isOverflow value -2.
+                                 
+      *01 dat type date.
+       01 dat.
+           02 YYYY PIC 9(4).
+           02 MM PIC 9(2).
+           02 DD PIC 9(2).
+                        
+      *01 t1 type DVZTEST2::Span.
+       01 t1.
+          02  ptr Pointer.
+          02  redefines ptr.
+              03  ptrdbef1f3d pic S9(05) comp-5.
+           02 len pic S9(5) comp-5.
+              88 isEmpty value 0.
+              88 isEndPack value -1 -2.
+              88 isOverflow value -2.
+                                 
+       01  TC-TCOSMPL2-FctList-Loaded PIC X(02).
+           88 TC-TCOSMPL2-FctList-IsLoaded      VALUE 'OK'.
+       01 TC-TCOSMPL2-PntTab.
+           05 TC-TCOSMPL2-PntNbr         PIC S9(04) COMP VALUE 1.
+      *To call program ea2e07d4GetTecMsg
+      *Which is generated code for TCOSMPL2.GetTecMsg
+      *Declared in source file MainPgm.rdz.tcbl
+           05 TC-TCOSMPL2-ea2e07d4-Idt   PIC X(08) VALUE 'ea2e07d4'.
+           05 TC-TCOSMPL2-ea2e07d4 PROCEDURE-POINTER.
+
+       LINKAGE SECTION.
+      *Common to all librairies used by the program.
+       01 TC-Library-PntTab.
+          05 TC-Library-PntNbr          PIC S9(04) COMP.
+          05 TC-Library-Item OCCURS 1000
+                               DEPENDING ON TC-Library-PntNbr
+                               INDEXED   BY TC-Library-Idx.
+              10 TC-Library-Item-Idt      PIC X(08).
+              10 TC-Library-Item-Pnt      PROCEDURE-POINTER.
+
+      *To call program a93b0351GetTecMsg in module DVZTEST1
+      *Which is generated code for DVZTEST1.GetTecMsg
+      *Declared in source file DVZTEST1.rdz.tcbl
+       01 TC-DVZTEST1-a93b0351-Item.
+          05 TC-DVZTEST1-a93b0351-Idt PIC X(08).
+          05 TC-DVZTEST1-a93b0351 PROCEDURE-POINTER.
+
+       01 PntTab-Pnt POINTER.
+
+      
+       procedure division USING PntTab-Pnt.
+                          
+      *
+      *    IF CallIsCopy
+      *      PERFORM Copy-Process-Mode
+      *    ELSE
+           PERFORM FctList-Process-Mode
+           perform INIT-LIBRARY
+      *    END-IF
+
+           GOBACK.
+
+        FctList-Process-Mode.
+            IF NOT TC-TCOSMPL2-FctList-IsLoaded
+              SET TC-TCOSMPL2-ea2e07d4   TO ENTRY 'ea2e07d4'
+
+              SET TC-TCOSMPL2-FctList-IsLoaded TO TRUE
+            END-IF
+               .
+
+            set PntTab-Pnt TO ADDRESS OF TC-TCOSMPL2-PntTab
+
+           .
+                          
+       INIT-LIBRARY.
+      *
+           PERFORM TC-INITIALIZATIONS
+
+                    
+      
+      *    call DVZTEST1::GetTecMsg INPUT t1
+      *    in-out s1
+           
+           IF ADDRESS OF TC-DVZTEST1-a93b0351-Item = NULL
+             OR TC-DVZTEST1-a93b0351-Idt not = 'a93b0351'
+               PERFORM TC-LOAD-POINTERS-DVZTEST1
+           END-IF
+      *    Equivalent to call a93b0351GetTecMsg in module DVZTEST1
+           CALL TC-DVZTEST1-a93b0351 USING
+                                 t1
+                    by reference s1
+           end-call
+                    
+      
+      *    call GetTecMsg input t1
+      *    in-out s1
+           CALL 'ea2e07d4GetTecMsg' USING
+                                 t1
+                    by reference s1
+           end-call
+                    
+      
+      
+           goback.
+      *=================================================================
+       TC-INITIALIZATIONS.
+      *=================================================================
+            IF TC-FirstCall
+                 SET TC-NthCall TO TRUE
+                 SET ADDRESS OF TC-DVZTEST1-a93b0351-Item  TO NULL
+            END-IF
+            .
+      *=================================================================
+        TC-LOAD-POINTERS-DVZTEST1.
+      *=================================================================
+            CALL 'ZCALLPGM' USING TC-DVZTEST1
+            ADDRESS OF TC-Library-PntTab
+            PERFORM VARYING TC-Library-Idx FROM 1 BY 1
+            UNTIL TC-Library-Idx > TC-Library-PntNbr
+                EVALUATE TC-Library-Item-Idt (TC-Library-Idx)
+                WHEN 'a93b0351'
+                     SET ADDRESS OF
+                     TC-DVZTEST1-a93b0351-Item
+                     TO ADDRESS OF
+                     TC-Library-Item(TC-Library-Idx)
+                WHEN OTHER
+                     CONTINUE
+                END-EVALUATE
+            END-PERFORM
+            .
+
+      *----------------------------------------------------------------
+      *declare procedure GetTecMsg public
+      *    input capt     type DVZTEST2::Span
+      *    in-out msg     type DVZTEST2::Span
+      *    .
+      
+       end program TCOSMPL2.
+      *
+      *declare procedure GetTecMsg public
+      *    input capt     type DVZTEST2::Span
+      *    in-out msg     type DVZTEST2::Span
+      *    .
+      *_________________________________________________________________
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ea2e07d4GetTecMsg.
+       DATA DIVISION.
+       LINKAGE SECTION.
+      *TCOSMPL2.GetTecMsg - Params :
+      *		input(capt: DVZTEST2.Span)
+      *		in-out(msg: DVZTEST2.Span)
+       01 capt.
+          02  ptr Pointer.
+          02  redefines ptr.
+              03  ptrdbef1f3d pic S9(05) comp-5.
+           02 len pic S9(5) comp-5.
+              88 isEmpty value 0.
+              88 isEndPack value -1 -2.
+              88 isOverflow value -2.
+       01 msg.
+          02  ptr Pointer.
+          02  redefines ptr.
+              03  ptrdbef1f3d pic S9(05) comp-5.
+           02 len pic S9(5) comp-5.
+              88 isEmpty value 0.
+              88 isEndPack value -1 -2.
+              88 isOverflow value -2.
+       PROCEDURE DIVISION
+             USING BY REFERENCE capt
+                   BY REFERENCE msg
+           .
+      *TCOSMPL2.GetTecMsg - Params :
+      *		input(capt: DVZTEST2.Span)
+      *		in-out(msg: DVZTEST2.Span)
+           continue
+           .
+       END PROGRAM ea2e07d4GetTecMsg.

--- a/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder_2/output_expected/error.txt
+++ b/CLI/test/ressources/dependenciesNotLoadedInCorrectOrder_2/output_expected/error.txt
@@ -1,0 +1,2 @@
+ReturnCode=Success_
+No error in "input\MainPgm.rdz.tcbl".

--- a/CLI/test/ressources/dependencies_7_bad_call_proc/CLIArguments.txt
+++ b/CLI/test/ressources/dependencies_7_bad_call_proc/CLIArguments.txt
@@ -1,0 +1,1 @@
+﻿-1 -i input\ProcedureCall-Public.rdz.tcbl -o output\ProcedureCall-Public.rdz.tcbl -d output\error.txt --dependencies input\Callee.rdz.tcbl -e rdz

--- a/CLI/test/ressources/dependencies_7_bad_call_proc/input/Callee.rdz.tcbl
+++ b/CLI/test/ressources/dependencies_7_bad_call_proc/input/Callee.rdz.tcbl
@@ -1,0 +1,34 @@
+﻿      *Callee contains public procedures and types
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Callee.
+       DATA DIVISION.
+       working-storage section.
+
+       01 TechnicalContext TYPEDEF STRICT PUBLIC.
+            05 TechName PIC X(8).
+            05 Site TYPE SITE.
+
+       01 SITE TYPEDEF STRICT PUBLIC.
+            05 SiteName PIC X(8).
+
+       PROCEDURE DIVISION.
+       
+       declare procedure check public
+          input mydate        TYPE Date
+         .
+       END-DECLARE.
+
+       declare procedure check2 public
+          input mydate        type Date
+                ctx           type TechnicalContext
+         .
+       END-DECLARE.
+
+       DECLARE PROCEDURE MyPublicProcedure PUBLIC
+           INPUT mydate        TYPE Date
+                 format        PIC X(08)
+          OUTPUT okay          TYPE Bool
+                 actual-format PIC X(08).
+         .
+       END-DECLARE.
+       END PROGRAM Callee.

--- a/CLI/test/ressources/dependencies_7_bad_call_proc/input/ProcedureCall-Public.rdz.tcbl
+++ b/CLI/test/ressources/dependencies_7_bad_call_proc/input/ProcedureCall-Public.rdz.tcbl
@@ -1,0 +1,43 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. PGM1.
+
+       DATA DIVISION.
+       Working-STORAGE SECTION.
+
+       01  somedate     TYPE Date.
+       01  someformat   PIC X(08).
+       01  flag         TYPE Bool.
+       01  realformat   PIC X(08).
+       01  W-TechCtx    TYPE CALLEE::TechnicalContext.
+
+       PROCEDURE DIVISION.
+
+
+           MOVE W-TechCtx::Site::SiteName TO someformat
+           .
+       P1.
+      *    OK  call check of PGM1
+           call Callee::check input somedate
+           .
+       P2.
+      *    KO, first argument missing
+           call Callee::check input 
+           .
+       P3.
+      *    KO, 2nd argument missing
+           call Callee::check2 input somedate W-TechCtx
+           .
+       P4.
+      *    KO, 2nd argument missing
+           call Callee::check2 input somedate
+           .
+       P5.
+      * OK : proper parameter list (TCRFUN_CALL_PUBLIC_ANY_PGM)
+           CALL Callee::MyPublicProcedure
+                    INPUT      somedate someformat
+                    OUTPUT     flag     realformat 
+
+
+           .
+       END PROGRAM PGM1.
+

--- a/CLI/test/ressources/dependencies_7_bad_call_proc/output_expected/error.txt
+++ b/CLI/test/ressources/dependencies_7_bad_call_proc/output_expected/error.txt
@@ -1,0 +1,7 @@
+ReturnCode=ParsingDiagnostics_
+5 errors in "input\ProcedureCall-Public.rdz.tcbl":
+Line 25[12,12] <27, Error, Syntax> - Syntax error : mismatched input '.' expecting {alphanumeric literal, numeric literal, symbol, special register, figurative constant, keyword}
+Line 24[12,35] <27, Error, Syntax> - Syntax error : No suitable function signature found for 'Callee.check' 
+Line 24[12,35] <27, Error, Syntax> - Syntax error : Function 'Callee.check' is missing parameter 'mydate' of type DATE and length 8
+Line 32[12,45] <27, Error, Syntax> - Syntax error : No suitable function signature found for 'Callee.check2' input(DATE)
+Line 32[12,45] <27, Error, Syntax> - Syntax error : Function 'Callee.check2' is missing parameter 'ctx' of type TechnicalContext and length 16

--- a/CLI/test/ressources/dependencies_7_bad_call_proc/readme.txt
+++ b/CLI/test/ressources/dependencies_7_bad_call_proc/readme.txt
@@ -1,0 +1,2 @@
+﻿Output:
+The Calee.rdz.tcbl must NO be generated

--- a/Codegen/src/Nodes/ParameterEntry.cs
+++ b/Codegen/src/Nodes/ParameterEntry.cs
@@ -49,7 +49,7 @@ internal class ParameterEntry: GenericNode<ParameterDescriptionEntry>, Generated
                     //Type exists from Cobol 2002
 				    string typedef = null;
 					if (this.CodeElement.DataType.CobolLanguageLevel >= TypeCobol.Compiler.CobolLanguageLevel.Cobol2002) {
-					    var type = this.Description?.TypeDefinition ?? this.SymbolTable.GetType(this.CodeElement.DataType).FirstOrDefault();
+					    var type = this.Description?.TypeDefinition;
 					    if (type != null)
 					    {
 							customtype = type;
@@ -84,7 +84,9 @@ internal class ParameterEntry: GenericNode<ParameterDescriptionEntry>, Generated
 
 				    if (picture == null && this.CodeElement.Usage == null && this.CodeElement.DataType.CobolLanguageLevel == Compiler.CobolLanguageLevel.Cobol85)
                     {//JCM humm... Type without picture lookup enclosing scope.
-                        var type = this.Description?.TypeDefinition ?? this.SymbolTable.GetType(this.CodeElement.DataType).FirstOrDefault();
+                       
+                        //TODO seems to be an impossible situation as we check if we are on Compiler.CobolLanguageLevel.Cobol85
+                        var type = this.Description?.TypeDefinition;
                         if (type != null)
                         {
                             customtype = type;

--- a/TypeCobol.Test/Parser/Programs/Cobol2002/ParserIntegration.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol2002/ParserIntegration.rdzPGM.txt
@@ -1,6 +1,6 @@
 --- Diagnostics ---
-Line 19[44,48] <27, Error, Syntax> - Syntax error : PICTURE clause incompatible with TYPE clause OffendingSymbol=[44,48:X(21)]<PictureCharacterString>
 Line 19[18,59] <30, Error, Semantics> - Semantic error: TYPE 'rib' is not referenced
+Line 19[44,48] <27, Error, Syntax> - Syntax error : PICTURE clause incompatible with TYPE clause OffendingSymbol=[44,48:X(21)]<PictureCharacterString>
 Line 23[44,48] <27, Error, Syntax> - Syntax error : PICTURE clause incompatible with TYPE clause OffendingSymbol=[44,48:X(08)]<PictureCharacterString>
 
 --- Program ---

--- a/TypeCobol.Test/Parser/Programs/Cobol2002/Typedef3-global.rdz.tcbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol2002/Typedef3-global.rdz.tcbl
@@ -35,19 +35,19 @@
 
 
       *Complex USED Typedef
-       01 Typedef1 TYPEDEF STRICT.
+       01 Typedef1 TYPEDEF STRICT global.
            05 td-var1         pic X.
            05 td-var10.
               10 td-var11     pic X.
               10 td-var12     pic X.
               10 td-var13     type Typedef2.
-       01 Typedef2 TYPEDEF STRICT.
+       01 Typedef2 TYPEDEF STRICT global.
            05 td-var2         pic X.
            05 td-var20.
               10 td-var21     pic X.
               10 td-var22     pic X.
               10 td-var23     type MainProgram::Typedef3.
-       01 Typedef3 TYPEDEF STRICT.
+       01 Typedef3 TYPEDEF STRICT global.
            05 td-var3         pic X.
            05 td-var30.
               10 td-var31     pic X.

--- a/TypeCobol.Test/Parser/Programs/Cobol2002/Typedef3-global.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol2002/Typedef3-global.rdzMix.txt
@@ -1,4 +1,4 @@
-﻿       IDENTIFICATION DIVISION.
+       IDENTIFICATION DIVISION.
        PROGRAM-ID. MainProgram.
        data division.
        working-storage section.
@@ -35,19 +35,19 @@
 
 
       *Complex USED Typedef
-       01 Typedef1 TYPEDEF STRICT.
+       01 Typedef1 TYPEDEF STRICT global.
            05 td-var1         pic X.
            05 td-var10.
               10 td-var11     pic X.
               10 td-var12     pic X.
               10 td-var13     type Typedef2.
-       01 Typedef2 TYPEDEF STRICT.
+       01 Typedef2 TYPEDEF STRICT global.
            05 td-var2         pic X.
            05 td-var20.
               10 td-var21     pic X.
               10 td-var22     pic X.
               10 td-var23     type MainProgram::Typedef3.
-       01 Typedef3 TYPEDEF STRICT.
+       01 Typedef3 TYPEDEF STRICT global.
            05 td-var3         pic X.
            05 td-var30.
               10 td-var31     pic X.

--- a/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdz.tcbl
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdz.tcbl
@@ -23,7 +23,76 @@
             05 MySecVariable PIC X.
             05 SelfRef    TYPE myType.
 
+       01 A1 typedef strict.
+            05 var1 type B1.
+
+       01 B1 typedef strict.
+            05 var1 type C1.
+
+       01 C1 typedef strict.
+            05 var1 type A1.
+
+
+      *Now backward
+       01 C2 typedef strict.
+            05 var2 type A2.
+
+       01 B2 typedef strict.
+            05 var2 type C2.
+
+       01 A2 typedef strict.
+            05 var2 type B2.
+
+      *Now backward
+       01 B3 typedef strict.
+            05 var3 type C3.
+
+       01 C3 typedef strict.
+            05 var3 type A3.
+
+       01 A3 typedef strict.
+            05 var3 type B3.
+
+
 
        PROCEDURE DIVISION.
             move MyVar1::myVar to MyVar2::secondGroup.
+       declare procedure CheckCircular private.
+       data division.
+       working-storage section.
+
+       01 A4 typedef strict.
+            05 var1 type B4.
+
+       01 B4 typedef strict.
+            05 var1 type C4.
+
+       01 C4 typedef strict.
+            05 var1 type A4.
+
+
+       end-declare.
+
+       declare procedure CheckCircular2 private.
+       data division.
+       working-storage section.
+
+       01 A5 typedef strict.
+            05 A5var type B5.
+
+       01 B5 typedef strict.
+            05 B5var type C5.
+
+       01 C5 typedef strict.
+            05 C5var type A5.
+
+       01 MyVar type A5.
+       procedure division.
+          move MyVar::A5var::B5Var::C5Var to MyVar::A5var::B5Var::C5Var
+ 
+      *KO, A5Var must not be a valid child of C5Var as it's a circular reference
+          move MyVar::A5var::B5Var::C5Var::A5Var 
+            to MyVar::A5var::B5Var::C5Var::A5Var
+          .
+       end-declare.
        END PROGRAM CircularRefCheck.

--- a/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdzMix.txt
@@ -5,23 +5,13 @@
        WORKING-STORAGE SECTION.
 
        01 ThirdType TYPEDEF STRICT.
-Line 8[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
+Line 8[13,35] <30, Error, Semantics> - Semantic error: Type circular reference detected : ThirdType -> myType
             05 renjgrn TYPE myType.
 
        01 myType TYPEDEF STRICT.
             05 myVar PIC X(10).
             05 secondGroup pic X.
-Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
-Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
-Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
-Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
-Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
             05 yhrtger    TYPE ThirdType.
-Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
-Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
-Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
-Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
-Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
             05 ezgoerk    TYPE MySendType.
 
        01 MyGroup.
@@ -33,7 +23,7 @@ Line 17[15,20] <30, Error, Semantics> - Semantic error: Variable 'MyVar1' has to
        01 MySendType TYPEDEF STRICT.
             05 MyVariable PIC X(10).
             05 MySecVariable PIC X.
-Line 24[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected
+Line 24[13,38] <30, Error, Semantics> - Semantic error: Type circular reference detected : MySendType -> myType
             05 SelfRef    TYPE myType.
 
 

--- a/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdzMix.txt
@@ -26,7 +26,83 @@ Line 17[15,20] <30, Error, Semantics> - Semantic error: Variable 'MyVar1' has to
 Line 24[13,38] <30, Error, Semantics> - Semantic error: Type circular reference detected : MySendType -> myType
             05 SelfRef    TYPE myType.
 
+       01 A1 typedef strict.
+            05 var1 type B1.
+
+       01 B1 typedef strict.
+            05 var1 type C1.
+
+       01 C1 typedef strict.
+Line 33[13,28] <30, Error, Semantics> - Semantic error: Type circular reference detected : C1 -> B1 -> A1
+            05 var1 type A1.
+
+
+      *Now backward
+       01 C2 typedef strict.
+            05 var2 type A2.
+
+       01 B2 typedef strict.
+Line 41[13,28] <30, Error, Semantics> - Semantic error: Type circular reference detected : B2 -> A2 -> C2
+            05 var2 type C2.
+
+       01 A2 typedef strict.
+            05 var2 type B2.
+
+      *Now backward
+       01 B3 typedef strict.
+            05 var3 type C3.
+
+       01 C3 typedef strict.
+            05 var3 type A3.
+
+       01 A3 typedef strict.
+Line 54[13,28] <30, Error, Semantics> - Semantic error: Type circular reference detected : A3 -> C3 -> B3
+            05 var3 type B3.
+
+
 
        PROCEDURE DIVISION.
             move MyVar1::myVar to MyVar2::secondGroup.
+       declare procedure CheckCircular private.
+       data division.
+       working-storage section.
+
+       01 A4 typedef strict.
+            05 var1 type B4.
+
+       01 B4 typedef strict.
+            05 var1 type C4.
+
+       01 C4 typedef strict.
+Line 71[13,28] <30, Error, Semantics> - Semantic error: Type circular reference detected : C4 -> B4 -> A4
+            05 var1 type A4.
+
+
+       end-declare.
+
+       declare procedure CheckCircular2 private.
+       data division.
+       working-storage section.
+
+       01 A5 typedef strict.
+            05 A5var type B5.
+
+       01 B5 typedef strict.
+            05 B5var type C5.
+
+       01 C5 typedef strict.
+Line 87[13,29] <30, Error, Semantics> - Semantic error: Type circular reference detected : C5 -> B5 -> A5
+            05 C5var type A5.
+
+       01 MyVar type A5.
+       procedure division.
+          move MyVar::A5var::B5Var::C5Var to MyVar::A5var::B5Var::C5Var
+ 
+      *KO, A5Var must not be a valid child of C5Var as it's a circular reference
+Line 94[44,48] <27, Error, Syntax> - Syntax error : Symbol MyVar.A5var.B5Var.C5Var.A5Var is not referenced
+          move MyVar::A5var::B5Var::C5Var::A5Var 
+Line 95[44,48] <27, Error, Syntax> - Syntax error : Symbol MyVar.A5var.B5Var.C5Var.A5Var is not referenced
+            to MyVar::A5var::B5Var::C5Var::A5Var
+          .
+       end-declare.
        END PROGRAM CircularRefCheck.

--- a/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdzPGM.txt
@@ -1,17 +1,7 @@
 --- Diagnostics ---
-Line 8[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:renjgrn]<UserDefinedWord>
-Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:yhrtger]<UserDefinedWord>
-Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:yhrtger]<UserDefinedWord>
-Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:yhrtger]<UserDefinedWord>
-Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:yhrtger]<UserDefinedWord>
-Line 13[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:yhrtger]<UserDefinedWord>
-Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:ezgoerk]<UserDefinedWord>
-Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:ezgoerk]<UserDefinedWord>
-Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:ezgoerk]<UserDefinedWord>
-Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:ezgoerk]<UserDefinedWord>
-Line 14[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:ezgoerk]<UserDefinedWord>
+Line 8[13,35] <30, Error, Semantics> - Semantic error: Type circular reference detected : ThirdType -> myType
 Line 17[15,20] <30, Error, Semantics> - Semantic error: Variable 'MyVar1' has to be limited to level 47 because of 'myType' maximum estimated children level OffendingSymbol=[15,20:MyVar1]<UserDefinedWord>
-Line 24[16,22] <30, Error, Semantics> - Semantic error: Type circular reference detected OffendingSymbol=[16,22:SelfRef]<UserDefinedWord>
+Line 24[13,38] <30, Error, Semantics> - Semantic error: Type circular reference detected : MySendType -> myType
 
 --- Program ---
 PROGRAM: CircularRefCheck common:False initial:False recursive:False

--- a/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/CircularReferenceType.rdzPGM.txt
@@ -2,6 +2,13 @@
 Line 8[13,35] <30, Error, Semantics> - Semantic error: Type circular reference detected : ThirdType -> myType
 Line 17[15,20] <30, Error, Semantics> - Semantic error: Variable 'MyVar1' has to be limited to level 47 because of 'myType' maximum estimated children level OffendingSymbol=[15,20:MyVar1]<UserDefinedWord>
 Line 24[13,38] <30, Error, Semantics> - Semantic error: Type circular reference detected : MySendType -> myType
+Line 33[13,28] <30, Error, Semantics> - Semantic error: Type circular reference detected : C1 -> B1 -> A1
+Line 41[13,28] <30, Error, Semantics> - Semantic error: Type circular reference detected : B2 -> A2 -> C2
+Line 54[13,28] <30, Error, Semantics> - Semantic error: Type circular reference detected : A3 -> C3 -> B3
+Line 71[13,28] <30, Error, Semantics> - Semantic error: Type circular reference detected : C4 -> B4 -> A4
+Line 87[13,29] <30, Error, Semantics> - Semantic error: Type circular reference detected : C5 -> B5 -> A5
+Line 94[44,48] <27, Error, Syntax> - Syntax error : Symbol MyVar.A5var.B5Var.C5Var.A5Var is not referenced OffendingSymbol=[44,48:A5Var]<UserDefinedWord>
+Line 95[44,48] <27, Error, Syntax> - Syntax error : Symbol MyVar.A5var.B5Var.C5Var.A5Var is not referenced OffendingSymbol=[44,48:A5Var]<UserDefinedWord>
 
 --- Program ---
 PROGRAM: CircularRefCheck common:False initial:False recursive:False
@@ -16,6 +23,24 @@ PROGRAM: CircularRefCheck common:False initial:False recursive:False
   ThirdType:ThirdType
   myType:myType
   MySendType:MySendType
+  A1:A1
+  B1:B1
+  C1:C1
+  C2:C2
+  B2:B2
+  A2:A2
+  B3:B3
+  C3:C3
+  A3:A3
+  A4:A4
+  B4:B4
+  C4:C4
+  A5:A5
+  B5:B5
+  C5:C5
+-- FUNCTIONS ---
+  CheckCircular
+  CheckCircular2
 --- Intrinsic
 -- TYPES -------
   BOOL:BOOL

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -195,11 +195,8 @@ namespace TypeCobol.Compiler.CodeModel
             //TypeDefinition must NOT be added to DataTypeEntries, only its children
             Debug.Assert(!(data is TypeDefinition)); 
 
-            //Types are declared in the Declarations SymbolTable
-            var table = GetTableFromScope(Scope.Declarations);
-            
             //Add symbol to the dictionary
-            Add(table.DataTypeEntries, data);
+            Add(this.DataTypeEntries, data);
         }
 
         public IEnumerable<DataDefinition> GetVariables(SymbolReference symbolReference)
@@ -686,6 +683,13 @@ namespace TypeCobol.Compiler.CodeModel
                 if (temp != null) {
                     resultDataDefinitions.AddRange(temp);
                 }
+
+                //Stop when we reach the first Global scope, because otherwise a nested program can end up searching in it the global scope of its parent
+                //Global is the most upper scope that can contains Typedef (GlobalStorage cannot contains typedef)
+                if (currSymbolTable.CurrentScope == Scope.Global) 
+                {
+                    break;
+                }
                 currSymbolTable = currSymbolTable.EnclosingScope;
             }
 
@@ -867,7 +871,7 @@ namespace TypeCobol.Compiler.CodeModel
             }
         }
 
-        public IList<TypeDefinition> EmptyTypeDefinitionList = new List<TypeDefinition>();
+        public List<TypeDefinition> EmptyTypeDefinitionList = new List<TypeDefinition>();
         [NotNull]
         public IList<TypeDefinition> GetType(DataDefinition symbol)
         {
@@ -882,7 +886,7 @@ namespace TypeCobol.Compiler.CodeModel
 
       
         [NotNull]
-        public IList<TypeDefinition> GetType(DataType dataType, string pgmName = null)
+        public List<TypeDefinition> GetType(DataType dataType, string pgmName = null)
         {
             if (dataType.CobolLanguageLevel == CobolLanguageLevel.Cobol85)
             {

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -30,36 +30,21 @@ namespace TypeCobol.Compiler.CodeModel
         public IEnumerable<DataDefinition> GetAllEnclosingTypeReferences(TypeDefinition currentTypeDef)
         {
             var result = new List<DataDefinition>();
+            
+
             SymbolTable symbolTable = this;//By default set this symboltable as the starting point
 
-            while (symbolTable.CurrentScope >= Scope.Namespace) //Loop on enclosing scope until null scope. 
+            while (symbolTable.CurrentScope > Scope.Namespace) //Loop on enclosing scope until we reach NameSpace 
             {
-                symbolTable.TypesReferences.TryGetValue(currentTypeDef, out var typeReferences);
-                if (typeReferences != null)
+                if (symbolTable.TypesReferences.TryGetValue(currentTypeDef, out var typeReferences))
                 {
                     result.AddRange(typeReferences);
-                }
 
-                if (symbolTable.CurrentScope == Scope.Namespace && symbolTable.Programs.Count > 0)
-                    //Some TypeReferences are stored only in program's symbolTable, need to seek into them. 
-                {
-                    foreach (var program in symbolTable.Programs.SelectMany(t => t.Value))
-                    {
-                        if (!program.SymbolTable.TypesReferences.IsNullOrEmpty())
-                        {
-
-                            program.SymbolTable.TypesReferences.TryGetValue(currentTypeDef, out var typeReferences2);
-                            if (typeReferences2 != null)
-                            {
-                                result.AddRange(typeReferences2);
-                            }
-                        }
-                    }
                 }
 
                 symbolTable = symbolTable.EnclosingScope; //Go to the next enclosing scope. 
             }
-            return result.Distinct();
+            return result.Distinct();//Distinct we are using path from 2 multiple SymbolTable and can have duplicate
         }
 
 
@@ -554,19 +539,16 @@ namespace TypeCobol.Compiler.CodeModel
                 //If typeDefContext is set : Ignore references of this typedefContext to avoid loop seeking
                 //                           Only takes variable references that are declared inside the typeDefContext
                 if (typeDefContext != null)
-                    references = references.Where(r => r.DataType != typeDefContext.DataType && r.ParentTypeDefinition == typeDefContext);
+                    references = references.Where(r => r.TypeDefinition != typeDefContext && r.ParentTypeDefinition == typeDefContext);
 
 
                 foreach (var reference in references)
                 {
                     //references property of a TypeDefinition can lead to variable in totally others scopes, like in another program
                     //So we need to check if we can access this variable
-                    if (reference.IsPartOfATypeDef || GetVariables(reference.Name).Contains(reference))
-                    {
-                        var newDataDefinitionPath = new DataDefinitionPath(dataDefinitionPath, reference);//Add the reference found to the dataDefinitionPath
+                    var newDataDefinitionPath = new DataDefinitionPath(dataDefinitionPath, reference);//Add the reference found to the dataDefinitionPath
 
-                        MatchVariable(foundedVariables, headDataDefinition, name, nameIndex, reference, newDataDefinitionPath, typeDefContext);
-                    }
+                    MatchVariable(foundedVariables, headDataDefinition, name, nameIndex, reference, newDataDefinitionPath, typeDefContext);
                 }
             }
 
@@ -591,25 +573,21 @@ namespace TypeCobol.Compiler.CodeModel
             //If typedefcontext is setted : Ignore references of this typedefContext to avoid loop seeking
             //                              + Only takes variable references that are declared inside the typeDefContext
             if (typeDefContext != null)
-                references = references.Where(r => r.DataType != typeDefContext.DataType && r.ParentTypeDefinition == typeDefContext);
+                references = references.Where(r => r.TypeDefinition != typeDefContext.TypeDefinition && r.ParentTypeDefinition == typeDefContext);
 
             foreach (var reference in references)
             {
                 var parentTypeDef = reference.ParentTypeDefinition;
-                if (parentTypeDef != null && parentTypeDef != typeDefContext)
+                if (parentTypeDef == null || parentTypeDef == typeDefContext)
+                {
+                    var newDataDefinitionPath = new DataDefinitionPath(dataDefinitionPath, reference);//Add the reference found to the dataDefinitionPath
+                    foundedVariables.Add(new KeyValuePair<DataDefinitionPath, DataDefinition>(newDataDefinitionPath, headDataDefinition));
+                    
+                }
+                else
                 {
                     var newDataDefinitionPath = new DataDefinitionPath(dataDefinitionPath, reference);//Add the reference found to the dataDefinitionPath
                     AddAllReference(foundedVariables, headDataDefinition, parentTypeDef, newDataDefinitionPath, typeDefContext);
-                }
-                else
-                { 
-                    //we are on a variable but ... references property of a TypeDefinition can lead to variable in totally others scopes, like in another program
-                    //So we need to check if we can access this variable OR check if the variable is declared inside the typeDefContext
-                    if (GetVariables(reference.Name).Contains(reference) || (typeDefContext != null && typeDefContext.Equals(parentTypeDef)))
-                    {
-                        var newDataDefinitionPath = new DataDefinitionPath(dataDefinitionPath, reference);//Add the reference found to the dataDefinitionPath
-                        foundedVariables.Add(new KeyValuePair<DataDefinitionPath, DataDefinition>(newDataDefinitionPath, headDataDefinition));
-                    }
                 }
             }
         }

--- a/TypeCobol/Compiler/CompilationUnit.cs
+++ b/TypeCobol/Compiler/CompilationUnit.cs
@@ -173,7 +173,7 @@ namespace TypeCobol.Compiler
                     SourceFile root = temporarySnapshot.Root;
                     List<Diagnostic> diagnostics = new List<Diagnostic>();
                     Dictionary<CodeElement, Node> nodeCodeElementLinkers = temporarySnapshot.NodeCodeElementLinkers ?? new Dictionary<CodeElement, Node>();
-                    ProgramClassParserStep.CrossCheckPrograms(root);
+                    ProgramClassParserStep.CrossCheckPrograms(root, temporarySnapshot);
               
                     // Capture the result of the parse in a new snapshot
                     ProgramClassDocumentSnapshot = new ProgramClassDocument(
@@ -221,11 +221,17 @@ namespace TypeCobol.Compiler
                     List<Diagnostic> newDiagnostics;
                     Dictionary<CodeElement, Node> nodeCodeElementLinkers = new Dictionary<CodeElement, Node>();
 
+                    List<DataDefinition> typedVariablesOutsideTypedef = new List<DataDefinition>();
+                    List<TypeDefinition> typeThatNeedTypeLinking = new List<TypeDefinition>();
+
                     //TODO cast to ImmutableList<CodeElementsLine> sometimes fails here
-                    ProgramClassParserStep.CupParseProgramOrClass(TextSourceInfo, ((ImmutableList<CodeElementsLine>)codeElementsDocument.Lines), CompilerOptions, CustomSymbols, perfStatsForParserInvocation, out root, out newDiagnostics, out nodeCodeElementLinkers);
+                    ProgramClassParserStep.CupParseProgramOrClass(TextSourceInfo, ((ImmutableList<CodeElementsLine>)codeElementsDocument.Lines), CompilerOptions, CustomSymbols, perfStatsForParserInvocation, out root, out newDiagnostics, out nodeCodeElementLinkers,
+                        out typedVariablesOutsideTypedef,
+                        out typeThatNeedTypeLinking);
 
                     // Capture the produced results
-                    TemporaryProgramClassDocumentSnapshot = new TemporarySemanticDocument(codeElementsDocument, new DocumentVersion<ICodeElementsLine>(this), codeElementsDocument.Lines,  root, newDiagnostics, nodeCodeElementLinkers);
+                    TemporaryProgramClassDocumentSnapshot = new TemporarySemanticDocument(codeElementsDocument, new DocumentVersion<ICodeElementsLine>(this), codeElementsDocument.Lines,  root, newDiagnostics, nodeCodeElementLinkers,
+                        typedVariablesOutsideTypedef, typeThatNeedTypeLinking);
 
                     // Stop perf measurement
                     PerfStatsForTemporarySemantic.OnStopRefreshParsingStep();

--- a/TypeCobol/Compiler/Diagnostics/Cobol2002Checker.cs
+++ b/TypeCobol/Compiler/Diagnostics/Cobol2002Checker.cs
@@ -150,6 +150,8 @@ namespace TypeCobol.Compiler.Diagnostics
                 DiagnosticUtils.AddError(redefinesNode, message, redefinesSymbolReference, code: MessageCode.SemanticTCErrorInParser);
                 return;
             }
+            redefinedVariable.AddDataRedefinition(redefinesNode);
+
 
             if (redefinedVariable.IsStronglyTyped || redefinedVariable.IsStrictlyTyped)
             {

--- a/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
@@ -229,6 +229,16 @@ namespace TypeCobol.Compiler.Diagnostics
             for (int c = 0; c < parameters.Count; c++)
             {
                 var expected = parameters[c];
+
+                //Hack until we get a real concept of project to build all of the dependencies
+                if (expected.CodeElement.UserDefinedDataType != null && expected.TypeDefinition == null)
+                {
+                    TypeCobolLinker.ResolveType(expected);
+                    if (expected.TypeDefinition != null)
+                    {
+                        TypeCobolLinker.CheckCircularReferences(expected.TypeDefinition);
+                    }
+                }
                 if (c < callArgsCount)
                 {
                     //Omitted

--- a/TypeCobol/Compiler/Diagnostics/TypeCobolLinker.cs
+++ b/TypeCobol/Compiler/Diagnostics/TypeCobolLinker.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.CodeElements.Expressions;
 using TypeCobol.Compiler.CodeModel;
@@ -11,142 +12,344 @@ using TypeCobol.Compiler.Parser;
 
 namespace TypeCobol.Compiler.Diagnostics
 {
-    public class TypeCobolLinker : AbstractAstVisitor
+    /// <summary>
+    /// TypeCobolLinker is responsible for:
+    /// - Resolve TypeDefinition.
+    ///    - It's the only class that can call SymbolTable.GetType() and set the property TypeDefinition on DataDefinition node
+    /// - Check circular reference between types
+    /// - Create a path between type reference and TypeDefinition in the SymbolTable (property SymbolTable.TypesReferences)
+    ///    - It's the only class that can update SymbolTable.TypesReferences
+    ///    - This path is not set for unused types
+    ///
+    ///
+    /// What is the "path" between type ? (SymbolTable.TypesReferences)
+    /// ----------------------------------------------------------
+    /// The path between type is used to search variables which are located under a typedef
+    /// and then find if a variable outside reference this type (directly or indirectly).
+    /// The path will link a DataDefinition that use the syntax (type XXXX) to a TypeDefinition.
+    ///
+    ///
+    /// Group1                  TypeA               TypeB                 TypeC
+    ///   var1                    A11 type typeB       B1                    C1
+    ///    var11 type typeA                             B2                    C2
+    ///                                                  B3 type typeC         C3
+    /// 
+    ///
+    /// Eg, with this SymbolReference:
+    /// var11::A11::B3::C3
+    /// 
+    /// We'll first find C3 under TypeC, then we need to know all DataDefinition that references TypeC.
+    /// So the path must start with: TypeC->B3
+    /// Then again, after B3 is found under TypeB, we need to find DataDefinition that references TypeB.
+    /// The path must continue with: TypeB->A11
+    /// ...
+    /// At the end, the full path path will be: TypeC->B3, TypeB->A11, TypeA->var11
+    /// As var11 is a variable outside a TypeDef, the path ends here.
+    ///
+    /// With the same SymbolReference but fully qualified:
+    /// var11::A11::B1::B2::B3::C1::C2::C3
+    /// The path will be exactly the same.
+    /// The path doesn't contains intermediate group-item.
+    ///
+    ///
+    /// Now when there are more Data/Definition/TypeDef
+    /// 
+    ///   Group1                  TypeA               TypeB                 TypeC
+    ///     var1                    A11 type typeB       B1                    C1
+    ///      var11 type typeA                             B2                    C2
+    ///                                                    B3 type typeC         C3
+    ///   
+    ///    Group2                  TypeZ
+    ///      var22                    Z11 type typeB
+    ///       var222 type typeZ     
+    ///
+    /// With a SymbolReference with Group2 it's the same logic.
+    /// var222::Z11::B3::C3
+    /// The path will be:
+    /// TypeC->B3, TypeB->Z11, TypeZ->var222
+    /// 
+    /// 
+    /// 
+    /// How the path is calculated/stored ? (SymbolTable.TypesReferences)
+    /// ------------------------------------------------------------------
+    /// The path will always contains a DataDefinition outside a Type.
+    /// So we use the SymbolTable of this DataDefinition to store the full path.
+    ///
+    /// In the previous example, if Group1 and Group2 are in 2 different SymbolTable, it means the full path will be stored twice.
+    /// It takes more time to construct the path but it ensure that when we use a path we'll always be sure to find variables accessible/visible to our SymbolTable.
+    ///
+    /// 
+    /// If all paths were common to all SymbolTable, then if Group1 and Group2 are in 2 different programs, there would be 2 downsides:
+    ///  - We'll spend time using path that takes us outside our visibility scope.
+    ///    - It's not a real problem on our unit test, but on big programs with a lot of dependencies this would be an issue.
+    ///  - At the end we need to check if the variable is accessible to our scope
+    ///
+    ///
+    ///
+    /// Optimization on path storage (SymbolTable.TypesReferences)
+    /// ------------------------------------------------------------
+    /// When 2 or more variable inside a typedef reference the same type, TypeCobolLinker will detect that and only store the path once.
+    /// 
+    /// 
+    /// </summary>
+    public class TypeCobolLinker 
     {
-        public override bool BeginNode(Node node)
-        {
-            return base.BeginNode(node);
-        }
-        public override bool BeginCodeElement(CodeElement codeElement)
-        {
-            return false; //We don't want to check deeper than Node
-        }
 
-        public override bool Visit(DataDescription dataEntry)
-        {
-            TypeReferencer(dataEntry, dataEntry.SymbolTable);
-            return true;
-        }
-
-        public override bool Visit(Paragraph paragraph)
-        {
-            return false;
-        }
-
-        public override bool Visit(Section section)
-        {
-            return false;
-        }
-
-        public override bool Visit(EnvironmentDivision environmentDivision)
-        {
-            return false;
-        }
-
-        public override bool IsStopVisitingChildren => false;
 
         /// <summary>
-        /// Do not visit children of IF.
-        /// Just in case there are statements directly under the procedure division.
+        /// This method will do the 3 actions:
+        ///   - Resolve TypeDefinition
+        ///   - Check circular references
+        ///   - Create a path between type reference and TypeDefinition
         /// </summary>
-        public override bool Visit(If _) => false;
-
-        /// <summary>
-        /// Do not visit children of Evaluate.
-        /// Just in case there are statements directly under the procedure division.
-        /// </summary>
-        public override bool Visit(Evaluate _) => false;
-
-        /// <summary>
-        /// Do not visit children of Perform.
-        /// Just in case there are statements directly under the procedure division.
-        /// </summary>
-        public override bool Visit(Perform _) => false;
-
-        public override bool Visit(Declaratives declaratives)
+        /// <param name="typedVariablesOutsideTypedef">Variable outside that use the "type" syntax</param>
+        /// <param name="typeThatNeedTypeLinking">Typedef that need all its typed children to be resolved (only use case for now is "Depending on")</param>
+        public static void LinkedTypedVariables([NotNull][ItemNotNull] in List<DataDefinition> typedVariablesOutsideTypedef, 
+            [NotNull][ItemNotNull] in List<TypeDefinition> typeThatNeedTypeLinking)
         {
-            return false;
-        }
+            //Stack to detect circular reference between types
+            Stack<DataDefinition> currentlyCheckedTypedefStack = new Stack<DataDefinition>();
 
-        public override bool Visit(ProcedureDivision procedureDivision)
-        {
-            var parent = procedureDivision.Parent as Program;
-            return parent != null && base.Visit(procedureDivision);
-        }
-
-        public override bool Visit(FunctionDeclaration funcDeclare)
-        {
-            //Get Function declaration parameters
-            var parameters = funcDeclare.Profile.Parameters;
-            if(funcDeclare.Profile.ReturningParameter != null)
-                parameters.Add(funcDeclare.Profile.ReturningParameter);
-
-            foreach (var dataEntry in parameters)
+            foreach (var dataDefinition in typedVariablesOutsideTypedef)
             {
-                TypeReferencer(dataEntry, dataEntry.SymbolTable);
+                //Warning, when you ask to parse multiple input files with CLI, then TypeDefinition of typedVariablesOutsideTypedef can already be resolved
+
+
+                if (ResolveType(dataDefinition)) //If type has been found in SymbolTable
+                {
+                    //Reference the path between the typedDataDefChild and its TypeDefinition on the SymbolTable on the original DataDefinition outside a typedef
+                    if (dataDefinition.SymbolTable.TypesReferences.TryGetValue(dataDefinition.TypeDefinition, out var dataDefsThatReferencedThisType))
+                    {
+                        //Link between the type and the dataDefinition cannot already be done
+                        System.Diagnostics.Debug.Assert(!dataDefsThatReferencedThisType.Contains(dataDefinition));
+
+                        //Type already referenced in our SymbolTable, it means all further typed children of the type have already been linked into this SymbolTable 
+                        dataDefsThatReferencedThisType.Add(dataDefinition);
+                    }
+                    else
+                    {
+                        dataDefinition.SymbolTable.TypesReferences.Add(dataDefinition.TypeDefinition, new List<DataDefinition> { dataDefinition });
+
+                        //First time this TypeDefinition is added to dataDefinition.SymbolTable, then link all children of the type
+                        LinkTypedChildren(dataDefinition.TypeDefinition, currentlyCheckedTypedefStack, dataDefinition.SymbolTable);
+                    }
+                }
             }
 
-            return base.Visit(funcDeclare);
+
+            //Now link type that use depending On
+            System.Diagnostics.Debug.Assert(currentlyCheckedTypedefStack.Count == 0, "Stack must be empty");
+            foreach (var typeDefinition in typeThatNeedTypeLinking)
+            {
+                LinkTypedChildren(typeDefinition, currentlyCheckedTypedefStack, typeDefinition.SymbolTable);
+            }
         }
 
-        private void TypeReferencer(DataDescription dataEntry, SymbolTable symbolTable)
+
+        public static void CheckCircularReferences([NotNull] TypeDefinition typeDefinition)
         {
-            if (symbolTable == null) return;
-            var types = symbolTable.GetType(dataEntry.DataType);
-            if (types.Count != 1)
+                                 
+            if (typeDefinition.TypedChildren.Count == 0                     //no typed children     
+                || typeDefinition.TypedChildren[0] == null                  //TypeDefinition of first children could not be resolved
+                || typeDefinition.TypedChildren[0].TypeDefinition != null)  //TypeDefinition of first children already resolved
             {
-                //Check the existing children, if they use a type
-                foreach (var child in dataEntry.Children) 
-                {
-                    if (child is DataDescription childDataDesc)
-                        TypeReferencer(childDataDesc, symbolTable);
-                }
+                //In these case, nothing to do because no children or job has already be done
                 return;
             }
-            var type = types.First();
-            dataEntry.TypeDefinition = type; //Set the TypeDefinition on DataDefinition Node so to avoid symbolTable access
 
-            //Check circular type reference
-            if (dataEntry.IsPartOfATypeDef)
+            //Stack to detect circular reference between types
+            Stack<DataDefinition> currentlyCheckedTypedefStack = new Stack<DataDefinition>();
+            LinkTypedChildren(typeDefinition, currentlyCheckedTypedefStack);
+        }
+
+        /// <summary>
+        /// This method will do the 3 actions:
+        ///   - Resolve TypeDefinition
+        ///   - Check circular references
+        ///   - Create a path between type reference and TypeDefinition
+        /// 
+        /// </summary>
+        /// <param name="currentlyCheckedTypedefStack"></param>
+        /// <param name="symbolTable"></param>
+        /// <param name="typeDefinition"></param>
+        private static void LinkTypedChildren([NotNull] TypeDefinition typeDefinition,
+            [CanBeNull] Stack<DataDefinition> currentlyCheckedTypedefStack0, [CanBeNull] SymbolTable symbolTable = null)
+        {
+
+            if (typeDefinition.TypedChildren.Count == 0)
             {
-                var circularRefInsideChildren = type.Children.Any(c =>
-                {
-                    DataDefinition dataChild = (DataDefinition)c;
-                    var childrenType = symbolTable.GetType(dataChild.DataType).FirstOrDefault();
-                    if (childrenType == null) return false;
-                    return dataEntry.ParentTypeDefinition == childrenType; //Circular reference detected will return true
-                });
+                return;
+            }
+            currentlyCheckedTypedefStack0?.Push(typeDefinition);
+            LinkTypedChildren0(currentlyCheckedTypedefStack0);
+            currentlyCheckedTypedefStack0?.Pop();
 
 
-                if (type == dataEntry.ParentTypeDefinition || circularRefInsideChildren)
+
+            //Only reason to use private method here, is because there are multiple return path in LinkTypedChildren0.
+            //So we can easily handle currentlyCheckedTypedefStack push/pop just above
+            void LinkTypedChildren0(Stack<DataDefinition> currentlyCheckedTypedefStack)
+            {
+                //If all typed children of typedef are resolved it means this typedef has already been fully linked
+                if (typeDefinition.TypedChildren[typeDefinition.TypedChildren.Count - 1] == null || typeDefinition.TypedChildren[typeDefinition.TypedChildren.Count - 1]?.TypeDefinition != null)
                 {
-                    DiagnosticUtils.AddError(dataEntry, "Type circular reference detected",
-                        dataEntry.CodeElement, code: MessageCode.SemanticTCErrorInParser);
-                    return; //Do not continue to prevent further work/crash with circular references
+                    //If symbolTable is null, it means we don't want to register link between TypeDefinition and DataDefinition that use it
+                    //So we can stop here.
+                    if (symbolTable == null)
+                    {
+                        return;
+                    }
+                    
+                    currentlyCheckedTypedefStack = null; //As typedef has already been linked, then no need to check circular reference
+                }
+
+
+                for (var i = 0; i < typeDefinition.TypedChildren.Count; i++)
+                {
+                    var typedDataDefChild = typeDefinition.TypedChildren[i];
+                    //If a typedDataDefChild is null it means is TypeDefinition could not be resolved or is part of a circular reference.
+                    //So let's continue to the next child.
+                    if (typedDataDefChild == null)
+                    {
+                        continue;
+                    }
+
+
+                    //Resolve type of typedDataDefChild if not already done yet
+                    if (typedDataDefChild.TypeDefinition == null)
+                    {
+                        if (!ResolveType(typedDataDefChild)) //Use the symbolTable of this typedDataDefChild to resolve the type
+                        {
+                            //No TypeDefinition found
+                            typeDefinition.TypedChildren[i] = null; //set to null so we don't try to check its TypeDefinition another time.
+                            continue;                               //Go to the next typed child
+                        }
+                    }
+
+
+                    System.Diagnostics.Debug.Assert(typedDataDefChild.TypeDefinition != null); //type must be resolved now
+
+
+                    //Detect circular reference
+                    if (currentlyCheckedTypedefStack?.Contains(typedDataDefChild.TypeDefinition) == true)
+                    {
+                        typeDefinition.TypedChildren[i] = null; //set this typed child to null so we don't enter this infinite loop another time
+                        DiagnosticUtils.AddError(typedDataDefChild, "Type circular reference detected : "
+                                                                    + string.Join(" -> ", currentlyCheckedTypedefStack.Select(t => t.Name)), code: MessageCode.SemanticTCErrorInParser);
+
+                        continue;//Go to the next typedChildren
+                                 //Do not make the link in symbolTable.TypesReferences with method ReferenceThisDataDefByThisType to avoid infinite loop in SymbolTable
+                    }
+
+
+                    if (symbolTable != null)//If we need to keep references between typed variable and type
+                    {
+                        //Reference the path between the typedDataDefChild and its TypeDefinition on the SymbolTable on the original DataDefinition outside a typedef
+                        if (!ReferenceThisDataDefByThisType(symbolTable, typedDataDefChild))
+                        {
+                            continue; //Type was already linked, so stop here
+                        }
+                    }
+
+
+                    //Continue to link children of typedDataDefChild.TypeDefinition
+                    LinkTypedChildren(typedDataDefChild.TypeDefinition, currentlyCheckedTypedefStack, symbolTable);
                 }
             }
+        }
 
-            if (dataEntry.CodeElement.IsGlobal)
-                symbolTable = symbolTable.GetTableFromScope(SymbolTable.Scope.Global);
+        /// <summary>
+        /// Lookup the TypeDefinition from the DataType of this dataDefinition.
+        /// If no TypeDefinition can be found, then property TypeDefinition stay null.
+        /// </summary>
+        /// <param name="dataDefinition"></param>
+        /// <returns>true if type has been resolved</returns>
+        public static bool ResolveType([NotNull] in DataDefinition dataDefinition)
+        {
+            //Note : dataDefinition.CodeElement cannot be null, only Index have a null CodeElement and Index cannot be typed
 
-            
-            if (symbolTable.TypesReferences.ContainsKey(type)) //If datatype already exists, add ref to the list
+
+            //Special hack until Visibility are fixed (#1081 and #938)
+            //As "Global" and "GlobalStorage" Scopes are above "Declarations" they cannot have access to "Declarations" scope.
+            //So types in "Declarations" scope cannot be reached from the SymbolTable of a variable declared as global or a variable inside global-storage.
+
+            //But a variable NOT global and not in global-storage can access the SymbolTable "Declarations" and "Global".
+            //So if we are in scopes "Global" or "GlobalStorage" we first need to retrieve a SymbolTable under "Declarations" and resolve the type using this SymbolTable.
+            List<TypeDefinition> types;
+            SymbolTable declarationsSymbolTable;
+            if (dataDefinition.SymbolTable.CurrentScope <= SymbolTable.Scope.Global)
             {
-                if (!symbolTable.TypesReferences[type].Contains(dataEntry))
-                    symbolTable.TypesReferences[type].Add(dataEntry);
+                //Retrieve the Scope Declarations by retrieving the SymbolTable of the program which is of Scope "Program".
+                //Then use the EnclosingScope which is of scope "Declarations"
+                declarationsSymbolTable = dataDefinition.GetProgramNode().SymbolTable.EnclosingScope;
             }
             else
             {
-                symbolTable.TypesReferences.Add(type, new List<DataDefinition> {dataEntry});
+                declarationsSymbolTable = dataDefinition.SymbolTable;
             }
+            System.Diagnostics.Debug.Assert(declarationsSymbolTable.CurrentScope >= SymbolTable.Scope.Declarations, "Scope of SymbolTable must be under Declarations until (#1081 and #938) are fixed");
 
-            //Also add all the typedChildren to reference list
-            foreach (var dataDescTypeChild in type.Children.Where(c => c is DataDescription))
+            types = declarationsSymbolTable.GetType(dataDefinition.CodeElement.DataType);
+            //End special hack
+
+            //When (#1081 and #938) are fixed, remove the hack above and simply use the following line: 
+            //var types = dataDefinition.SymbolTable.GetType(dataDefinition.CodeElement.DataType);
+
+
+
+            if (types.Count < 1)
             {
-                TypeReferencer(dataDescTypeChild as DataDescription, symbolTable);
+                string message = "TYPE \'" + dataDefinition.CodeElement.DataType + "\' is not referenced";
+                DiagnosticUtils.AddError(dataDefinition, message, MessageCode.SemanticTCErrorInParser);
             }
-        }
-        
+            else if (types.Count > 1)
+            {
+                string message = "Ambiguous reference to TYPE \'" + dataDefinition.CodeElement.DataType + "\'";
+                DiagnosticUtils.AddError(dataDefinition, message, MessageCode.SemanticTCErrorInParser);
+            }
+            else
+            {
+                dataDefinition.TypeDefinition = types[0];
+                dataDefinition.DataType.RestrictionLevel = types[0].DataType.RestrictionLevel;
+                return true;
+            }
 
+            return false;
+        }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="symbolTable"></param>
+        /// <param name="dataDefinition">Data definition that reference a Type.</param>
+        /// <returns>true if reference has been set. False is reference was already made</returns>
+        private static bool ReferenceThisDataDefByThisType([NotNull] in SymbolTable symbolTable, [NotNull] in DataDefinition dataDefinition)
+        {
+            //Reminder on symbolTable.TypesReferences Dictionary
+            //Key is TypeDefinition, Value is List<DataDefinition>
+            //
+            //TypesReferences can be understood/read as:
+            //TypeDefinition is referenced by these DataDefinitions
+
+
+            //Do NOT use the SymbolTable of the DataDefinition because we are linking all types references to the first
+            //dataDefinition outside typedef (see explanation at top of the class).
+            if (symbolTable.TypesReferences.TryGetValue(dataDefinition.TypeDefinition, out var dataDefsThatReferencedThisType))
+            {
+                if (dataDefsThatReferencedThisType.Contains(dataDefinition))
+                {
+                    return false;
+                }
+                dataDefsThatReferencedThisType.Add(dataDefinition);
+            }
+            else
+            {
+                //Same here, don't use the SymbolTable of the DataDefinition
+                symbolTable.TypesReferences.Add(dataDefinition.TypeDefinition, new List<DataDefinition> { dataDefinition });
+            }
+
+            return true;
+        }
     }
 }

--- a/TypeCobol/Compiler/Diagnostics/TypeCobolLinker.cs
+++ b/TypeCobol/Compiler/Diagnostics/TypeCobolLinker.cs
@@ -28,12 +28,6 @@ namespace TypeCobol.Compiler.Diagnostics
             return true;
         }
 
-        public override bool Visit(DataRedefines dataRedefinition)
-        {
-            RedefinitionReferencer(dataRedefinition);
-            return base.Visit(dataRedefinition);
-        }
-
         public override bool Visit(Paragraph paragraph)
         {
             return false;
@@ -152,14 +146,7 @@ namespace TypeCobol.Compiler.Diagnostics
                 TypeReferencer(dataDescTypeChild as DataDescription, symbolTable);
             }
         }
-
-        private void RedefinitionReferencer(DataRedefines dataRedefinition)
-        {
-            SymbolReference redefined = dataRedefinition.CodeElement.RedefinesDataName;
-            var result = dataRedefinition.SymbolTable.GetRedefinedVariable(dataRedefinition, redefined);
-
-            result?.AddDataRedefinition(dataRedefinition);
-        }
+        
 
     }
 }

--- a/TypeCobol/Compiler/Nodes/Data.cs
+++ b/TypeCobol/Compiler/Nodes/Data.cs
@@ -261,6 +261,7 @@ namespace TypeCobol.Compiler.Nodes {
             get { return _typeDefinition; }
             set
             {
+                //Implementation note : Only TypeCobolLinker should set this value
                 if (_typeDefinition == null)
                     _typeDefinition = value;
             }
@@ -815,7 +816,10 @@ namespace TypeCobol.Compiler.Nodes {
     // [COBOL 2002]
     public class TypeDefinition: DataDefinition, Parent<DataDescription>, IDocumentable
     {
-        public TypeDefinition([NotNull] DataTypeDescriptionEntry entry) : base(entry) { }
+        public TypeDefinition([NotNull] DataTypeDescriptionEntry entry) : base(entry)
+        {
+            TypedChildren = new List<DataDefinition>();
+        }
 
         [NotNull]
         public new DataTypeDescriptionEntry CodeElement => (DataTypeDescriptionEntry) base.CodeElement;
@@ -826,6 +830,17 @@ namespace TypeCobol.Compiler.Nodes {
             return base.VisitNode(astVisitor) && astVisitor.Visit(this);
         }
 
+        /// <summary>
+        /// List of all children that reference a type.
+        /// Element of this list can be null if :
+        ///  - the child reference an unknown type, it'll be set to null in this list.
+        ///  - We detect a circular reference between type. To avoid infinite loop one link of the circular reference will be set to null.
+        ///
+        /// ProgramClassBuilder to initialize this list.
+        /// Only TypeCobolLinker can check the link and set items to null.
+        /// </summary>
+        [NotNull][ItemCanBeNull]
+        public List<DataDefinition>  TypedChildren { get;  }
 
         public override bool IsPartOfATypeDef => true;
 

--- a/TypeCobol/Compiler/Parser/TemporarySemanticDocument.cs
+++ b/TypeCobol/Compiler/Parser/TemporarySemanticDocument.cs
@@ -12,7 +12,11 @@ namespace TypeCobol.Compiler.Parser
 
     public class TemporarySemanticDocument : ICompilerStepDocumentSnapshot<ICodeElementsLine, ICodeElementsLine>
     {
-        public TemporarySemanticDocument(CodeElementsDocument previousSnapShot, DocumentVersion<ICodeElementsLine> codeElementsLinesVersion, ISearchableReadOnlyList<ICodeElementsLine> codeElementsLines, SourceFile root, [NotNull] List<Diagnostic> diagnostics, Dictionary<CodeElement, Node> nodeCodeElementLinkers)
+        public TemporarySemanticDocument(CodeElementsDocument previousSnapShot, DocumentVersion<ICodeElementsLine> codeElementsLinesVersion, 
+            ISearchableReadOnlyList<ICodeElementsLine> codeElementsLines, SourceFile root, [NotNull] List<Diagnostic> diagnostics, 
+            Dictionary<CodeElement, Node> nodeCodeElementLinkers, 
+            List<DataDefinition> typedVariablesOutsideTypedef, 
+            List<TypeDefinition> typeThatNeedTypeLinking)
         {
             PreviousStepSnapshot = previousSnapShot;
             Root = root;
@@ -21,11 +25,21 @@ namespace TypeCobol.Compiler.Parser
             TextSourceInfo = previousSnapShot.TextSourceInfo;
             CurrentVersion = codeElementsLinesVersion;
             Lines = codeElementsLines;
+            TypedVariablesOutsideTypedef = typedVariablesOutsideTypedef;
+            TypeThatNeedTypeLinking = typeThatNeedTypeLinking;
         }
 
         public TextSourceInfo TextSourceInfo { get; set; }
         public SourceFile Root { get; private set; }
         public Dictionary<CodeElement, Node> NodeCodeElementLinkers { get; private set; }
+
+
+        [NotNull] [ItemNotNull]
+        public List<DataDefinition> TypedVariablesOutsideTypedef { get; }
+
+        [NotNull][ItemNotNull]
+        public List<TypeDefinition> TypeThatNeedTypeLinking { get; }
+
         /// <summary>
         /// Errors found while parsing Program or Class
         /// </summary>


### PR DESCRIPTION
Issues #1302 #1326 #1327 #1338 #1295

WI #1302 TypeCobolLinker refactoring but doesn't change its goals:
- Resolve type reference
- Detect circular reference between typedef
- Register link between type and variable in SymbolTable

TypeCobolLinker is now in CrossCheck phase.
It doesn't check/link dependencies directly but start Type resolution from the main file.
This allows to fix #1326 and #1338.
It means the loading order of dependencies doesn't affect the work of TypeCobolLinker.

As a TypeCobolLinker only start its work from the main file, it means that unused Typedef and procedure in dependencies won't be resolved anymore.
Type of used procedure will only be resolved,

WI #1295 TypeCobolLinker can now detect circular references between more than 2 types.
It can also handle circular references between main file and dependencies.

WI #1327 Fix global but it requires new TypeCobolLinker thats why it's merged in the same commit.
The correct SymbolTable is now associated with global Node.


This refactoring allow a good performance boost when you use the same type multiple times:

|                                                       |                 | 
|-------------------------------------------------------|-----------------| 
| Test                                                  | Gain| 
| Part1_FullParsing_Cobol85_NoRedefines                 |                 | 
| Part1_FullParsing_TC_BigTypesNoProcedure              |                 | 
| Part1_FullParsing_TC_BigTypesWithProcedure            |                 | 
| Part1_FullParsing_TC_GlobalStorage                    |                 | 
| Part1_Incremental_Cobol85_NoRedefines                 |                 | 
| Part1_Incremental_TC_BigTypesNoProcedure              |                 | 
| Part1_Incremental_TC_BigTypesWithProcedure            |                 | 
| Part1_Incremental_TC_GlobaStorage                     |                 | 
| Part2_FullParsing_TC_UseALotOfTypes_001Time           |                 | 
| Part2_FullParsing_TC_UseALotOfTypes_100Times          | 16%             | 
| Part2_FullParsing_TC_UseALotOfTypes_WithProc_100Times | 21%             | 
| Part2_Incremental_TC_UseALotOfTypes_001Time           | 7%              | 
| Part2_Incremental_TC_UseALotOfTypes_100Times          | 45%             | 
| Part2_Incremental_TC_UseALotOfTypes_WithProc_100Times | 53%             | 
| Part3_FullParsing_Cobol85_DeepVariables               | 6%              | 
| Part3_FullParsing_TC_DeepTypes                        | 11%             | 
| Part3_Incremental_Cobol85_DeepVariables               | 13%             | 
| Part3_Incremental_TC_DeepTypes                        | 26%             | 

