### PR TITLE
WI #1303 #1294 Checker and DataType.Equals optimizations

### DIFF
--- a/TypeCobol/Compiler/CodeElements/Entry/DataType.cs
+++ b/TypeCobol/Compiler/CodeElements/Entry/DataType.cs
@@ -34,11 +34,16 @@ namespace TypeCobol.Compiler.CodeElements
 			return other == this;
 		}
 
-		public static bool operator ==(DataType x, DataType y) {
-			if (Object.ReferenceEquals(x, null) && Object.ReferenceEquals(y, null)) return true;
-			if (Object.ReferenceEquals(x, null) || Object.ReferenceEquals(y, null)) return false;
-			return x.Name.ToUpper() == y.Name.ToUpper();
-		}
+		public static bool operator ==(DataType x, DataType y)
+        {
+            //Data instance for Cobol85 are unique so we can compare reference
+            if (Object.ReferenceEquals(x, y)) return true;
+            if (x?.CobolLanguageLevel == CobolLanguageLevel.Cobol85 ||
+                y?.CobolLanguageLevel == CobolLanguageLevel.Cobol85) return false;
+
+            if (Object.ReferenceEquals(x, null) || Object.ReferenceEquals(y, null)) return false;
+            return x.Name.Equals(y.Name, StringComparison.OrdinalIgnoreCase);
+        }
 		public static bool operator !=(DataType x, DataType y) {
 			return !(x == y);
 		}

--- a/TypeCobol/Compiler/Diagnostics/Cobol2002Checker.cs
+++ b/TypeCobol/Compiler/Diagnostics/Cobol2002Checker.cs
@@ -167,13 +167,8 @@ namespace TypeCobol.Compiler.Diagnostics
 
     class RenamesChecker
     {
-        public static void OnNode(Node node)
+        public static void OnNode(DataRenames renames)
         {
-            var renames = node as DataRenames;
-            if (renames == null)
-            {
-                return; //not my job
-            }
             if (renames.CodeElement?.RenamesFromDataName != null)
                 Check(renames.CodeElement.RenamesFromDataName, renames);
             if(renames.CodeElement?.RenamesToDataName != null)
@@ -220,10 +215,9 @@ namespace TypeCobol.Compiler.Diagnostics
 
         private static List<Node> browsedTypes = new List<Node>();
 
-        public static void OnNode(Node node)
+        public static void OnNode(DataDefinition dataDefinition)
         {
-            DataDefinition dataDefinition = node as DataDefinition;
-            if (dataDefinition == null || node is TypeDefinition)
+            if (dataDefinition is TypeDefinition)
             {
                 return; //not my job
             }
@@ -232,7 +226,7 @@ namespace TypeCobol.Compiler.Diagnostics
             if (data != null && data.UserDefinedDataType != null && data.Picture != null)
             {
                 string message = "PICTURE clause incompatible with TYPE clause";
-                DiagnosticUtils.AddError(node, message, data.Picture.Token);
+                DiagnosticUtils.AddError(dataDefinition, message, data.Picture.Token);
             }
 
             var type = dataDefinition.DataType;
@@ -243,14 +237,14 @@ namespace TypeCobol.Compiler.Diagnostics
 
             if (data.LevelNumber.Value == 88 || data.LevelNumber.Value == 66)
             {
-                DiagnosticUtils.AddError(node,
+                DiagnosticUtils.AddError(dataDefinition,
                     string.Format("A {0} level variable cannot be typed", data.LevelNumber.Value),
                     data, code: MessageCode.SemanticTCErrorInParser);
             }
 
             if (data.LevelNumber.Value == 77 && foundedType.Children.Count > 0)
             {
-                DiagnosticUtils.AddError(node, "A 77 level variable cannot be typed with a type containing children",
+                DiagnosticUtils.AddError(dataDefinition, "A 77 level variable cannot be typed with a type containing children",
                     data, code: MessageCode.SemanticTCErrorInParser);
             }
 
@@ -264,7 +258,7 @@ namespace TypeCobol.Compiler.Diagnostics
                         string.Format(
                             "Variable '{0}' has to be limited to level {1} because of '{2}' maximum estimated children level",
                             data.Name, data.LevelNumber.Value - (simulatedTypeLevel - 49), foundedType.Name);
-                    DiagnosticUtils.AddError(node, message, data, code: MessageCode.SemanticTCErrorInParser);
+                    DiagnosticUtils.AddError(dataDefinition, message, data, code: MessageCode.SemanticTCErrorInParser);
                 }
             }
 
@@ -272,7 +266,7 @@ namespace TypeCobol.Compiler.Diagnostics
             if (type == DataType.Boolean && data.InitialValue != null &&
                 data.InitialValue.LiteralType != Value.ValueLiteralType.Boolean)
             {
-                DiagnosticUtils.AddError(node, "Boolean type requires TRUE/FALSE value clause",
+                DiagnosticUtils.AddError(dataDefinition, "Boolean type requires TRUE/FALSE value clause",
                     MessageCode.SemanticTCErrorInParser);
             }
         }

--- a/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
@@ -376,12 +376,24 @@ namespace TypeCobol.Compiler.Diagnostics
         /// Test if the received DataDefinition has other children than DataConditionEntry or DataRenamesEntry
         /// </summary>
         /// <param name="dataDefinition">Item to check</param>
-        /// <returns>True if there are only DataConditionEntry or DataRenamesEntry childrens</returns>
-        private static bool HasChildrenThatDeclareData(DataDefinition dataDefinition)
+        /// <returns>True if there are only DataConditionEntry or DataRenamesEntry children</returns>
+        private static bool HasChildrenThatDeclareData([NotNull] DataDefinition dataDefinition)
         {
-            return dataDefinition.Children.Any(elem=>elem.CodeElement != null && 
-                                                     elem.CodeElement.Type != CodeElementType.DataConditionEntry && 
-                                                     elem.CodeElement.Type != CodeElementType.DataRenamesEntry);
+            //We only need to check the last children:
+            //DataConditionEntry is a level 88, DataRenamesEntry is level 66 and they cannot have children
+            //DataDescription and DataRedefines are level between 1 and 49 inclusive.
+            //As the level number drive the positioning of Node inside the Children property DataConditionEntry and DataRenamesEntry will always be
+            //positioned before dataDescription.
+            if (dataDefinition.ChildrenCount > 0)
+            {
+                var lastChild = ((DataDefinition) dataDefinition.Children[dataDefinition.ChildrenCount - 1]);
+
+                return lastChild.CodeElement != null 
+                       && lastChild.CodeElement.Type != CodeElementType.DataConditionEntry 
+                       && lastChild.CodeElement.Type != CodeElementType.DataRenamesEntry;
+            }
+
+            return false;
         }
 
         public override bool Visit(IndexDefinition indexDefinition)

--- a/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
@@ -291,7 +291,8 @@ namespace TypeCobol.Compiler.Diagnostics
                 if (dataDefinitionParent != null)
                 {
                     //Check if DataDefinition is level 88 and declared under a Type BOOL variable
-                    if (dataDefinitionParent.DataType == DataType.Boolean && levelNumberValue == 88)
+                    //Perf note: first compare levelNumberValue because it's faster than DataType
+                    if (levelNumberValue == 88 && dataDefinitionParent.DataType == DataType.Boolean)
                     {
                         DiagnosticUtils.AddError(dataDefinition,
                             "The Level 88 symbol '" + dataDefinition.Name + "' cannot be declared under a BOOL typed symbol");

--- a/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
@@ -45,12 +45,13 @@ namespace TypeCobol.Compiler.Diagnostics
                 CheckVariable(node, codeElement.StorageAreaGroupsCorrespondingImpact.ReceivingGroupItem, false);
             }
 
-            FunctionCallChecker.OnNode(node);
-            TypedDeclarationChecker.OnNode(node);
-            RenamesChecker.OnNode(node);
-            ReadOnlyPropertiesChecker.OnNode(node);
-            GlobalStorageSectionChecker.OnNode(node);
+            return true;
+        }
 
+
+        public override bool Visit(GlobalStorageSection globalStorageSection)
+        {
+            GlobalStorageSectionChecker.OnNode(globalStorageSection);
             return true;
         }
 
@@ -72,6 +73,19 @@ namespace TypeCobol.Compiler.Diagnostics
             RedefinesChecker.OnNode(dataRedefines);
             return true;
         }
+        public override bool Visit(DataRenames dataRenames)
+        {
+            RenamesChecker.OnNode(dataRenames);
+            return true;
+        }
+
+        public override bool Visit(ProcedureStyleCall call)
+        {
+            FunctionCallChecker.OnNode(call);
+            return true;
+        }
+
+        
 
         public override bool Visit(PerformProcedure performProcedureNode)
         {
@@ -267,11 +281,14 @@ namespace TypeCobol.Compiler.Diagnostics
         public override bool VisitVariableWriter(VariableWriter variableWriter)
         {
             WriteTypeConsistencyChecker.OnNode(variableWriter, CurrentNode);
+            ReadOnlyPropertiesChecker.OnNode(variableWriter, CurrentNode);
             return true;
         }
 
         public override bool Visit(DataDefinition dataDefinition)
         {
+            TypedDeclarationChecker.OnNode(dataDefinition);
+
             var commonDataDataDefinitionCodeElement = dataDefinition.CodeElement as CommonDataDescriptionAndDataRedefines;
             if (commonDataDataDefinitionCodeElement!=null)
             {

--- a/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
@@ -21,14 +21,8 @@ namespace TypeCobol.Compiler.Diagnostics
     {
         private static string[] READONLY_DATATYPES = {"DATE",};
 
-        public static void OnNode([NotNull] Node node)
+        public static void OnNode([NotNull] VariableWriter variableWriter, Node node)
         {
-            VariableWriter variableWriter = node as VariableWriter;
-            if (variableWriter == null)
-            {
-                return; //not our job
-            }
-
             var element = node.CodeElement as VariableWriter;
             if (element?.VariablesWritten != null)
                 foreach (var pair in element.VariablesWritten)
@@ -999,14 +993,11 @@ namespace TypeCobol.Compiler.Diagnostics
 
     public class GlobalStorageSectionChecker
     {
-        public static void OnNode([NotNull] Node node)
+        public static void OnNode([NotNull] GlobalStorageSection globalStorageSection)
         {
-            var globalStorageSection = node as GlobalStorageSection;
-            if (globalStorageSection == null) return;
-
             //Check if GlobalStorageSection is declared in main program Rule - GLOBALSS_ONLY_IN_MAIN 
             if (!globalStorageSection.GetProgramNode().IsMainProgram)
-                DiagnosticUtils.AddError(node,
+                DiagnosticUtils.AddError(globalStorageSection,
                     "GLOBAL-STORAGE SECTION is only authorized in the main program of this source file.");
 
             //Check every GlobalStorageSection DataDefinition (children)

--- a/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
@@ -47,10 +47,10 @@ namespace TypeCobol.Compiler.Diagnostics
         private static void checkReadOnly(Node node, [NotNull] Node receiving)
         {
             var rtype = receiving.Parent as DataDefinition;
-            if (rtype == null) return;
+            if (rtype == null || rtype.DataType.CobolLanguageLevel == CobolLanguageLevel.Cobol85) return;
             foreach (var type in READONLY_DATATYPES)
             {
-                if (type.Equals(rtype.DataType.Name.ToUpper()))
+                if (type.Equals(rtype.DataType.Name, StringComparison.OrdinalIgnoreCase))
                     DiagnosticUtils.AddError(node, type + " properties are read-only");
             }
         }


### PR DESCRIPTION
#1303
- Checker Visitor now use the most derivated method.
   - Instead of calling some checkers on "BeginNode" method, call them with the most derivated method.
- DataDefinition : Only use last child to detect children that declare data

WI #1294 Misc optimization for DataType.Equals
Use StringComparison.OrdinalIgnoreCase instead to convert the string to uppercase.

Performance gain:

|                                                       |      | 
|-------------------------------------------------------|------| 
| Test                                                  | Gain | 
| Part1_FullParsing_Cobol85_NoRedefines                 | 2%   | 
| Part1_FullParsing_TC_BigTypesNoProcedure              | 2%   | 
| Part1_FullParsing_TC_BigTypesWithProcedure            | 5%   | 
| Part1_FullParsing_TC_GlobalStorage                    | 5%   | 
| Part1_Incremental_Cobol85_NoRedefines                 | 12%  | 
| Part1_Incremental_TC_BigTypesNoProcedure              | 11%  | 
| Part1_Incremental_TC_BigTypesWithProcedure            | 10%  | 
| Part1_Incremental_TC_GlobaStorage                     | 11%  | 
| Part2_FullParsing_TC_UseALotOfTypes_001Time           | 3%   | 
| Part2_FullParsing_TC_UseALotOfTypes_100Times          | 4%   | 
| Part2_FullParsing_TC_UseALotOfTypes_WithProc_100Times | 3%   | 
| Part2_Incremental_TC_UseALotOfTypes_001Time           | 2%   | 
| Part2_Incremental_TC_UseALotOfTypes_100Times          | 4%   | 
| Part2_Incremental_TC_UseALotOfTypes_WithProc_100Times | 8%   | 
| Part3_FullParsing_Cobol85_DeepVariables               | 3%   | 
| Part3_FullParsing_TC_DeepTypes                        | 3%   | 
| Part3_Incremental_Cobol85_DeepVariables               | 5%   | 
| Part3_Incremental_TC_DeepTypes                        | 15%  | 
