### PR TITLE
WI #1762 Remember index hash on StorageArea and use it during code ge…

### DIFF
--- a/Codegen/src/Nodes/ProcedureStyleCall.cs
+++ b/Codegen/src/Nodes/ProcedureStyleCall.cs
@@ -141,8 +141,26 @@ namespace TypeCobol.Codegen.Nodes {
                     _cache.Add(callTextLine);
 
                 }
+
+                //Find and set computed hash (if any) to each DataOrConditionStorageArea used by the CALL node
+                var hashes = Node.Root.GeneratedCobolHashes;
+                if (Node.QualifiedStorageAreas != null)
+                {
+                    foreach (var qualifiedStorageArea in Node.QualifiedStorageAreas)
+                    {
+                        if (qualifiedStorageArea.Value != null
+                            &&
+                            hashes.TryGetValue(qualifiedStorageArea.Value.ToString("."), out var indexHash)
+                            &&
+                            qualifiedStorageArea.Key is DataOrConditionStorageArea dataOrConditionStorageArea)
+                        {
+                            dataOrConditionStorageArea.Hash = indexHash;
+                        }
+                    }
+                }
+
                 //Rule: TCCODEGEN-FIXFOR-ALIGN-FUNCALL
-				var indent = new string(' ', 13);
+                var indent = new string(' ', 13);
                 //Hanle Input parameters
                 //Rule: TCCODEGEN-FUNCALL-PARAMS
                 TypeCobol.Compiler.CodeElements.ParameterSharingMode previousSharingMode = (TypeCobol.Compiler.CodeElements.ParameterSharingMode)(-1);

--- a/Codegen/test/resources/input/TypeCobol/Global_Storage/GlobalStorageWithTypedefAndIndex.rdz.tcbl
+++ b/Codegen/test/resources/input/TypeCobol/Global_Storage/GlobalStorageWithTypedefAndIndex.rdz.tcbl
@@ -25,10 +25,13 @@
            SET GlobalTab::IdxA TO 1
            SET GlobalTab::Flag(GlobalTab::IdxA) TO false
            SET GlobalTab::Flag(IdxA) TO false
+           CALL DisplayTable INPUT GlobalTab::Flag(GlobalTab::IdxA)
+           CALL DisplayTable INPUT GlobalTab::Flag(IdxA)
            GOBACK
            .
            
-       DECLARE PROCEDURE DisplayTable.
+       DECLARE PROCEDURE DisplayTable
+               INPUT myBool Type Bool.
        DATA DIVISION.
        PROCEDURE DIVISION.
            PERFORM VARYING GlobalTab::IdxA FROM 1 BY 1

--- a/Codegen/test/resources/output/TypeCobol/Global_Storage/GlobalStorageWithTypedefAndIndex.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/Global_Storage/GlobalStorageWithTypedefAndIndex.rdz.tcbl
@@ -54,20 +54,38 @@
            SET Flag-false OF GlobalTab(a14c7288IdxA) TO TRUE
       *    SET GlobalTab::Flag(IdxA) TO false
            SET Flag-false OF GlobalTab(a14c7288IdxA) TO TRUE
+      *    CALL DisplayTable INPUT GlobalTab::Flag(GlobalTab::IdxA)
+           CALL 'aff15808' USING
+                                 Flag-value IN GlobalTab(a14c7288IdxA)
+           end-call
+                                                                   
+      *    CALL DisplayTable INPUT GlobalTab::Flag(IdxA)
+           CALL 'aff15808' USING
+                                 Flag-value IN GlobalTab(a14c7288IdxA)
+           end-call
+                                                        
            GOBACK
            .
            
-      *DECLARE PROCEDURE DisplayTable.
+      *DECLARE PROCEDURE DisplayTable
+      *        INPUT myBool Type Bool.
 
        END PROGRAM TCOZDR03.
       *
-      *DECLARE PROCEDURE DisplayTable.
+      *DECLARE PROCEDURE DisplayTable
+      *        INPUT myBool Type Bool.
       *_________________________________________________________________
        IDENTIFICATION DIVISION.
-       PROGRAM-ID. c8f713a3.
+       PROGRAM-ID. aff15808.
        DATA DIVISION.
        LINKAGE SECTION.
-      *TCOZDR03.DisplayTable  - No Params
+      *TCOZDR03.DisplayTable - Params :
+      *     input(myBool: BOOL)
+       01 myBool-value PIC X     VALUE LOW-VALUE.
+           88 myBool       VALUE 'T'.
+           88 myBool-false VALUE 'F'
+                             X'00' thru 'S'
+                             'U' thru X'FF'.
        01 TC-GlobalData.
 
 
@@ -86,8 +104,10 @@
 
 
        PROCEDURE DIVISION
+             USING BY REFERENCE myBool-value
            .
-      *TCOZDR03.DisplayTable  - No Params
+      *TCOZDR03.DisplayTable - Params :
+      *     input(myBool: BOOL)
       * Get the data from the global storage section
            CALL 'b8131d02' USING
                by reference address of TC-GlobalData
@@ -100,7 +120,7 @@
              DISPLAY 'Test' Obj OF GlobalTab(a14c7288IdxA)
            END-PERFORM
            .
-       END PROGRAM c8f713a3.
+       END PROGRAM aff15808.
       *
       * Global Storage Section variables
       *_________________________________________________________________

--- a/TypeCobol/Compiler/CodeElements/Expressions/StorageArea.cs
+++ b/TypeCobol/Compiler/CodeElements/Expressions/StorageArea.cs
@@ -143,13 +143,31 @@ namespace TypeCobol.Compiler.CodeElements
 			return ToString(false);
 		}
 
+        /// <summary>
+        /// For indexes, stores the computed hash of the corresponding IndexDefinition
+        /// Used by Codegen only.
+        /// </summary>
+        public string Hash { get; set; }
+
         public string ToString(bool onlySubscript)
         {
             var str = new System.Text.StringBuilder();
             if (SymbolReference != null)
             {
-                if(!onlySubscript)
-                    str.Append(SymbolReference.Name);
+                if (!onlySubscript)
+                {
+                    if (Hash != null)
+                    {
+                        var symbolReference = SymbolReference.IsQualifiedReference
+                            ? ((QualifiedSymbolReference) SymbolReference).First
+                            : SymbolReference;
+                        str.Append(Hash + symbolReference.Name);
+                    }
+                    else
+                    {
+                        str.Append(SymbolReference.Name);
+                    }
+                }
                 if (Subscripts.Count > 0)
                 {
                     str.Append('(');

--- a/TypeCobol/Compiler/Nodes/Node.cs
+++ b/TypeCobol/Compiler/Nodes/Node.cs
@@ -987,7 +987,7 @@ namespace TypeCobol.Compiler.Nodes {
     public class SourceFile : GenericNode<CodeElement> {
         public SourceFile() : base(null)
         {
-            GeneratedCobolHashes = new Dictionary<string, string>();
+            GeneratedCobolHashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
@@ -995,9 +995,10 @@ namespace TypeCobol.Compiler.Nodes {
         }
 
         /// <summary>
-        /// Dictionary of hashes and signatures for the different function and procedure. Allows to avoid duplicates. 
+        /// Dictionary of hashes and signatures for the different function and procedure. Allows to avoid duplicates.
+        /// Key is the  qualified name of function/procedure/index, Value is the corresponding index.
         /// </summary>
-        public Dictionary<string, string> GeneratedCobolHashes { get; set; }
+        public Dictionary<string, string> GeneratedCobolHashes { get; }
 
         public IEnumerable<Program> Programs {
             get

--- a/TypeCobol/Tools/Hash.cs
+++ b/TypeCobol/Tools/Hash.cs
@@ -69,15 +69,20 @@ namespace TypeCobol.Tools
             if(result.Length < size)
                 result += hash.Substring(0, size - result.Length);
 
-            if(node != null)
+            if (node?.Root != null)
             {
-                var RootNode = (SourceFile)node.Root;
-                if (RootNode != null && RootNode.GeneratedCobolHashes.Any(v => v.Key == result && v.Value != text))
+                var existingNameForComputedHash = node.Root.GeneratedCobolHashes.SingleOrDefault(p => p.Value == result).Key;
+                if (existingNameForComputedHash == null)
+                {
+                    //No conflict, add the new hash
+                    node.Root.GeneratedCobolHashes.Add(text, result);
+                }
+                else if (existingNameForComputedHash != text)
+                {
+                    //Hash conflict, same hash has been computed for two different names !
                     DiagnosticUtils.AddError(node, "Duplicated hash detected. Please contact TypeCobol support team.", MessageCode.ImplementationError);
-                else if (RootNode != null && !RootNode.GeneratedCobolHashes.Any(v => v.Key == result))
-                    RootNode.GeneratedCobolHashes.Add(result, text);
+                }
             }
-           
 
             return result;
         }


### PR DESCRIPTION
…neration
Fixes #1762.
This is more a hack than a fix because it involves adding a Codegen-specific field into `DataOrConditionStorageArea` class.