### PR TITLE
WI #1837 Add Violation class

### DIFF
--- a/TypeCobol/Analysis/Violation.cs
+++ b/TypeCobol/Analysis/Violation.cs
@@ -1,0 +1,27 @@
+﻿using TypeCobol.Compiler.Diagnostics;
+
+namespace TypeCobol.Analysis
+{
+    /// <summary>
+    /// Custom diagnostic to represent a Quality Rule Violation
+    /// </summary>
+    public class Violation : Diagnostic
+    {
+        private const int DIAGNOSTIC_CODE = (int) MessageCode.QualityRuleViolation;
+
+        private static DiagnosticMessage ToDiagnosticMessage(Severity severity, string message, string ruleId)
+        {
+            //RuleId is stored in ReferenceText, it will then be transferred through LSP as 'source'.
+            //Diagnostic code is fixed, it means that all diagnostics with code '47' are in fact quality rule violations created by an analyzer.
+            return new DiagnosticMessage(Category.CodeAnalysis, DIAGNOSTIC_CODE, severity, message, null, 0, ruleId);
+        }
+
+        public string RuleId => Info.ReferenceText;
+
+        public Violation(string ruleId, Severity severity, int lineNumber, int columnStart, int columnEnd, string message)
+            : base(ToDiagnosticMessage(severity, message, ruleId), columnStart, columnEnd, lineNumber)
+        {
+
+        }
+    }
+}

--- a/TypeCobol/Compiler/CodeElements/ASTAnalyzerBase.cs
+++ b/TypeCobol/Compiler/CodeElements/ASTAnalyzerBase.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using TypeCobol.Analysis;
 using TypeCobol.Compiler.Diagnostics;
@@ -26,19 +27,7 @@ namespace TypeCobol.Compiler.CodeElements
         /// Returns the diagnostics produced by this analyzer.
         /// May be empty, but not null.
         /// </summary>
-        public IEnumerable<Diagnostic> Diagnostics
-        {
-            get
-            {
-                if (_diagnostics != null)
-                {
-                    foreach (var diagnostic in _diagnostics)
-                    {
-                        yield return diagnostic;
-                    }
-                }
-            }
-        }
+        public IEnumerable<Diagnostic> Diagnostics => _diagnostics ?? Enumerable.Empty<Diagnostic>();
 
         /// <summary>
         /// Returns the result produced by this analyzer.

--- a/TypeCobol/Compiler/CupParser/NodeBuilder/SyntaxDrivenAnalyzerBase.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/SyntaxDrivenAnalyzerBase.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using TypeCobol.Analysis;
 using TypeCobol.Compiler.Diagnostics;
@@ -28,19 +29,7 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
         /// Returns the diagnostics produced by this analyzer.
         /// May be empty, but not null.
         /// </summary>
-        public IEnumerable<Diagnostic> Diagnostics
-        {
-            get
-            {
-                if (_diagnostics != null)
-                {
-                    foreach (var diagnostic in _diagnostics)
-                    {
-                        yield return diagnostic;
-                    }
-                }
-            }
-        }
+        public IEnumerable<Diagnostic> Diagnostics => _diagnostics ?? Enumerable.Empty<Diagnostic>();
 
         /// <summary>
         /// Returns the result produced by this analyzer.

--- a/TypeCobol/Compiler/Diagnostics/Diagnostic.cs
+++ b/TypeCobol/Compiler/Diagnostics/Diagnostic.cs
@@ -12,17 +12,23 @@ namespace TypeCobol.Compiler.Diagnostics
     public class Diagnostic
     {
         public Diagnostic(MessageCode messageCode, int columnStart, int columnEnd, int lineNumber, params object[] messageArgs)
+            : this(DiagnosticMessage.GetFromCode[(int)messageCode], columnStart, columnEnd, lineNumber, messageArgs)
         {
-            Info = DiagnosticMessage.GetFromCode[(int)messageCode];
+
+        }
+
+        protected Diagnostic(DiagnosticMessage info, int columnStart, int columnEnd, int lineNumber, params object[] messageArgs)
+        {
+            Info = info;
 
             ColumnStart = Math.Max(columnStart, 0);
-            ColumnEnd   = Math.Max(columnEnd,   0);
+            ColumnEnd = Math.Max(columnEnd, 0);
 
             Line = lineNumber;
-            Message = String.Format(Info.MessageTemplate, messageArgs ?? new object[0]);
+            Message = string.Format(Info.MessageTemplate, messageArgs ?? new object[0]);
             if (messageArgs != null)
             {
-                CatchedException = messageArgs.FirstOrDefault(x => x is Exception) as Exception;
+                CatchedException = messageArgs.OfType<Exception>().FirstOrDefault();
                 MessageArgs = messageArgs;
             }
         }

--- a/TypeCobol/Compiler/Diagnostics/DiagnosticMessage.cs
+++ b/TypeCobol/Compiler/Diagnostics/DiagnosticMessage.cs
@@ -22,12 +22,13 @@ namespace TypeCobol.Compiler.Diagnostics
         Syntax = 4,
         Semantics = 5,
         Generation = 6,
-        General = 7
+        General = 7,
+        CodeAnalysis = 8
     }
 
     public class DiagnosticMessage
     {
-        private DiagnosticMessage(Category category, int code, Severity severity, string messageTemplate, ReferenceDocument document, int pageNumber, string referenceText)
+        internal DiagnosticMessage(Category category, int code, Severity severity, string messageTemplate, ReferenceDocument document, int pageNumber, string referenceText)
         {
             Category = category;
             Code = code;

--- a/TypeCobol/Compiler/Diagnostics/MessageCode.cs
+++ b/TypeCobol/Compiler/Diagnostics/MessageCode.cs
@@ -53,6 +53,7 @@ namespace TypeCobol.Compiler.Diagnostics
         ErrorFormalizedCommentMissplaced = 43,
         MultiFormalizedCommentIndicatorMisused = 44,
         Info = 45,
-        AnalyzerFailure = 46
+        AnalyzerFailure = 46,
+        QualityRuleViolation = 47 //MessageCode 47 is reserved for violations coming from any analyzer
     }
 }

--- a/TypeCobol/Compiler/Diagnostics/Resources/DiagnosticMessages.csv
+++ b/TypeCobol/Compiler/Diagnostics/Resources/DiagnosticMessages.csv
@@ -44,4 +44,4 @@ Category;Code;Severity;MessageTemplate;Document;PageNumber;ReferenceText
 5;43;1;Formalized Comment misplaced;0;0;Page
 5;44;1;Invalid use of '%'. Should be used with "%<< ... (linebreak) %>>" for MultiLine Comment or "%<<< ... (linebreak) %>>>" for Formalized Comment;0;0;Page
 7;45;2;Info: {0};0;0;
-7;46;1;CodeAnalysis: analyzer '{0}' failed. Exception message is '{1}';0;0;
+8;46;1;CodeAnalysis: analyzer '{0}' failed. Exception message is '{1}';0;0;


### PR DESCRIPTION
Minimal implementation of `Violation` concept :
- no change in API, violations are still handled as regular diagnostics through the whole process
- the new `Violation` class can be used by analyzer implementers to represent a quality rule violation
- `RuleId` is transported as 'source' in LSP diagnostic object
- all rule violations are identified by the same reserved 'code' (47)