### PR TITLE
1552 unwanted line breaks

### DIFF
--- a/Codegen/test/TestTypeCobolCodegen.cs
+++ b/Codegen/test/TestTypeCobolCodegen.cs
@@ -901,6 +901,15 @@ namespace TypeCobol.Codegen {
             CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "OmittableParameters") + ".rdz.tcbl", skeletons);
         }
 
+        [TestMethod]
+        [TestCategory("Codegen")]
+        [TestProperty("Time", "fast")]
+        public void PreserveLineBreaksAndIndents()
+        {
+            var skeletons = UseSkeleton ? CodegenTestUtils.ParseConfig(Path.Combine("TypeCobol", "skeletons") + ".xml") : null;
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "PreserveLineBreaksAndIndents") + ".rdz.tcbl", skeletons);
+        }
+
 #if EUROINFO_RULES
         [TestMethod]
         [TestCategory("Codegen")]

--- a/Codegen/test/resources/input/TypeCobol/PreserveLineBreaksAndIndents.rdz.tcbl
+++ b/Codegen/test/resources/input/TypeCobol/PreserveLineBreaksAndIndents.rdz.tcbl
@@ -1,0 +1,15 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. RB1LEQU1.
+       procedure division.
+      *Issue #1552: Picture was mistakenly split across multiple lines
+       declare procedure Foo2
+                 input  EquipementObject PIC X(3)
+                        EquipementMainReference
+                                         PIC S9(4)
+                        EquipementSecondaryReference
+                                         PIC S9(4)
+                        EquipementOccurrence
+                                         PIC S9(4).
+       procedure division.
+       end-declare.
+       end program RB1LEQU1.

--- a/Codegen/test/resources/output/TypeCobol/PreserveLineBreaksAndIndents.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/PreserveLineBreaksAndIndents.rdz.tcbl
@@ -1,0 +1,49 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. RB1LEQU1.
+       procedure division.
+      *Issue #1552: Picture was mistakenly split across multiple lines
+      *declare procedure Foo2
+      *          input  EquipementObject PIC X(3)
+      *                 EquipementMainReference
+      *                                  PIC S9(4)
+      *                 EquipementSecondaryReference
+      *                                  PIC S9(4)
+      *                 EquipementOccurrence
+      *                                  PIC S9(4).
+       end program RB1LEQU1.
+      *
+      *declare procedure Foo2
+      *          input  EquipementObject PIC X(3)
+      *                 EquipementMainReference
+      *                                  PIC S9(4)
+      *                 EquipementSecondaryReference
+      *                                  PIC S9(4)
+      *                 EquipementOccurrence
+      *                                  PIC S9(4).
+      *_________________________________________________________________
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ce3384b8.
+       DATA DIVISION.
+       LINKAGE SECTION.
+      *RB1LEQU1.Foo2 - Params :
+      *		input(EquipementObject: pic X(3), EquipementMainReference: pic
+      *S9(4), EquipementSecondaryReference: pic S9(4), EquipementOccurre
+      *nce: pic S9(4))
+       01 EquipementObject PIC X(3).
+       01 EquipementMainReference
+                                         PIC S9(4).
+       01 EquipementSecondaryReference
+                                         PIC S9(4).
+       01 EquipementOccurrence
+                                         PIC S9(4).
+       PROCEDURE DIVISION
+             USING BY REFERENCE EquipementObject
+                   BY REFERENCE EquipementMainReference
+                   BY REFERENCE EquipementSecondaryReference
+                   BY REFERENCE EquipementOccurrence
+           .
+      *RB1LEQU1.Foo2 - Params :
+      *		input(EquipementObject: pic X(3), EquipementMainReference: pic
+      *S9(4), EquipementSecondaryReference: pic S9(4), EquipementOccurre
+      *nce: pic S9(4))
+       END PROGRAM ce3384b8.

--- a/TypeCobol/Compiler/Text/CobolTextLine.cs
+++ b/TypeCobol/Compiler/Text/CobolTextLine.cs
@@ -116,30 +116,35 @@ namespace TypeCobol.Compiler.Text
         public static ICollection<ITextLine> CreateCobolLines(ColumnsLayout layout, int index, char indicator, string indent, string text, int pmax, int pmin, bool bConvertFirstLine)
         {
             var result = new List<ITextLine>();
-            int max = pmax;
-            int min = pmax;
-            int nLine = (text.Length / max) + ((text.Length % max) != 0 ? 1 : 0);
-            if (nLine == 1)
+            foreach (var part in text.Split(new[] { Environment.NewLine, "\n", "\r" }, StringSplitOptions.None))
             {
-                result.Add(new TextLineSnapshot(index, bConvertFirstLine ? Convert(layout, text, indicator, indent, pmax) : text, null));
-                return result;
-            }
-            if (indicator == ' ')
-            {
-                max = pmax;
-                min = pmin;
-                indicator = '-';
-            }
+                int max = pmax;
+                int min = pmax;
+                int nLine = (part.Length / max) + ((part.Length % max) != 0 ? 1 : 0);
+                if (nLine == 1)
+                {
+                    result.Add(new TextLineSnapshot(index, bConvertFirstLine ? Convert(layout, part, indicator, indent, pmax) : part, null));
+                }
+                else
+                {
+                    if (indicator == ' ')
+                    {
+                        max = pmax;
+                        min = pmin;
+                        indicator = '-';
+                    }
 
-            IList<Tuple<string, bool>> lines = Split(text, max, min);
+                    IList<Tuple<string, bool>> lines = Split(part, max, min);
 
-            for (int i = 0; i < lines.Count; i++)
-            {
-                if (index > -1) index++;
-                result.Add(new TextLineSnapshot(index,(i == 0 && !bConvertFirstLine) ? lines[i].Item1 : Convert(layout, lines[i].Item1,
-                    indicator != '-'
-                    ? indicator
-                    : ((lines[i].Item2 && i != 0) ? indicator : (i == 0 ? NoIndicator : NoOneIndicator)), indent, pmax), null));
+                    for (int i = 0; i < lines.Count; i++)
+                    {
+                        if (index > -1) index++;
+                        result.Add(new TextLineSnapshot(index, (i == 0 && !bConvertFirstLine) ? lines[i].Item1 : Convert(layout, lines[i].Item1,
+                            indicator != '-'
+                                ? indicator
+                                : ((lines[i].Item2 && i != 0) ? indicator : (i == 0 ? NoIndicator : NoOneIndicator)), indent, pmax), null));
+                    }
+                }
             }
             return result;
         }


### PR DESCRIPTION
Fix for issue #1552.

The idea behind this fix is that the line breaks added by `TypedDataNode.FlushConsumedTokens` were not considered as line breaks but as standard characters. This would lead to errors when splitting based on length. Now the splitting process starts by splitting over line breaks and then apply length restrictions.