### PR TITLE
WI #1750 Add DataDefinition nodes having initial value to START Block.

### DIFF
--- a/TypeCobol.Analysis.Test/BasicCfgPrograms/HanoiPrg.dot
+++ b/TypeCobol.Analysis.Test/BasicCfgPrograms/HanoiPrg.dot
@@ -8,7 +8,7 @@ edge [
 arrowtail = "empty"
 ]
 Block0 [
-label = "{START|    02  TPROC     PIC 9(1)    VALUE 0.\l    02  TTO       PIC X(1)    VALUE \"3\".\l    02  TUSING    PIC X(1)    VALUE \"2\".\l    02  TFROM     PIC X(1)    VALUE \"1\".\l    02  TN        PIC 9(1)    VALUE 3.\l    02  CPROC     PIC 9(1)    VALUE 0.\l    02  CTO       PIC X(1)    VALUE \"3\".\l    02  CUSING    PIC X(1)    VALUE \"2\".\l    02  CFROM     PIC X(1)    VALUE \"1\".\l    02  CN        PIC 9(1)    VALUE 3.\l}"
+label = "{START|    02  CN        PIC 9(1)    VALUE 3.\l    02  CFROM     PIC X(1)    VALUE \"1\".\l    02  CUSING    PIC X(1)    VALUE \"2\".\l    02  CTO       PIC X(1)    VALUE \"3\".\l    02  CPROC     PIC 9(1)    VALUE 0.\l    02  TN        PIC 9(1)    VALUE 3.\l    02  TFROM     PIC X(1)    VALUE \"1\".\l    02  TUSING    PIC X(1)    VALUE \"2\".\l    02  TTO       PIC X(1)    VALUE \"3\".\l    02  TPROC     PIC 9(1)    VALUE 0.\l}"
 ]
 Block1 [
 label = "{BEGIN-PROGRAM. Block1|}"

--- a/TypeCobol.Analysis.Test/BasicCfgPrograms/HanoiPrg.dot
+++ b/TypeCobol.Analysis.Test/BasicCfgPrograms/HanoiPrg.dot
@@ -8,7 +8,7 @@ edge [
 arrowtail = "empty"
 ]
 Block0 [
-label = "{START|}"
+label = "{START|    02  TPROC     PIC 9(1)    VALUE 0.\l    02  TTO       PIC X(1)    VALUE \"3\".\l    02  TUSING    PIC X(1)    VALUE \"2\".\l    02  TFROM     PIC X(1)    VALUE \"1\".\l    02  TN        PIC 9(1)    VALUE 3.\l    02  CPROC     PIC 9(1)    VALUE 0.\l    02  CTO       PIC X(1)    VALUE \"3\".\l    02  CUSING    PIC X(1)    VALUE \"2\".\l    02  CFROM     PIC X(1)    VALUE \"1\".\l    02  CN        PIC 9(1)    VALUE 3.\l}"
 ]
 Block1 [
 label = "{BEGIN-PROGRAM. Block1|}"

--- a/TypeCobol.Analysis.Test/DfaBuildUseAndDefListTest.cs
+++ b/TypeCobol.Analysis.Test/DfaBuildUseAndDefListTest.cs
@@ -24,7 +24,7 @@ namespace TypeCobol.Analysis.Test
             Assert.AreEqual(useList[0].Variable.Name, "A");
 
             var defList = dfaResults.GetDefList(dfaResults.Graphs[0]);
-            Assert.AreEqual(0, defList.Count);
+            Assert.AreEqual(1, defList.Count);
         }
 
         [TestMethod]

--- a/TypeCobol.Analysis.Test/DfaCallPgmReport.cs
+++ b/TypeCobol.Analysis.Test/DfaCallPgmReport.cs
@@ -59,11 +59,11 @@ namespace TypeCobol.Analysis.Test
         public void ProcCallPgmReportTest()
         {
             string path = Path.Combine(CfgTestUtils.Report, "ProcCallPgm.cbl");
-            var cfgs = ParseCompareDiagnostics<DfaBasicBlockInfo<VariableSymbol>>(path, CfgBuildingMode.WithDfa);
-            Assert.IsTrue(cfgs.Count == 1);
+            DfaTestResults dfaresult = ParseCompareDiagnosticsWithDfa(path);
+            Assert.IsTrue(dfaresult.Graphs.Count == 1);
 
             //Create the report file.
-            ZCallPgmReport reporter = new ZCallPgmReport(cfgs);
+            ZCallPgmReport reporter = new ZCallPgmReport(dfaresult.Graphs);
             using (StringWriter sw = new StringWriter())
             {
                 reporter.Report(sw);

--- a/TypeCobol.Analysis.Test/DfaCallPgmReport.cs
+++ b/TypeCobol.Analysis.Test/DfaCallPgmReport.cs
@@ -54,5 +54,26 @@ namespace TypeCobol.Analysis.Test
                 TypeCobol.Test.TestUtils.compareLines(path, result, expected, output);
             }
         }
+
+        [TestMethod]
+        public void ProcCallPgmReportTest()
+        {
+            string path = Path.Combine(CfgTestUtils.Report, "ProcCallPgm.cbl");
+            var cfgs = ParseCompareDiagnostics<DfaBasicBlockInfo<VariableSymbol>>(path, CfgBuildingMode.WithDfa);
+            Assert.IsTrue(cfgs.Count == 1);
+
+            //Create the report file.
+            ZCallPgmReport reporter = new ZCallPgmReport(cfgs);
+            using (StringWriter sw = new StringWriter())
+            {
+                reporter.Report(sw);
+                // compare with expected result
+                string result = sw.ToString();
+                string output = Path.Combine(CfgTestUtils.Report, "ProcCallPgm.csv");
+                string expected = File.ReadAllText(output, DocumentFormat.RDZReferenceFormat.Encoding);
+                TypeCobol.Test.TestUtils.compareLines(path, result, expected, output);
+            }
+        }
+
     }
 }

--- a/TypeCobol.Analysis.Test/Report/ProcCallPgm.cbl
+++ b/TypeCobol.Analysis.Test/Report/ProcCallPgm.cbl
@@ -1,0 +1,26 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ProcCall.
+      
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 PROGRAM_NAME      pic X(08) value 'PGM00000'.
+       01 I pic 9(03) value 0.
+      
+       PROCEDURE DIVISION.
+           perform varying I from 1 by 1 until I < 10
+               if(I > 50) 
+                    move "MyPgm" to PROGRAM_NAME
+                end-if  
+                call 'zcallpgm' using PROGRAM_NAME
+                move "MyPgm2" to PROGRAM_NAME
+                if(I > 50) 
+                    perform Set-MyPgm3
+                end-if
+           end-perform
+           call 'zcallpgm' using PROGRAM_NAME
+           .
+       Set-MyPgm3.
+           move "MyPgm3" to PROGRAM_NAME
+           .
+      
+       END PROGRAM ProcCall.  

--- a/TypeCobol.Analysis.Test/Report/ProcCallPgm.csv
+++ b/TypeCobol.Analysis.Test/Report/ProcCallPgm.csv
@@ -1,0 +1,7 @@
+ObjectName=PGM00000;Line=14;Column=17;Path=ProcCall.PROGRAM_NAME<-"PGM00000";SourceText=call 'zcallpgm' using PROGRAM_NAME
+ObjectName=MyPgm;Line=14;Column=17;Path=ProcCall.PROGRAM_NAME<-"MyPgm";SourceText=call 'zcallpgm' using PROGRAM_NAME
+ObjectName=MyPgm2;Line=14;Column=17;Path=ProcCall.PROGRAM_NAME<-"MyPgm2";SourceText=call 'zcallpgm' using PROGRAM_NAME
+ObjectName=MyPgm3;Line=14;Column=17;Path=ProcCall.PROGRAM_NAME<-"MyPgm3";SourceText=call 'zcallpgm' using PROGRAM_NAME
+ObjectName=PGM00000;Line=20;Column=12;Path=ProcCall.PROGRAM_NAME<-"PGM00000";SourceText=call 'zcallpgm' using PROGRAM_NAME
+ObjectName=MyPgm2;Line=20;Column=12;Path=ProcCall.PROGRAM_NAME<-"MyPgm2";SourceText=call 'zcallpgm' using PROGRAM_NAME
+ObjectName=MyPgm3;Line=20;Column=12;Path=ProcCall.PROGRAM_NAME<-"MyPgm3";SourceText=call 'zcallpgm' using PROGRAM_NAME

--- a/TypeCobol.Analysis/Dfa/DataFlowGraphBuilder.cs
+++ b/TypeCobol.Analysis/Dfa/DataFlowGraphBuilder.cs
@@ -26,7 +26,13 @@ namespace TypeCobol.Analysis.Dfa
             System.Diagnostics.Debug.Assert(cfg != null);
             this.Cfg = cfg;
             this.Cfg.ResetAllBlockData();
+            CollectDataDefinitions();
         }
+
+        /// <summary>
+        /// Collect Data Definitions
+        /// </summary>
+        protected abstract void CollectDataDefinitions();
 
         /// <summary>
         /// The USE List

--- a/TypeCobol.Analysis/Dfa/DefaultDataFlowGraphBuilder.cs
+++ b/TypeCobol.Analysis/Dfa/DefaultDataFlowGraphBuilder.cs
@@ -44,16 +44,20 @@ namespace TypeCobol.Analysis.Dfa
                 var dataDivision = this.Cfg.ProcedureDivisionNode.Parent.GetChildren<DataDivision>().FirstOrDefault();
                 if (dataDivision != null)
                 {
-                    foreach(var dataDef in Collect(dataDivision))
+                    var firstInstr = root.Instructions.First;
+                    foreach (var dataDef in Collect(dataDivision))
                     {
-                        root.Instructions.AddFirst(dataDef);
+                        if (firstInstr == null)
+                            root.Instructions.AddLast(dataDef);
+                        else
+                            root.Instructions.AddBefore(firstInstr, dataDef);
                     }
                 }
                 IEnumerable<DataDefinition> Collect(Node node)
                 {
-                    if (node.SemanticData is VariableSymbol variable && variable.Value != null)
+                    if (node.SemanticData is VariableSymbol variable && variable.Value is Value)
                     {
-                        yield return node as DataDefinition;
+                        yield return (DataDefinition)node;
                     }
 
                     if (node.ChildrenCount > 0)
@@ -88,7 +92,7 @@ namespace TypeCobol.Analysis.Dfa
         public override HashSet<VariableSymbol> GetDefVariables(Node node)
         {
             System.Diagnostics.Debug.Assert(node != null);
-            return node is DataDefinition ? new HashSet<VariableSymbol>() { node.SemanticData as VariableSymbol} : GetSymbols(node.StorageAreaWritesSymbol);
+            return node is DataDefinition ? new HashSet<VariableSymbol>() { (VariableSymbol)node.SemanticData} : GetSymbols(node.StorageAreaWritesSymbol);
         }
     }
 }

--- a/TypeCobol.Analysis/Dfa/DefaultDataFlowGraphBuilder.cs
+++ b/TypeCobol.Analysis/Dfa/DefaultDataFlowGraphBuilder.cs
@@ -4,6 +4,7 @@ using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.Nodes;
 using TypeCobol.Compiler.Symbols;
 using TypeCobol.Compiler.Types;
+using System.Linq;
 
 namespace TypeCobol.Analysis.Dfa
 {
@@ -12,40 +13,6 @@ namespace TypeCobol.Analysis.Dfa
     /// </summary>
     public class DefaultDataFlowGraphBuilder : DataFlowGraphBuilder<Node, VariableSymbol>
     {
-        /// <summary>
-        /// Collector of DataDefinition Nodes in the list of Instructions of a given block.
-        /// </summary>
-        public class DataDefinitionCollector : AbstractSymbolAndTypeVisitor<BasicBlock<Node, DfaBasicBlockInfo<VariableSymbol>> , BasicBlock<Node, DfaBasicBlockInfo<VariableSymbol>> >
-        {
-            public override BasicBlock<Node, DfaBasicBlockInfo<VariableSymbol>>  VisitSymbol(Symbol s, BasicBlock<Node, DfaBasicBlockInfo<VariableSymbol>>  block)
-            {
-                s.Type?.Accept(this, block);
-                return block;
-            }
-
-            public override BasicBlock<Node, DfaBasicBlockInfo<VariableSymbol>>  VisitType(Type t, BasicBlock<Node, DfaBasicBlockInfo<VariableSymbol>> block)
-            {
-                t.TypeComponent?.Accept(this, block);
-                return block;
-            }
-
-            public override BasicBlock<Node, DfaBasicBlockInfo<VariableSymbol>>  VisitVariableSymbol(VariableSymbol s, BasicBlock<Node, DfaBasicBlockInfo<VariableSymbol>> block)
-            {
-                if (s.Value != null)
-                    block.Instructions.AddFirst(s.TargetNode as DataDefinition);
-                return VisitSymbol(s, block);
-            }
-
-            public override BasicBlock<Node, DfaBasicBlockInfo<VariableSymbol>>  VisitGroupType(Compiler.Types.GroupType t, BasicBlock<Node, DfaBasicBlockInfo<VariableSymbol>> block)
-            {
-                foreach (var field in t.Fields)
-                {
-                    field.Accept(this, block);
-                }
-                return block;
-            }
-        }
-
         private static HashSet<VariableSymbol> GetSymbols(Dictionary<StorageArea, VariableSymbol> symbolDictionary)
         {
             var result = new HashSet<VariableSymbol>();
@@ -74,24 +41,31 @@ namespace TypeCobol.Analysis.Dfa
             if (Cfg != null && Cfg.IsInitialized)
             {
                 var root = Cfg.RootBlock;
-                var prg = Cfg.ProgramOrFunctionNode;
-                var prgSymbol = (ProgramSymbol)prg.SemanticData;
-                DataDefinitionCollector ddc = new DataDefinitionCollector();
-                foreach(var vs in prgSymbol.WorkingStorageData)
+                var dataDivision = this.Cfg.ProcedureDivisionNode.Parent.GetChildren<DataDivision>().FirstOrDefault();
+                if (dataDivision != null)
                 {
-                    vs.Accept(ddc, root);
+                    foreach(var dataDef in Collect(dataDivision))
+                    {
+                        root.Instructions.AddFirst(dataDef);
+                    }
                 }
-                foreach (var vs in prgSymbol.LocalStorageData)
+                IEnumerable<DataDefinition> Collect(Node node)
                 {
-                    vs.Accept(ddc, root);
-                }
-                foreach (var vs in prgSymbol.LinkageData)
-                {
-                    vs.Accept(ddc, root);
-                }
-                foreach (var vs in prgSymbol.FileData)
-                {
-                    vs.Accept(ddc, root);
+                    if (node.SemanticData is VariableSymbol variable && variable.Value != null)
+                    {
+                        yield return node as DataDefinition;
+                    }
+
+                    if (node.ChildrenCount > 0)
+                    {
+                        foreach (var child in node.Children)
+                        {
+                            foreach (var childVariable in Collect(child))
+                            {
+                                yield return childVariable;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/TypeCobol.Analysis/Dfa/ValueOrigin.cs
+++ b/TypeCobol.Analysis/Dfa/ValueOrigin.cs
@@ -27,7 +27,7 @@ namespace TypeCobol.Analysis.Dfa
         /// (2.1.1.2) a SET statement
         ///     (2.1.1.2.1) The Set instruction is Condition variable set then
         ///                 the value is the first value of the level 88 variable
-        /// (2.1.1.3) a DataDescription, Redefines or a DataCondition Entry from a Data Definition.
+        /// (2.1.1.3) a DataDescription or Redefines Entry from a Data Definition.
         ///     (2.1.1.3.1) Take the initiale value and add it to the origins path.
         /// </summary>
         /// <param name="start">UsePoint to start the analysis.</param>
@@ -70,7 +70,6 @@ namespace TypeCobol.Analysis.Dfa
                         break;
                     case CodeElementType.DataDescriptionEntry:
                     case CodeElementType.DataRedefinesEntry:
-                    case CodeElementType.DataConditionEntry:
                         //(2.1.1.3)
                         ProcessDataDefinition(defPoint.Instruction as DataDefinition);
                         break;                    
@@ -150,14 +149,6 @@ namespace TypeCobol.Analysis.Dfa
                         };
                         result.Origins.Add(origin);
                     }
-                    else if (vs.Value is Value[] values && values.Length > 0)
-                    {
-                        var origin = new ValueOrigin(vs)
-                        {
-                            Value = values[0]
-                        };
-                        result.Origins.Add(origin);
-                    };                        
                 }
             }
 

--- a/TypeCobol.Analysis/Dfa/ValueOrigin.cs
+++ b/TypeCobol.Analysis/Dfa/ValueOrigin.cs
@@ -140,25 +140,24 @@ namespace TypeCobol.Analysis.Dfa
                 void ProcessDataDefinition(DataDefinition dataDef)
                 {
                     VariableSymbol vs = (VariableSymbol)dataDef.SemanticData;
-                    if (vs.Value != null)
-                    { //(2.1.1.3.1) Take the initial value and add it to the origins path.
-                        if (vs.Value is Value value)
-                        {                            
-                            var origin = new ValueOrigin(vs)
-                            {
-                                Value = value
-                            };
-                            result.Origins.Add(origin);
-                        }
-                        else if (vs.Value is Value[] values && values.Length > 0)
+                    System.Diagnostics.Debug.Assert(vs.Value != null);
+                    //(2.1.1.3.1) Take the initial value and add it to the origins path.
+                    if (vs.Value is Value value)
+                    {                            
+                        var origin = new ValueOrigin(vs)
                         {
-                            var origin = new ValueOrigin(vs)
-                            {
-                                Value = values[0]
-                            };
-                            result.Origins.Add(origin);
-                        };                        
+                            Value = value
+                        };
+                        result.Origins.Add(origin);
                     }
+                    else if (vs.Value is Value[] values && values.Length > 0)
+                    {
+                        var origin = new ValueOrigin(vs)
+                        {
+                            Value = values[0]
+                        };
+                        result.Origins.Add(origin);
+                    };                        
                 }
             }
 


### PR DESCRIPTION
**Purpose**
This Pull request is based on branch 
https://github.com/TypeCobolTeam/TypeCobol/compare/1260_CFG_DFA_SemanticDomainLite_IntegrateAsAnalyzer

To allow Data Definition having values and declared in the DataDivision of a Program to be put as instruction nodes in the START block of the corresponding PROCEDURE DIVISION.
So that their intial values are correctly propagated by DFA algorithms from the START block.