### PR TITLE
WI #599 Use a MultilineScanStateSnapshot

### DIFF
--- a/TypeCobol.Test/Parser/ProgramsNew/Cobol85/ReplaceTokenDataDiv.rdz.cbl
+++ b/TypeCobol.Test/Parser/ProgramsNew/Cobol85/ReplaceTokenDataDiv.rdz.cbl
@@ -1,0 +1,13 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOZCHKP.
+       data division.
+       working-storage section.
+       REPLACE                                         
+           ==:LONGUEUR-IDOFUS:==      BY ==0900==.
+       01  var1         PIC X(:LONGUEUR-IDOFUS:).
+      
+       PROCEDURE DIVISION.
+           move :LONGUEUR-IDOFUS: to var1
+           .
+      
+       END PROGRAM TCOZCHKP.

--- a/TypeCobol.Test/Parser/ProgramsNew/Cobol85/ReplaceTokenDataDiv.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/ProgramsNew/Cobol85/ReplaceTokenDataDiv.rdzPGM.txt
@@ -1,0 +1,14 @@
+﻿--- Program ---
+PROGRAM: TCOZCHKP common:False initial:False recursive:False
+ author: ? written: ? compiled: ? installation: ? security: ?
+--- Intrinsic:Namespace:Program:Global:Local
+-- DATA --------
+  var1:Alphanumeric:(.NET Type=PictureType, Tag=Picture)
+Picture: X(900)
+
+--- Intrinsic
+-- TYPES -------
+  BOOL:BOOL
+  DATE:DATE
+  CURRENCY:CURRENCY
+  STRING:STRING

--- a/TypeCobol.Test/TestUtils.cs
+++ b/TypeCobol.Test/TestUtils.cs
@@ -100,7 +100,7 @@ namespace TypeCobol.Test
             report.AppendLine("- " + (compiler?.CobolTextLines.Count ?? stats.Line) + " lines");
             report.AppendLine("- " + (compiler?.CodeElementsDocumentSnapshot.CodeElements.Count() ?? stats.TotalCodeElements) + " code elements");
 
-            report.AppendLine(" Iteration : " + stats.IterationNumber); 
+            report.AppendLine(" Iteration : " + stats.IterationNumber);
 
             if (compiler != null)
             {
@@ -150,7 +150,7 @@ namespace TypeCobol.Test
             }
         }
 
-        
+
 
         private static string FormatPercentage(float averageTime, float totalTime)
         {

--- a/TypeCobol.Test/Utils/ParserUtils.cs
+++ b/TypeCobol.Test/Utils/ParserUtils.cs
@@ -150,7 +150,15 @@ namespace TypeCobol.Test.Utils
             }
         }
 
-        internal static string DumpResult(IEnumerable<Program> programs, IEnumerable<TypeCobol.Compiler.Nodes.Class> classes, IList<Diagnostic> diagnostics)
+        /// <summary>
+        /// Dump a set of Program nodes and Class nodes.
+        /// </summary>
+        /// <param name="programs">The set of program nodes</param>
+        /// <param name="classes">The set of Class nodes</param>
+        /// <param name="diagnostics">Any diagnostics</param>
+        /// <param name="dumpSymTyps">true if any associated symbol's type must be add to the returned string, false otherwise.</param>
+        /// <returns>The String representation of the dump</returns>
+        internal static string DumpResult(IEnumerable<Program> programs, IEnumerable<TypeCobol.Compiler.Nodes.Class> classes, IList<Diagnostic> diagnostics, bool dumpSymTyps = false)
         {
             StringBuilder builder = new StringBuilder();
             if (diagnostics != null && diagnostics.Count > 0)
@@ -162,7 +170,7 @@ namespace TypeCobol.Test.Utils
                 foreach (var program in programs)
                 {
                     builder.AppendLine("--- Program ---");
-                    Dump(builder, program);
+                    Dump(builder, program, dumpSymTyps);
                 }
             }
             if (classes != null)
@@ -176,12 +184,19 @@ namespace TypeCobol.Test.Utils
             return builder.ToString();
         }
 
-        internal static StringBuilder Dump(StringBuilder str, TypeCobol.Compiler.CodeModel.Program program)
+        /// <summary>
+        /// Dump a Program node
+        /// </summary>
+        /// <param name="str">The StringBuilder instance into which to dump the program node</param>
+        /// <param name="program">The program node to be dumped</param>
+        /// <param name="dumpSymTyps">true if any associated symbol's type must be add to the returned string, false otherwise.</param>
+        /// <returns>The StringBuilder instance</returns>
+        internal static StringBuilder Dump(StringBuilder str, TypeCobol.Compiler.CodeModel.Program program, bool dumpSymTyps = false)
         {
             str.Append("PROGRAM: ");
             Dump(str, program.Identification);
             str.AppendLine();
-            str.AppendLine(program.SymbolTable.ToString(true));
+            str.AppendLine(program.SymbolTable.ToString(true, dumpSymTyps));
             return str;
         }
 

--- a/TypeCobol/Compiler/Preprocessor/ReplaceTokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Preprocessor/ReplaceTokensLinesIterator.cs
@@ -451,7 +451,7 @@ namespace TypeCobol.Compiler.Preprocessor
                     // TO DO use Replace(String, String, StringComparison) overload, available in .NET 5
                     // TO DO : find a way to transfer the scanner context the of original token to the call below
                     Diagnostic error = null;
-                    Token generatedToken = Scanner.Scanner.ScanIsolatedTokenInDefaultContext(tokenText, out error);
+                    Token generatedToken = Scanner.Scanner.ScanIsolatedTokenInDefaultContext(originalToken.ScanStateSnapshot, tokenText, out error);
                     // TO DO : find a way to report the error above ...
 
                     if (originalToken.PreviousTokenType != null) //In case orignal token was previously an other type of token reset it back to it's orignal type. 

--- a/TypeCobol/Compiler/Scanner/MultilineScanState.cs
+++ b/TypeCobol/Compiler/Scanner/MultilineScanState.cs
@@ -117,7 +117,7 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// Initialize scanner state
         /// </summary>
-        public MultilineScanState(bool insideDataDivision, bool insideProcedureDivision, bool insidePseudoText, bool insideSymbolicCharacterDefinitions, 
+        public MultilineScanState(bool insideDataDivision, bool insideProcedureDivision, bool insidePseudoText, bool insideSymbolicCharacterDefinitions,
                 bool insideFormalizedComment, bool insideMultilineComments, bool insideParamsField,
                 bool decimalPointIsComma, bool withDebuggingMode, Encoding encodingForAlphanumericLiterals)
         {
@@ -138,21 +138,29 @@ namespace TypeCobol.Compiler.Scanner
         /// </summary>
         public MultilineScanState Clone()
         {
-            MultilineScanState clone = new MultilineScanState(InsideDataDivision, InsideProcedureDivision, InsidePseudoText, InsideSymbolicCharacterDefinitions,
-                InsideFormalizedComment, InsideMultilineComments, InsideParamsField, 
-                DecimalPointIsComma, WithDebuggingMode, EncodingForAlphanumericLiterals);
-            if (LastSignificantToken != null) clone.LastSignificantToken = LastSignificantToken;
-            if (BeforeLastSignificantToken != null) clone.BeforeLastSignificantToken = BeforeLastSignificantToken;
-            if (SymbolicCharacters != null)
+            return new MultilineScanState(this);
+        }
+
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        /// <param name="from">Copy from this state</param>
+        public MultilineScanState(MultilineScanState from) :
+            this(from.InsideDataDivision, from.InsideProcedureDivision, from.InsidePseudoText, from.InsideSymbolicCharacterDefinitions,
+                from.InsideFormalizedComment, from.InsideMultilineComments, from.InsideParamsField,
+                from.DecimalPointIsComma, from.WithDebuggingMode, from.EncodingForAlphanumericLiterals)
+        {
+            if (from.LastSignificantToken != null) LastSignificantToken = from.LastSignificantToken;
+            if (from.BeforeLastSignificantToken != null) BeforeLastSignificantToken = from.BeforeLastSignificantToken;
+            if (from.SymbolicCharacters != null)
             {
-                clone.SymbolicCharacters = new List<string>(SymbolicCharacters);
+                SymbolicCharacters = new List<string>(from.SymbolicCharacters);
             }
 #if EUROINFO_RULES
-            clone.InsideRemarksDirective = InsideRemarksDirective;
-            clone.InsideRemarksParentheses = InsideRemarksParentheses;
-            clone.LeavingRemarksDirective = LeavingRemarksDirective;
+            InsideRemarksDirective = from.InsideRemarksDirective;
+            InsideRemarksParentheses = from.InsideRemarksParentheses;
+            LeavingRemarksDirective = from.LeavingRemarksDirective;
 #endif
-            return clone;
         }
 
         /// <summary>
@@ -371,7 +379,7 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// True after (EXEC | EXECUTE) (SQL | SQLIMS)
         /// </summary>
-        public bool AfterExecSql
+        public virtual bool AfterExecSql
         {
             get
             {
@@ -385,17 +393,17 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// True after (EXEC | EXECUTE)
         /// </summary>
-        public bool AfterExec
+        public virtual bool AfterExec
         {
             get { return LastSignificantToken != null && (LastSignificantToken.TokenType == TokenType.EXEC || LastSignificantToken.TokenType == TokenType.EXECUTE); }
         }
 
-        public bool AfterExecTranslatorName
+        public virtual bool AfterExecTranslatorName
         {
             get { return LastSignificantToken != null && LastSignificantToken.TokenType == TokenType.ExecTranslatorName; }
         }
 
-        public bool AfterExecStatementText
+        public virtual bool AfterExecStatementText
         {
             get { return LastSignificantToken != null && LastSignificantToken.TokenType == TokenType.ExecStatementText; }
         }
@@ -403,7 +411,7 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// True after (PIC | PICTURE) IS?
         /// </summary>
-        public bool AfterPicture
+        public virtual bool AfterPicture
         {
             get
             {
@@ -418,7 +426,7 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// True after (AUTHOR | INSTALLATION | DATE_WRITTEN | DATE_COMPILED | SECURITY)
         /// </summary>
-        public bool AfterCommentEntryKeyword
+        public virtual bool AfterCommentEntryKeyword
         {
             get
             {
@@ -434,7 +442,7 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// True after (AUTHOR | INSTALLATION | DATE_WRITTEN | DATE_COMPILED | SECURITY) PeriodSeparator
         /// </summary>
-        public bool AfterCommentEntryKeywordPeriod
+        public virtual bool AfterCommentEntryKeywordPeriod
         {
             get
             {
@@ -448,12 +456,12 @@ namespace TypeCobol.Compiler.Scanner
             }
         }
 
-        public bool AfterCommentEntry
+        public virtual bool AfterCommentEntry
         {
             get { return LastSignificantToken != null && LastSignificantToken.TokenType == TokenType.CommentEntry; }
         }
 
-        public bool AfterFUNCTION
+        public virtual bool AfterFUNCTION
         {
             get { return LastSignificantToken != null && LastSignificantToken.TokenType == TokenType.FUNCTION; }
         }
@@ -461,7 +469,7 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// True at the beggining of a parse section, or after PeriodSeparator, or after END-EXEC
         /// </summary>
-        public bool AtBeginningOfSentence
+        public virtual bool AtBeginningOfSentence
         {
             get
             {

--- a/TypeCobol/Compiler/Scanner/MultilineScanStateSnapshot.cs
+++ b/TypeCobol/Compiler/Scanner/MultilineScanStateSnapshot.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TypeCobol.Compiler.Scanner
+{
+    /// <summary>
+    /// Snapshot of a  MultilineScanState
+    /// </summary>
+    public class MultilineScanStateSnapshot : MultilineScanState
+    {
+        public MultilineScanStateSnapshot(MultilineScanState currentState) : base(currentState)
+        {
+            _AfterExecSql = currentState.AfterExecSql;
+            _AfterExec = currentState.AfterExec;
+            _AfterExecTranslatorName = currentState.AfterExecTranslatorName;
+            _AfterExecStatementText = currentState.AfterExecStatementText;
+            _AfterPicture = currentState.AfterPicture;
+            _AfterCommentEntryKeyword = currentState.AfterCommentEntryKeyword;
+            _AfterCommentEntryKeywordPeriod = currentState.AfterCommentEntryKeywordPeriod;
+            _AfterCommentEntry = currentState.AfterCommentEntry;
+            _AfterFUNCTION = currentState.AfterFUNCTION;
+            _AtBeginningOfSentence = currentState.AtBeginningOfSentence;
+        }
+
+        private bool _AfterExecSql;
+        public override bool AfterExecSql
+        {
+            get
+            {
+                return AfterExecSql;
+            }
+        }
+
+        private bool _AfterExec;
+        public override bool AfterExec
+        {
+            get
+            {
+                return _AfterExec;
+            }
+        }
+
+        private bool _AfterExecTranslatorName;
+        public override bool AfterExecTranslatorName
+        {
+            get
+            {
+                return _AfterExecTranslatorName;
+            }
+        }
+
+        private bool _AfterExecStatementText;
+        public override bool AfterExecStatementText
+        {
+            get
+            {
+                return _AfterExecStatementText;
+            }
+        }
+
+        private bool _AfterPicture;
+        public override bool AfterPicture
+        {
+            get
+            {
+                return _AfterPicture;
+            }
+        }
+
+        private bool _AfterCommentEntryKeyword;
+        public override bool AfterCommentEntryKeyword
+        {
+            get
+            {
+                return _AfterCommentEntryKeyword;
+            }
+        }
+
+        private bool _AfterCommentEntryKeywordPeriod;
+        public override bool AfterCommentEntryKeywordPeriod
+        {
+            get
+            {
+                return _AfterCommentEntryKeywordPeriod;
+            }
+        }
+
+        private bool _AfterCommentEntry;
+        public override bool AfterCommentEntry
+        {
+            get
+            {
+                return _AfterCommentEntry;
+            }
+        }
+
+        private bool _AfterFUNCTION;
+        public override bool AfterFUNCTION
+        {
+            get
+            {
+                return _AfterFUNCTION;
+            }
+        }
+
+        private bool _AtBeginningOfSentence;
+        public override bool AtBeginningOfSentence
+        {
+            get
+            {
+                return _AtBeginningOfSentence;
+            }
+        }
+
+    }
+}

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -540,22 +540,23 @@ namespace TypeCobol.Compiler.Scanner
         }
 
         /// <summary>
-        /// Scan an isolated token in the following "default" context :
+        /// Scan an isolated token given a a Scan State.
+        /// If the given scan state is null then Scan in performed in the following "default" context :
         /// - insideDataDivision = true
         /// - decimalPointIsComma = false
         /// - withDebuggingMode = false
         /// - encodingForAlphanumericLiterals = IBM 1147
         /// - default compiler options
         /// </summary>
-        public static Token ScanIsolatedTokenInDefaultContext(string tokenText, out Diagnostic error)
+        public static Token ScanIsolatedTokenInDefaultContext(MultilineScanState scanState, string tokenText, out Diagnostic error)
         {
             TokensLine tempTokensLine = TokensLine.CreateVirtualLineForInsertedToken(0, tokenText);
-            tempTokensLine.InitializeScanState(new MultilineScanState(true, false, false, IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147)));
+            tempTokensLine.InitializeScanState(scanState ?? new MultilineScanState(true, false, false, IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147)));
 
             Scanner tempScanner = new Scanner(tokenText, 0, tokenText.Length - 1, tempTokensLine, new TypeCobolOptions(), false);
             Token candidateToken = tempScanner.GetNextToken();
 
-            if(tempTokensLine.ScannerDiagnostics.Count > 0)
+            if (tempTokensLine.ScannerDiagnostics.Count > 0)
             {
                 error = tempTokensLine.ScannerDiagnostics[0];
             }
@@ -1930,6 +1931,7 @@ namespace TypeCobol.Compiler.Scanner
                 { //Check if there is cobol partial word inside the picture declaration. 
                     picToken.TokenType = TokenType.PartialCobolWord; //Match the whole PictureCharecterString token as a partial cobol word. 
                     picToken.PreviousTokenType = TokenType.PictureCharacterString; //Save that the token was previously a picture character string token
+                    picToken.ScanStateSnapshot = new MultilineScanStateSnapshot(tokensLine.ScanState);
                     return picToken;
                 }
                 else
@@ -2349,7 +2351,9 @@ namespace TypeCobol.Compiler.Scanner
             // Consume the entire the partial Cobol word
             currentIndex = endIndex + 1;
 
-            return new Token(TokenType.PartialCobolWord, startIndex, endIndex, tokensLine);
-        }        
+            Token t = new Token(TokenType.PartialCobolWord, startIndex, endIndex, tokensLine);
+            t.ScanStateSnapshot = new MultilineScanStateSnapshot(tokensLine.ScanState);
+            return t;
+        }
     }
 }

--- a/TypeCobol/Compiler/Scanner/Token.cs
+++ b/TypeCobol/Compiler/Scanner/Token.cs
@@ -295,8 +295,13 @@ namespace TypeCobol.Compiler.Scanner
         /// </summary>
         public LiteralTokenValue LiteralValue { get; set; }
 
+        /// <summary>
+        /// ScanState associated to this token if any, null otherwise.
+        /// </summary>
+        public MultilineScanState ScanStateSnapshot { get; set; }
+
         // --- Ambiguous tokens resolved after having been created ---
-        
+
         internal void CorrectType(TokenType tokenType)
         {
             // Copy token type and family from the continuation token


### PR DESCRIPTION
**What have been done.**

- A new class MultilineScanStateSnapshot have been introduced to capture a Scan state associated to a PartialCobolWord. A Snapshot is used to capture values of calculated properties.

- The MultilineScanStateSnapshot instance is used in : ReplaceTokensLinesIterator::CreateReplacedTokens(...) method and the call to the Scanner.Scanner.ScanIsolatedTokenInDefaultContext(...) method.

- New comparison results use Symbol's type Dump

