### PR TITLE
WI #1718 Fix wrong generated index names in SET statements

### DIFF
--- a/Codegen/src/Actions/Qualifier.cs
+++ b/Codegen/src/Actions/Qualifier.cs
@@ -161,6 +161,7 @@ namespace TypeCobol.Codegen.Actions
                     string hashName = GeneratorHelper.ComputeIndexHashName(qualified_name, this.CurrentNode);
                     item = new GenerateToken(
                         new TokenCodeElement(storageArea.SymbolReference.NameLiteral.Token), hashName, sourcePositions);
+                    item.SetFlag(Node.Flag.NodeContainsIndex, true);
                     item.SetFlag(Node.Flag.HasBeenTypeCobolQualifierVisited, true);
                     this.CurrentNode.Add(item);
                     if (UsedStorageArea == null)
@@ -615,12 +616,14 @@ namespace TypeCobol.Codegen.Actions
                                 item = new GenerateToken(
                                     new TokenCodeElement(nodeTokens[r]), "",
                                     sourcePositions);
+                                item.SetFlag(Node.Flag.NodeContainsIndex, true);
                                 item.SetFlag(Node.Flag.HasBeenTypeCobolQualifierVisited, true);
                                 sourceNode.Add(item);
-                             }
+                            }
                             item = new GenerateToken(
                                 new TokenCodeElement(nodeTokens[range.Item2]), hashName,
                                 sourcePositions);
+                            item.SetFlag(Node.Flag.NodeContainsIndex, true);
                             item.SetFlag(Node.Flag.HasBeenTypeCobolQualifierVisited, true);
                             sourceNode.Add(item);
                             continue;

--- a/Codegen/src/Actions/Replace.cs
+++ b/Codegen/src/Actions/Replace.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using TypeCobol.Codegen.Nodes;
 using TypeCobol.Codegen.Skeletons;
 using TypeCobol.Compiler.Nodes;
+using TypeCobol.Compiler.Scanner;
 
 namespace TypeCobol.Codegen.Actions
 {
@@ -91,16 +92,16 @@ namespace TypeCobol.Codegen.Actions
                 int count = node.Children.Count;
                 Node previousNode = null;
 
-                foreach (var child in node.Children)
+                foreach (var token in node.Children.Cast<Qualifier.GenerateToken>())
                 {
-                    TypeCobol.Codegen.Actions.Qualifier.GenerateToken token = child as TypeCobol.Codegen.Actions.Qualifier.GenerateToken;
+                    if (token.IsFlagSet(Node.Flag.NodeContainsIndex)) continue;
 
-                    if (previousNode == null || child.CodeElement.ConsumedTokens[0].TokenType == Compiler.Scanner.TokenType.UserDefinedWord && previousNode.CodeElement.ConsumedTokens[0].TokenType != Compiler.Scanner.TokenType.QualifiedNameSeparator)
+                    if (previousNode == null || token.CodeElement.ConsumedTokens[0].TokenType == TokenType.UserDefinedWord && previousNode.CodeElement.ConsumedTokens[0].TokenType != TokenType.QualifiedNameSeparator)
                     {
                         //Add the -false
-                        if (token != null) token.ReplaceCode = token.ReplaceCode + "-false";
+                        token.ReplaceCode += "-false";
                     }
-                    previousNode = child;
+                    previousNode = token;
                 }
 
                 //Create a Token to replase the "false" to TRUE ==> lookup for the last one;

--- a/Codegen/src/Actions/ReplaceCode.cs
+++ b/Codegen/src/Actions/ReplaceCode.cs
@@ -85,18 +85,18 @@ namespace TypeCobol.Codegen.Actions
                 int count = node.Children.Count;
                 Node previousNode = null;
 
-                foreach (var child in node.Children)
+                foreach (var token in node.Children.Cast<Qualifier.GenerateToken>())
                 {
-                    TypeCobol.Codegen.Actions.Qualifier.GenerateToken token = child as TypeCobol.Codegen.Actions.Qualifier.GenerateToken;
+                    if (token.IsFlagSet(Node.Flag.NodeContainsIndex)) continue;
 
-                    if (previousNode == null || child.CodeElement.ConsumedTokens[0].TokenType == TokenType.UserDefinedWord && previousNode.CodeElement.ConsumedTokens[0].TokenType != TokenType.QualifiedNameSeparator)
+                    if (previousNode == null || token.CodeElement.ConsumedTokens[0].TokenType == TokenType.UserDefinedWord && previousNode.CodeElement.ConsumedTokens[0].TokenType != TokenType.QualifiedNameSeparator)
                     {
                         //Add the -false
-                        if (token != null) token.ReplaceCode = token.ReplaceCode + "-false";
+                        token.ReplaceCode += "-false";
                     }
-                    previousNode = child;
+                    previousNode = token;
                 }
-                
+
                 //Create a Token to replase the "false" to TRUE ==> lookup for the last one;
                 var consumedTokens = node.CodeElement.ConsumedTokens;
                 count = consumedTokens.Count;

--- a/Codegen/test/resources/input/TypeCobol/Global_Storage/GlobalStorageWithTypedefAndIndex.rdz.tcbl
+++ b/Codegen/test/resources/input/TypeCobol/Global_Storage/GlobalStorageWithTypedefAndIndex.rdz.tcbl
@@ -13,13 +13,21 @@
              10 Ligne OCCURS 10
                       ASCENDING KEY IS Obj
                       INDEXED BY IdxA.
-                15 Obj PIC X(12).
+                15 Obj  PIC X(12).
+                15 Flag Type Bool.
 
        PROCEDURE DIVISION.
 
        INIT-LIBRARY.
            CONTINUE.
 
+       MAIN.
+           SET GlobalTab::IdxA TO 1
+           SET GlobalTab::Flag(GlobalTab::IdxA) TO false
+           SET GlobalTab::Flag(IdxA) TO false
+           GOBACK
+           .
+           
        DECLARE PROCEDURE DisplayTable.
        DATA DIVISION.
        PROCEDURE DIVISION.

--- a/Codegen/test/resources/output/TypeCobol/Global_Storage/GlobalStorageWithTypedefAndIndex.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/Global_Storage/GlobalStorageWithTypedefAndIndex.rdz.tcbl
@@ -14,13 +14,49 @@
       *      10 Ligne OCCURS 10
       *               ASCENDING KEY IS Obj
       *               INDEXED BY IdxA.
-      *         15 Obj PIC X(12).
+      *         15 Obj  PIC X(12).
+      *         15 Flag Type Bool.
+       LINKAGE SECTION.
+
+       01 TC-GlobalData.
+
+
+      *01 GlobalTab Type TypeA.
+       02 GlobalTab.
+           03 Contenu.
+             04 Ligne OCCURS 10
+                      ASCENDING KEY IS Obj
+                      INDEXED BY a14c7288IdxA.
+               05 Obj PIC X(12).
+              05  Flag-value PIC X VALUE LOW-VALUE.
+                  88  Flag       VALUE 'T'.
+                  88  Flag-false VALUE 'F'
+                             X'00' thru 'S'
+                             'U' thru X'FF'.
+
+
 
        PROCEDURE DIVISION.
 
        INIT-LIBRARY.
+      * Get the data from the global storage section
+           CALL 'b8131d02' USING
+               by reference address of TC-GlobalData
+           end-call
+
+                    
            CONTINUE.
 
+       MAIN.
+      *    SET GlobalTab::IdxA TO 1
+           SET a14c7288IdxA TO 1
+      *    SET GlobalTab::Flag(GlobalTab::IdxA) TO false
+           SET Flag-false OF GlobalTab(a14c7288IdxA) TO TRUE
+      *    SET GlobalTab::Flag(IdxA) TO false
+           SET Flag-false OF GlobalTab(a14c7288IdxA) TO TRUE
+           GOBACK
+           .
+           
       *DECLARE PROCEDURE DisplayTable.
 
        END PROGRAM TCOZDR03.
@@ -42,6 +78,11 @@
                       ASCENDING KEY IS Obj
                       INDEXED BY a14c7288IdxA.
                05 Obj PIC X(12).
+              05  Flag-value PIC X VALUE LOW-VALUE.
+                  88  Flag       VALUE 'T'.
+                  88  Flag-false VALUE 'F'
+                             X'00' thru 'S'
+                             'U' thru X'FF'.
 
 
        PROCEDURE DIVISION
@@ -78,6 +119,11 @@
                       ASCENDING KEY IS Obj
                       INDEXED BY a14c7288IdxA.
                05 Obj PIC X(12).
+              05  Flag-value PIC X VALUE LOW-VALUE.
+                  88  Flag       VALUE 'T'.
+                  88  Flag-false VALUE 'F'
+                             X'00' thru 'S'
+                             'U' thru X'FF'.
                                
 
        LINKAGE SECTION.


### PR DESCRIPTION
Partial fix for #1718.
This PR tackles the wrong index names in SET statements only.

See [1718_WrongIndexNames_FixIdeaForCALLs](https://github.com/TypeCobolTeam/TypeCobol/tree/1718_WrongIndexNames_FixIdeaForCALLs) branch for a possible fix for CALLs.