### PR TITLE
WI #1747 Use TypeDefinition to improve overload resolution

### DIFF
--- a/CLI/test/CLITest.cs
+++ b/CLI/test/CLITest.cs
@@ -95,9 +95,15 @@ namespace CLI.Test
         /// Tests with a dependency that depends on a dependency which is loaded after itself.
         /// </summary>
         [TestMethod]
-        public void TestDpendenciesNotLoadedInCorrectOrder() {
+        public void TestDependenciesNotLoadedInCorrectOrder() {
             CLITestHelper.Test("dependenciesNotLoadedInCorrectOrder", ReturnCode.ParsingDiagnostics);
             CLITestHelper.Test("dependenciesNotLoadedInCorrectOrder_2", ReturnCode.Success);
+        }
+
+        [TestMethod]
+        public void TestDependenciesSignatureOverload()
+        {
+            CLITestHelper.Test("dependenciesSignatureOverload", ReturnCode.Success);
         }
 
         [TestMethod]

--- a/CLI/test/ressources/dependenciesSignatureOverload/CLIArguments.txt
+++ b/CLI/test/ressources/dependenciesSignatureOverload/CLIArguments.txt
@@ -1,0 +1,1 @@
+﻿-i input\Main.tcbl -o output\Main.cbl -d output\errors.txt -dp input\Dependency.tcbl

--- a/CLI/test/ressources/dependenciesSignatureOverload/input/Dependency.tcbl
+++ b/CLI/test/ressources/dependenciesSignatureOverload/input/Dependency.tcbl
@@ -1,0 +1,22 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DPDCY01.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 Type01 typedef strict public.
+          05 myPic       pic X.
+       01 GroupType typedef strict public.
+          05 subType     type Type01.
+       PROCEDURE DIVISION.
+       declare procedure FunTest public
+                                 input myInput pic X.
+       data division.
+       procedure division.
+                continue.
+       end-declare.
+       declare procedure FunTest public
+                                 input myInput type Type01.
+       data division.
+       procedure division.
+                continue.
+       end-declare.
+       end program DPDCY01.

--- a/CLI/test/ressources/dependenciesSignatureOverload/input/Main.tcbl
+++ b/CLI/test/ressources/dependenciesSignatureOverload/input/Main.tcbl
@@ -1,0 +1,14 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. PGMTEST.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 alpha     pic X.
+       01 myVar     type DPDCY01::GroupType.
+       PROCEDURE DIVISION.
+       INIT-LIBRARY.
+           Continue.
+      *Must resolve dependency function acepting alphanumeric
+       call DPDCY01::FunTest input alpha.
+      *Must resolve dependency function acepting Type01
+       call DPDCY01::FunTest input myVar::subType.
+       end program PGMTEST.

--- a/CLI/test/ressources/dependenciesSignatureOverload/output_expected/Main.cbl
+++ b/CLI/test/ressources/dependenciesSignatureOverload/output_expected/Main.cbl
@@ -1,0 +1,107 @@
+      *TypeCobol_Version:0.1(alpha)
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. PGMTEST.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 TC-DPDCY01 pic X(08) value 'DPDCY01'.
+       01 TC-Call          PIC X VALUE 'T'.
+           88 TC-FirstCall  VALUE 'T'.
+           88 TC-NthCall    VALUE 'F'
+                            X'00' thru 'S'
+                            'U' thru X'FF'.
+
+                               
+       01 alpha     pic X.
+      *01 myVar     type DPDCY01::GroupType.
+       01 myVar.
+           02 subType.
+             03 myPic pic X.
+                                            
+       LINKAGE SECTION.
+      *Common to all librairies used by the program.
+       01 TC-Library-PntTab.
+          05 TC-Library-PntNbr          PIC S9(04) COMP.
+          05 TC-Library-Item OCCURS 1000
+                               DEPENDING ON TC-Library-PntNbr
+                               INDEXED   BY TC-Library-Idx.
+              10 TC-Library-Item-Idt      PIC X(08).
+              10 TC-Library-Item-Pnt      PROCEDURE-POINTER.
+
+      *To call program b20bd03f in module DPDCY01
+      *Which is generated code for DPDCY01.FunTest
+      *Declared in source file Dependency.tcbl
+       01 TC-DPDCY01-b20bd03f-Item.
+          05 TC-DPDCY01-b20bd03f-Idt PIC X(08).
+          05 TC-DPDCY01-b20bd03f PROCEDURE-POINTER.
+      *To call program fa50eaf6 in module DPDCY01
+      *Which is generated code for DPDCY01.FunTest
+      *Declared in source file Dependency.tcbl
+       01 TC-DPDCY01-fa50eaf6-Item.
+          05 TC-DPDCY01-fa50eaf6-Idt PIC X(08).
+          05 TC-DPDCY01-fa50eaf6 PROCEDURE-POINTER.
+
+       PROCEDURE DIVISION.
+       INIT-LIBRARY.
+      *
+           PERFORM TC-INITIALIZATIONS
+
+                    
+           Continue.
+      *Must resolve dependency function acepting alphanumeric
+      *call DPDCY01::FunTest input alpha.
+       
+           IF ADDRESS OF TC-DPDCY01-b20bd03f-Item = NULL
+             OR TC-DPDCY01-b20bd03f-Idt not = 'b20bd03f'
+               PERFORM TC-LOAD-POINTERS-DPDCY01
+           END-IF
+      *    Equivalent to call b20bd03f in module DPDCY01
+           CALL TC-DPDCY01-b20bd03f USING
+                                 alpha
+           end-call
+                                        .
+      *Must resolve dependency function acepting Type01
+      *call DPDCY01::FunTest input myVar::subType.
+       
+           IF ADDRESS OF TC-DPDCY01-fa50eaf6-Item = NULL
+             OR TC-DPDCY01-fa50eaf6-Idt not = 'fa50eaf6'
+               PERFORM TC-LOAD-POINTERS-DPDCY01
+           END-IF
+      *    Equivalent to call fa50eaf6 in module DPDCY01
+           CALL TC-DPDCY01-fa50eaf6 USING
+                                 subType IN myVar
+           end-call
+                                                 .
+      *=================================================================
+       TC-INITIALIZATIONS.
+      *=================================================================
+            IF TC-FirstCall
+                 SET TC-NthCall TO TRUE
+                 SET ADDRESS OF TC-DPDCY01-b20bd03f-Item  TO NULL
+                 SET ADDRESS OF TC-DPDCY01-fa50eaf6-Item  TO NULL
+            END-IF
+            .
+      *=================================================================
+        TC-LOAD-POINTERS-DPDCY01.
+      *=================================================================
+            CALL 'ZCALLPGM' USING TC-DPDCY01
+            ADDRESS OF TC-Library-PntTab
+            PERFORM VARYING TC-Library-Idx FROM 1 BY 1
+            UNTIL TC-Library-Idx > TC-Library-PntNbr
+                EVALUATE TC-Library-Item-Idt (TC-Library-Idx)
+                WHEN 'b20bd03f'
+                     SET ADDRESS OF
+                     TC-DPDCY01-b20bd03f-Item
+                     TO ADDRESS OF
+                     TC-Library-Item(TC-Library-Idx)
+                WHEN 'fa50eaf6'
+                     SET ADDRESS OF
+                     TC-DPDCY01-fa50eaf6-Item
+                     TO ADDRESS OF
+                     TC-Library-Item(TC-Library-Idx)
+                WHEN OTHER
+                     CONTINUE
+                END-EVALUATE
+            END-PERFORM
+            .
+
+       end program PGMTEST.

--- a/CLI/test/ressources/dependenciesSignatureOverload/output_expected/errors.txt
+++ b/CLI/test/ressources/dependenciesSignatureOverload/output_expected/errors.txt
@@ -1,0 +1,2 @@
+ReturnCode=Success_
+No error in "input\Main.tcbl".

--- a/TypeCobol.Test/Parser/Programs/TypeCobol/FunctionsDeclaration.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/FunctionsDeclaration.rdzPGM.txt
@@ -24,7 +24,6 @@ Line 90[21,21] <27, Error, Syntax> - Syntax error : Parameter with name 'y' decl
 Line 92[21,21] <27, Error, Syntax> - Syntax error : Parameter with name 'x' declared multiple times OffendingSymbol=[21,21:x]<UserDefinedWord>
 Line 93[21,21] <27, Error, Syntax> - Syntax error : Parameter with name 'y' declared multiple times OffendingSymbol=[21,21:y]<UserDefinedWord>
 Line 103[11,11] <27, Error, Syntax> - Syntax error : Illegal GLOBAL clause in function data item. OffendingSymbol=[11,11:g]<UserDefinedWord>
-Line 112[25,37] <30, Error, Semantics> - Semantic error: A function "FunConditions" with the same profile already exists in namespace "FunDeclare". OffendingSymbol=[25,37:FunConditions]<UserDefinedWord>
 Line 114[18,19] <27, Error, Syntax> - Syntax error : no viable alternative at input '88' RuleStack=codeElement>tcCodeElement>functionDeclarationHeader>inputPhrase>parameterDescription>functionDataParameter>tcfuncParameterUsageClause,  OffendingSymbol=[18,19:88]<IntegerLiteral>{88}
 Line 114[35,39] <27, Error, Syntax> - Syntax error : mismatched input 'VALUE' expecting {FUNCTION-POINTER, PIC, PICTURE, POINTER, PROCEDURE-POINTER, TYPE, ?} RuleStack=codeElement>tcCodeElement>functionDeclarationHeader>inputPhrase>parameterDescription>functionDataParameter,  OffendingSymbol=[35,39:VALUE]<VALUE>
 Line 114[22,33] <27, Error, Syntax> - Syntax error : A group item cannot be empty. OffendingSymbol=[22,33:valid-gender]<UserDefinedWord>
@@ -32,7 +31,6 @@ Line 115[29,33] <27, Error, Syntax> - Syntax error : mismatched input 'VALUE' ex
 Line 115[22,27] <27, Error, Syntax> - Syntax error : A group item cannot be empty. OffendingSymbol=[22,27:female]<UserDefinedWord>
 Line 116[29,33] <27, Error, Syntax> - Syntax error : mismatched input 'VALUE' expecting {FUNCTION-POINTER, PIC, PICTURE, POINTER, PROCEDURE-POINTER, TYPE, ?} RuleStack=codeElement>tcCodeElement>functionDeclarationHeader>inputPhrase>parameterDescription>functionDataParameter,  OffendingSymbol=[29,33:VALUE]<VALUE>
 Line 116[22,25] <27, Error, Syntax> - Syntax error : A group item cannot be empty. OffendingSymbol=[22,25:male]<UserDefinedWord>
-Line 123[25,37] <30, Error, Semantics> - Semantic error: A function "FunConditions" with the same profile already exists in namespace "FunDeclare". OffendingSymbol=[25,37:FunConditions]<UserDefinedWord>
 Line 124[20,21] <27, Error, Syntax> - Syntax error : extraneous input '88' expecting user defined word RuleStack=codeElement>tcCodeElement>functionDeclarationHeader>inputPhrase,  OffendingSymbol=[20,21:88]<IntegerLiteral>{88}
 Line 124[36,40] <27, Error, Syntax> - Syntax error : mismatched input 'VALUE' expecting {FUNCTION-POINTER, PIC, PICTURE, POINTER, PROCEDURE-POINTER, TYPE, ?} RuleStack=codeElement>tcCodeElement>functionDeclarationHeader>inputPhrase>parameterDescription>functionDataParameter,  OffendingSymbol=[36,40:VALUE]<VALUE>
 Line 124[23,34] <27, Error, Syntax> - Syntax error : A group item cannot be empty. OffendingSymbol=[23,34:valid-gender]<UserDefinedWord>

--- a/TypeCobol/Compiler/CodeElements/Expressions/StorageArea.cs
+++ b/TypeCobol/Compiler/CodeElements/Expressions/StorageArea.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using JetBrains.Annotations;
-using TypeCobol.Compiler.CodeElements.Expressions;
-using TypeCobol.Compiler.CodeModel;
 using TypeCobol.Compiler.Nodes;
 using TypeCobol.Compiler.Scanner;
 
@@ -417,14 +415,9 @@ namespace TypeCobol.Compiler.CodeElements
         public abstract Token FunctionNameToken { get; }
 	    public virtual CallSiteParameter[] Arguments { get; private set; }
 
-        public virtual ParameterList AsProfile(Node node)
+        public virtual IProfile BuildProfile(Node node)
         {
-            //Need to be updated in a near future
-            var profile = new FunctionCallParameterList
-            {
-                InputParameters = FunctionCallParameterList.CreateParameters(Arguments.ToList(), node),
-            };
-            return profile;
+            return ArgumentsProfile.Create(node, Arguments, null, null);
         }
      
         public virtual bool NeedDeclaration {
@@ -437,68 +430,68 @@ namespace TypeCobol.Compiler.CodeElements
         }
 
 
-	    public class FunctionCallParameterList: ParameterList {
-		    private IList<DataType> inputs = new List<DataType>();
-		    public IList<DataType> InputParameters {
-			    get { return inputs; }
-			    set { inputs = value; }
-		    }
-		    private IList<DataType> inouts = new List<DataType>();
-		    public IList<DataType> InoutParameters {
-			    get { return inouts; }
-			    set { inouts = value; }
-		    }
-		    private IList<DataType> outputs = new List<DataType>();
-		    public IList<DataType> OutputParameters {
-			    get { return outputs; }
-			    set { outputs = value; }
-		    }
+	    protected class ArgumentsProfile : IProfile
+        {
+            private static readonly TypeInfo _Unknown = new TypeInfo() { DataType = DataType.Unknown };
+            private static readonly TypeInfo _Omitted = new TypeInfo() { DataType = DataType.Omitted };
+            private static readonly TypeInfo _Numeric = new TypeInfo() { DataType = DataType.Numeric };
+            private static readonly TypeInfo _Alphanumeric = new TypeInfo() { DataType = DataType.Alphanumeric };
 
-	        public FunctionCallParameterList() {
-	            ReturningParameter = null;
-	        }
+            public static ArgumentsProfile Create(Node node, IEnumerable<CallSiteParameter> inputParameters, IEnumerable<CallSiteParameter> inoutParameters, IEnumerable<CallSiteParameter> outputParameters)
+            {
+                var inputs = inputParameters?.Select(Convert).ToList();
+                var inouts = inoutParameters?.Select(Convert).ToList();
+                var outputs = outputParameters?.Select(Convert).ToList();
+                //NOTE : Returning parameter for functions is not supported yet
+                return new ArgumentsProfile(inputs, inouts, outputs, null);
 
-	        public DataType ReturningParameter { get; set; }
-
-	        internal static IList<DataType> CreateParameters([NotNull] List<CallSiteParameter> parameters, Node node) {
-			    var results = new List<DataType>();
-			    foreach(var parameter in parameters) results.Add(CreateParameter(parameter, node));
-			    return results;
-		    }
-		    internal static DataType CreateParameter([NotNull] CallSiteParameter p,Node node) {
-		        if (p.IsOmitted) {
-		            return DataType.Omitted;
-		        }
-
-                DataType type = null;
-                var parameter = p.StorageAreaOrValue;
-		        if (parameter != null)
-		        {
-                    if (parameter.IsLiteral)
+                TypeInfo Convert(CallSiteParameter parameter)
+                {
+                    if (parameter.IsOmitted)
                     {
-                        if (parameter.NumericValue != null)
-                            type = DataType.Numeric;
-                        else
-                        if (parameter.AlphanumericValue != null)
-                            type = DataType.Alphanumeric;
-                        else type = DataType.Unknown;
+                        return _Omitted;
                     }
-		            else
-		            {
-                        if (node != null)
-		                {
-		                    var found = node.GetDataDefinitionFromStorageAreaDictionary(parameter.StorageArea);
-		                    var data = found as DataDescription;
-		                    type = data == null ? DataType.Unknown : data.DataType;
-		                }
 
-		                if (type == null) type = DataType.Unknown;
-		            }
-		            return type;
+                    var variable = parameter.StorageAreaOrValue;
+                    if (variable != null)
+                    {
+                        if (variable.IsLiteral)
+                        {
+                            if (variable.NumericValue != null)
+                            {
+                                return _Numeric;
+                            }
+                            if (variable.AlphanumericValue != null)
+                            {
+                                return _Alphanumeric;
+                            }
+                        }
+                        else
+                        {
+                            if (node?.GetDataDefinitionFromStorageAreaDictionary(variable.StorageArea) is DataDescription data)
+                            {
+                                return new TypeInfo() {DataType = data.DataType, TypeDefinition = data.TypeDefinition};
+                            }
+                        }
+                    }
+
+                    return _Unknown;
                 }
-		        return DataType.Unknown;
-		    }
-	    }
+            }
+
+            public IList<TypeInfo> Inputs { get; }
+            public IList<TypeInfo> Inouts { get; }
+            public IList<TypeInfo> Outputs { get; }
+            public TypeInfo Returning { get; }
+
+            private ArgumentsProfile(IList<TypeInfo> inputs, IList<TypeInfo> inouts, IList<TypeInfo> outputs, TypeInfo returning)
+            {
+                Inputs = inputs ?? new List<TypeInfo>();
+                Inouts = inouts ?? new List<TypeInfo>();
+                Outputs = outputs ?? new List<TypeInfo>();
+                Returning = returning;
+            }
+        }
     }
 
 	/// <summary>Call to an intrinsic function</summary>
@@ -586,16 +579,9 @@ namespace TypeCobol.Compiler.CodeElements
 
         public override string Namespace { get { return (ProcedureName as QualifiedSymbolReference) == null ? null : ((QualifiedSymbolReference) ProcedureName).Tail.Name; } }
 
-        public override ParameterList AsProfile(Node node)
-	    {
-	        var profile = new FunctionCallParameterList
-	        {
-	            InputParameters = FunctionCallParameterList.CreateParameters(InputParameters, node),
-	            InoutParameters = FunctionCallParameterList.CreateParameters(InoutParameters, node),
-	            OutputParameters = FunctionCallParameterList.CreateParameters(OutputParameters, node),
-	            ReturningParameter = null
-	        };
-	        return profile;
+        public override IProfile BuildProfile(Node node)
+        {
+            return ArgumentsProfile.Create(node, InputParameters, InoutParameters, OutputParameters);
         }
 		
 

--- a/TypeCobol/Compiler/CodeElements/Header/FunctionDeclarationHeader.cs
+++ b/TypeCobol/Compiler/CodeElements/Header/FunctionDeclarationHeader.cs
@@ -75,47 +75,53 @@ namespace TypeCobol.Compiler.CodeElements {
 	    Procedure = 2,
     }
 
-    public interface ParameterList {
-	    IList<DataType> InputParameters { get; }
-	    IList<DataType> InoutParameters { get; }
-	    IList<DataType> OutputParameters { get; }
-	    DataType ReturningParameter { get; }
+    public class TypeInfo
+    {
+        public DataType DataType { get; set; }
+        public TypeDefinition TypeDefinition { get; set; }
     }
 
+    public interface IProfile
+    {
+        IList<TypeInfo> Inputs { get; }
+        IList<TypeInfo> Inouts { get; }
+        IList<TypeInfo> Outputs { get; }
+        TypeInfo Returning { get; }
+    }
 
     public static class ParameterListHelper
     {
         /// <summary>
-        /// Get the signature of the ParameterList as string.
+        /// Get the signature of the profile as string.
         /// This string is intended to be displayed to the user.
         /// </summary>
         /// <returns></returns>
-        public static string GetSignature([NotNull] this ParameterList parameterList)
+        public static string GetSignature([NotNull] this IProfile profile)
         {
             var str = new System.Text.StringBuilder();
 
-            if (parameterList.InputParameters.Count > 0)
+            if (profile.Inputs.Count > 0)
             {
                 str.Append("input(");
-                foreach (var p in parameterList.InputParameters) str.Append(p).Append(", ");
+                foreach (var p in profile.Inputs) str.Append(p.DataType.Name).Append(", ");
                 str.Length -= 2;
                 str.Append(")");
             }
-            if (parameterList.InoutParameters.Count > 0)
+            if (profile.Inouts.Count > 0)
             {
                 str.Append(" in-out(");
-                foreach (var p in parameterList.InoutParameters) str.Append(p).Append(", ");
+                foreach (var p in profile.Inouts) str.Append(p.DataType.Name).Append(", ");
                 str.Length -= 2;
                 str.Append(")");
             }
-            if (parameterList.OutputParameters.Count > 0)
+            if (profile.Outputs.Count > 0)
             {
                 str.Append(" output(");
-                foreach (var p in parameterList.OutputParameters) str.Append(p).Append(", ");
+                foreach (var p in profile.Outputs) str.Append(p.DataType.Name).Append(", ");
                 str.Length -= 2;
                 str.Append(")");
             }
-            if (parameterList.ReturningParameter != null) str.Append(" : ").Append(parameterList.ReturningParameter);
+            if (profile.Returning != null) str.Append(" : ").Append(profile.Returning.DataType.Name);
             return str.ToString();
         }
 
@@ -204,7 +210,7 @@ namespace TypeCobol.Compiler.CodeElements {
         }
     }
 
-    public class ParametersProfile: CodeElement, ParameterList, IVisitable, IEquatable<ParametersProfile>
+    public class ParametersProfile: CodeElement, IVisitable, IEquatable<ParametersProfile>
     {
 	    public IList<ParameterDescriptionEntry> InputParameters { get; set; }
 	    public IList<ParameterDescriptionEntry> InoutParameters { get; set; }
@@ -297,45 +303,6 @@ namespace TypeCobol.Compiler.CodeElements {
             str.Append(')');
             return str.ToString();
         }
-
-
-
-	    IList<DataType> _icache = null;
-	    IList<DataType> ParameterList.InputParameters {
-		    get {
-			    if (_icache != null) return _icache;
-			    _icache = new List<DataType>();
-			    foreach(var parameter in this.InputParameters)
-				    _icache.Add(parameter.DataType);
-			    return _icache;
-		    }
-	    }
-	    IList<DataType> _ycache = null;
-	    IList<DataType> ParameterList.InoutParameters {
-		    get {
-			    if (_ycache != null) return _ycache;
-			    _ycache = new List<DataType>();
-			    foreach(var parameter in this.InoutParameters)
-				    _ycache.Add(parameter.DataType);
-			    return _ycache;
-		    }
-	    }
-	    IList<DataType> _ocache = null;
-	    IList<DataType> ParameterList.OutputParameters {
-		    get {
-			    if (_ocache != null) return _ocache;
-			    _ocache = new List<DataType>();
-			    foreach(var parameter in this.OutputParameters)
-				    _ocache.Add(parameter.DataType);
-			    return _ocache;
-		    }
-	    }
-	    DataType ParameterList.ReturningParameter {
-		    get {
-			    if (this.ReturningParameter == null) return null;
-			    return this.ReturningParameter.DataType;
-		    }
-	    }
     }
 
     public class Passing {

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -1036,12 +1036,7 @@ namespace TypeCobol.Compiler.CodeModel
             var argumentType = argumentTypeInfo.TypeDefinition;
             if (argumentType == null)
             {
-                var argumentTypes = GetType(argumentTypeInfo.DataType);
-                if (argumentTypes.Count > 1)
-                {
-                    return false;
-                }
-                argumentType = argumentTypes.FirstOrDefault();
+                return parameterType == null && parameter.DataType == argumentTypeInfo.DataType;
             }
 
             return parameterType == argumentType;

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -938,12 +938,12 @@ namespace TypeCobol.Compiler.CodeModel
             Add(Functions, function);
         }
 
-        public List<FunctionDeclaration> GetFunction(StorageArea storageArea, ParameterList profile = null)
+        public List<FunctionDeclaration> GetFunction(StorageArea storageArea, IProfile profile = null)
         {
             return GetFunction(storageArea.SymbolReference, profile);
         }
 
-        private List<FunctionDeclaration> GetFunction(SymbolReference symbolReference, ParameterList profile = null)
+        private List<FunctionDeclaration> GetFunction(SymbolReference symbolReference, IProfile profile = null)
         {
             var uri = new URI(symbolReference.Name);
             return GetFunction(uri, profile);
@@ -981,7 +981,7 @@ namespace TypeCobol.Compiler.CodeModel
             return foundedFunctions.Distinct();
         }
 
-        public List<FunctionDeclaration> GetFunction(QualifiedName name, ParameterList profile = null, string nameSpace = null)
+        public List<FunctionDeclaration> GetFunction(QualifiedName name, IProfile profile = null, string nameSpace = null)
         {
             var found = GetFunction(name, nameSpace);
             
@@ -999,46 +999,52 @@ namespace TypeCobol.Compiler.CodeModel
             return found;
         }
 
-        private bool Matches(ParametersProfileNode p1, ParameterList p2, string pgmName)
+        private bool Matches(ParametersProfileNode expected, IProfile actual, string pgmName)
         {
-            if (p1.InputParameters.Count != p2.InputParameters.Count) return false;
-            if (p1.InoutParameters.Count != p2.InoutParameters.Count) return false;
-            if (p1.OutputParameters.Count != p2.OutputParameters.Count) return false;
+            if (expected.InputParameters.Count != actual.Inputs.Count) return false;
+            if (expected.InoutParameters.Count != actual.Inouts.Count) return false;
+            if (expected.OutputParameters.Count != actual.Outputs.Count) return false;
 
-            for (int c = 0; c < p1.InputParameters.Count; c++)
-                if (!TypeCompare(p1.InputParameters[c], p2.InputParameters[c], pgmName)) return false;
-            for (int c = 0; c < p1.InoutParameters.Count; c++)
-                if (!TypeCompare(p1.InoutParameters[c], p2.InoutParameters[c], pgmName)) return false;
-            for (int c = 0; c < p1.OutputParameters.Count; c++)
-                if (!TypeCompare(p1.OutputParameters[c], p2.OutputParameters[c], pgmName)) return false;
+            for (int c = 0; c < expected.InputParameters.Count; c++)
+                if (!TypeCompare(expected.InputParameters[c], actual.Inputs[c], pgmName)) return false;
+            for (int c = 0; c < expected.InoutParameters.Count; c++)
+                if (!TypeCompare(expected.InoutParameters[c], actual.Inouts[c], pgmName)) return false;
+            for (int c = 0; c < expected.OutputParameters.Count; c++)
+                if (!TypeCompare(expected.OutputParameters[c], actual.Outputs[c], pgmName)) return false;
             return true;
         }
-        /// <summary>
-        /// Type comparaison
-        /// </summary>
-        /// <param name="p1">Represent the DataType from the called function/procedure</param>
-        /// <param name="p2">Represent the DataType from the caller function/procedure</param>
-        /// <param name="pgmName">Corresponds to the progam containing the called function/procedure</param>
-        /// <returns></returns>
-        private bool TypeCompare(ParameterDescription p1, DataType p2, string pgmName)
+
+        private bool TypeCompare(ParameterDescription parameter, TypeInfo argumentTypeInfo, string pgmName)
         {
             //Omitted accepted only if parameter is Omittable
-            if (p2 == DataType.Omitted) {
-                return p1.IsOmittable;
+            if (argumentTypeInfo.DataType == DataType.Omitted)
+            {
+                return parameter.IsOmittable;
             }
-            
-            var p1Types = p1.Name.Contains(".") ? this.GetType(p1) : this.GetType(p1.DataType, pgmName);
-            var p2Types = this.GetType(p2);
 
-            if (p1Types.Count > 1 || p2Types.Count > 1)
-                return false; //Means that a type is declare many times. Case already handle by checker.
-            var p1Type = p1Types.FirstOrDefault();
-            var p2Type = p2Types.FirstOrDefault();
+            var parameterType = parameter.TypeDefinition;
+            if (parameterType == null)
+            {
+                var parameterTypes = parameter.Name.Contains(".") ? this.GetType(parameter) : this.GetType(parameter.DataType, pgmName);
+                if (parameterTypes.Count > 1)
+                {
+                    return false;
+                }
+                parameterType = parameterTypes.FirstOrDefault();
+            }
 
-            if (p1Type != p2Type)
-                return false;
+            var argumentType = argumentTypeInfo.TypeDefinition;
+            if (argumentType == null)
+            {
+                var argumentTypes = GetType(argumentTypeInfo.DataType);
+                if (argumentTypes.Count > 1)
+                {
+                    return false;
+                }
+                argumentType = argumentTypes.FirstOrDefault();
+            }
 
-            return true;
+            return parameterType == argumentType;
         }
 
         [NotNull]

--- a/TypeCobol/Compiler/Nodes/ParametersProfileNode.cs
+++ b/TypeCobol/Compiler/Nodes/ParametersProfileNode.cs
@@ -2,13 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using JetBrains.Annotations;
 using TypeCobol.Compiler.CodeElements;
 
 namespace TypeCobol.Compiler.Nodes
 {
-    public class ParametersProfileNode : GenericNode<ParametersProfile>, ParameterList, IEquatable<ParametersProfileNode>
+    public class ParametersProfileNode : GenericNode<ParametersProfile>, IProfile, IEquatable<ParametersProfileNode>
     {
         public IList<ParameterDescription> InputParameters { get; set; }
         public IList<ParameterDescription> InoutParameters { get; set; }
@@ -81,49 +79,23 @@ namespace TypeCobol.Compiler.Nodes
             return base.CodeElement.GetHashCode();
         }
 
-        IList<DataType> _icache = null;
-        IList<DataType> ParameterList.InputParameters
-        {
-            get
+        private IList<TypeInfo> _inputsCache;
+        public IList<TypeInfo> Inputs => _inputsCache ?? (_inputsCache = InputParameters.Select(MakeTypeInfo).ToList());
+
+        private IList<TypeInfo> _inoutsCache;
+        public IList<TypeInfo> Inouts => _inoutsCache ?? (_inoutsCache = InoutParameters.Select(MakeTypeInfo).ToList());
+
+        private IList<TypeInfo> _outputsCache;
+        public IList<TypeInfo> Outputs => _outputsCache ?? (_outputsCache = OutputParameters.Select(MakeTypeInfo).ToList());
+
+        private TypeInfo _returningCache;
+        public TypeInfo Returning => _returningCache ?? (_returningCache = MakeTypeInfo(ReturningParameter));
+
+        private static TypeInfo MakeTypeInfo(ParameterDescription parameter) =>
+            new TypeInfo()
             {
-                if (_icache != null) return _icache;
-                _icache = new List<DataType>();
-                foreach (var parameter in this.InputParameters)
-                    _icache.Add(parameter.DataType);
-                return _icache;
-            }
-        }
-        IList<DataType> _ycache = null;
-        IList<DataType> ParameterList.InoutParameters
-        {
-            get
-            {
-                if (_ycache != null) return _ycache;
-                _ycache = new List<DataType>();
-                foreach (var parameter in this.InoutParameters)
-                    _ycache.Add(parameter.DataType);
-                return _ycache;
-            }
-        }
-        IList<DataType> _ocache = null;
-        IList<DataType> ParameterList.OutputParameters
-        {
-            get
-            {
-                if (_ocache != null) return _ocache;
-                _ocache = new List<DataType>();
-                foreach (var parameter in this.OutputParameters)
-                    _ocache.Add(parameter.DataType);
-                return _ocache;
-            }
-        }
-        DataType ParameterList.ReturningParameter
-        {
-            get
-            {
-                if (this.ReturningParameter == null) return null;
-                return this.ReturningParameter.DataType;
-            }
-        }
+                DataType = parameter.DataType,
+                TypeDefinition = parameter.TypeDefinition
+            };
     }
 }


### PR DESCRIPTION
Fixes #1747.
The fix uses the TypeDefinition and DataType (instead of DataType only) to improve overload resolution.
Also include some renaming.