### PR TITLE
WI #1782 Allow "VALUE ARE" and "VALUES IS" syntaxes in data condition…

### DIFF
--- a/TypeCobol.Test/Parser/Programs/Cobol85/ValueClauseAlternateSyntaxes.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ValueClauseAlternateSyntaxes.rdz.cbl
@@ -1,0 +1,15 @@
+﻿       identification division.
+       program-id. DVZZMFT3.
+       data division.
+       working-storage section.
+       01 var1 PIC X.
+      *These variants are not compliant with language specs
+      *But still are accepted by IBM compiler.
+          88 case1 VALUE ARE 'A' 'B'.
+          88 case2 VALUES IS 'C' 'D'.
+          88 case3 VALUE ARE 'E'.
+          88 case4 VALUES IS 'F'.
+       procedure division.
+           goback
+           .
+       end program DVZZMFT3.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ValueClauseAlternateSyntaxes.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ValueClauseAlternateSyntaxes.rdz.cbl
@@ -3,12 +3,15 @@
        data division.
        working-storage section.
        01 var1 PIC X.
+      *These two are standard
+          88 case1 VALUE IS 'A'.
+          88 case2 VALUES ARE 'B' 'C'.
       *These variants are not compliant with language specs
       *But still are accepted by IBM compiler.
-          88 case1 VALUE ARE 'A' 'B'.
-          88 case2 VALUES IS 'C' 'D'.
-          88 case3 VALUE ARE 'E'.
-          88 case4 VALUES IS 'F'.
+          88 case3 VALUE ARE 'D' 'E'.
+          88 case4 VALUES IS 'F' 'G'.
+          88 case5 VALUE ARE 'H'.
+          88 case6 VALUES IS 'I'.
        procedure division.
            goback
            .

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ValueClauseAlternateSyntaxes.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ValueClauseAlternateSyntaxes.rdzMix.txt
@@ -1,0 +1,15 @@
+﻿       identification division.
+       program-id. DVZZMFT3.
+       data division.
+       working-storage section.
+       01 var1 PIC X.
+      *These variants are not compliant with language specs
+      *But still are accepted by IBM compiler.
+          88 case1 VALUE ARE 'A' 'B'.
+          88 case2 VALUES IS 'C' 'D'.
+          88 case3 VALUE ARE 'E'.
+          88 case4 VALUES IS 'F'.
+       procedure division.
+           goback
+           .
+       end program DVZZMFT3.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ValueClauseAlternateSyntaxes.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ValueClauseAlternateSyntaxes.rdzMix.txt
@@ -3,12 +3,15 @@
        data division.
        working-storage section.
        01 var1 PIC X.
+      *These two are standard
+          88 case1 VALUE IS 'A'.
+          88 case2 VALUES ARE 'B' 'C'.
       *These variants are not compliant with language specs
       *But still are accepted by IBM compiler.
-          88 case1 VALUE ARE 'A' 'B'.
-          88 case2 VALUES IS 'C' 'D'.
-          88 case3 VALUE ARE 'E'.
-          88 case4 VALUES IS 'F'.
+          88 case3 VALUE ARE 'D' 'E'.
+          88 case4 VALUES IS 'F' 'G'.
+          88 case5 VALUE ARE 'H'.
+          88 case6 VALUES IS 'I'.
        procedure division.
            goback
            .

--- a/TypeCobol/AntlrGrammar/CobolCodeElements.g4
+++ b/TypeCobol/AntlrGrammar/CobolCodeElements.g4
@@ -3183,7 +3183,7 @@ valueClause:
 // p240: ... more details - Rules for condition-name entries ...
 
 valueClauseForCondition:
-	((VALUE IS?) | (VALUES ARE?)) (value1 | valuesRange)+; 
+	(VALUE | VALUES) (IS | ARE)? (value1 | valuesRange)+; 
 
 valuesRange: 
 	startValue=value1 (THROUGH | THRU) endValue=value1;

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -1557,14 +1557,23 @@ namespace TypeCobol.Compiler.Scanner
                                     return true;
 
                                 //Try to guess if it is a LevelNumber or Literal depending on previous tokens
-                                bool currentTokenIsExpectedToBeALiteral =
-                                    lastSignificantToken.TokenType == TokenType.OCCURS ||
-                                    lastSignificantToken.TokenType == TokenType.VALUE ||
-                                    lastSignificantToken.TokenType == TokenType.VALUES ||
-                                    lastSignificantToken.TokenType == TokenType.THRU ||
-                                    lastSignificantToken.TokenType == TokenType.THROUGH ||
-                                    (beforeLastSignificantToken.TokenType == TokenType.VALUE && lastSignificantToken.TokenType == TokenType.IS) ||
-                                    (beforeLastSignificantToken.TokenType == TokenType.VALUES && lastSignificantToken.TokenType == TokenType.ARE);
+                                bool currentTokenIsExpectedToBeALiteral = false;
+                                switch (lastSignificantToken.TokenType)
+                                {
+                                    case TokenType.OCCURS:
+                                    case TokenType.VALUE:
+                                    case TokenType.VALUES:
+                                    case TokenType.THROUGH:
+                                    case TokenType.THRU:
+                                        currentTokenIsExpectedToBeALiteral = true;
+                                        break;
+                                    case TokenType.IS:
+                                    case TokenType.ARE:
+                                        currentTokenIsExpectedToBeALiteral =
+                                            beforeLastSignificantToken.TokenType == TokenType.VALUE ||
+                                            beforeLastSignificantToken.TokenType == TokenType.VALUES;
+                                        break;
+                                }
                                 if (!currentTokenIsExpectedToBeALiteral)
                                 {
                                     /*


### PR DESCRIPTION
… value clauses

Fixes  #1782.
