### PR TITLE
WI #1385 Avoid NullReferenceException when completing a DEPENDING ON …

### DIFF
--- a/TypeCobol.LanguageServer/Completion Factory/CompletionFactory.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionFactory.cs
@@ -548,7 +548,7 @@ namespace TypeCobol.LanguageServer
             if (node == null)
                 return completionItems;
 
-            IEnumerable<DataDefinition> potentialVariables = null;
+            var potentialVariables = Enumerable.Empty<DataDefinition>();
             var userFilterText = userFilterToken == null ? string.Empty : userFilterToken.Text;
             Expression<Func<DataDefinition, bool>> variablePredicate =
                 da =>


### PR DESCRIPTION
…clause
(see issue #1385)

Completion after `DEPENDING ON` is NOT supported, this hotfix only prevents the exception to be thrown. The completion results will be empty in the considered case of the issue.