### PR TITLE
WI #428 Handle token scan state dependent in DataDivision.

### DIFF
--- a/TypeCobol.Test/Parser/Programs/Cobol85/ReplaceTokenInsideDataDiv2.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ReplaceTokenInsideDataDiv2.rdz.cbl
@@ -1,0 +1,9 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOZCHKP.
+       data division.
+       working-storage section.
+       REPLACE
+                ==C-NBRPCB==      BY ==6==.  
+       01  W-IDTPCB OCCURS C-NBRPCB    PIC X(8).      
+      
+       END PROGRAM TCOZCHKP.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ReplaceTokenInsideDataDiv2.rdzSYM.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ReplaceTokenInsideDataDiv2.rdzSYM.txt
@@ -1,0 +1,19 @@
+﻿--- Program ---
+TCOZCHKP (.NET Type=ProgramSymbol, Kind=Program)
+Type:
+  (.NET Type=ScopeType, Tag=Scope)
+WorkingStorageData:
+  W-IDTPCB (.NET Type=VariableSymbol, Kind=Variable)
+  Flags: [WORKING_STORAGE]
+  Owner: TCOZCHKP
+  Type:
+    (.NET Type=ArrayType, Tag=Array)
+    MinOccur: 1
+    MaxOccur: 6
+    ElementType:
+      (.NET Type=PictureType, Tag=Picture)
+      Picture: X(8)
+  Level: 1
+  IsFiller: False
+IsNested: False
+

--- a/TypeCobol/Compiler/Preprocessor/ReplaceTokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Preprocessor/ReplaceTokensLinesIterator.cs
@@ -451,7 +451,7 @@ namespace TypeCobol.Compiler.Preprocessor
 					string replacedTokenText = Regex.Replace(normalizedTokenText, normalizedPartToReplace, replacementPart, RegexOptions.IgnoreCase);
                     // Transfer the scanner context the of original token to the call below
                     Diagnostic error = null;					
-                    MultilineScanState scanState = FigureOutScanState(originalToken);
+                    MultilineScanState scanState = originalToken.ScanStateSnapshot;
                     Token generatedToken = Scanner.Scanner.ScanIsolatedToken(replacedTokenText, out error, scanState);
                     // TO DO : find a way to report the error above ...
 
@@ -509,27 +509,13 @@ namespace TypeCobol.Compiler.Preprocessor
         }
 
         /// <summary>
-        /// Figure out a scan state from the given token.
-        /// </summary>
-        /// <param name="token">The Token to figure out the scan state.</param>
-        /// <returns>The Scan state in any, null otherwise</returns>
-        private static MultilineScanState FigureOutScanState(Token token)
-        {
-            if (token != null)
-            {
-                return token.ScanStateSnapshot ?? (token.TokensLine is TokensLine tl ? tl.ScanState : null);
-            }
-            return null;
-        }
-
-        /// <summary>
         /// Rescan the TokenType of a set of replaced Tokens.
         /// </summary>
         /// <param name="firstOriginalToken">The first original token to be replaced</param>
         /// <param name="replacedTokens">The array of replacement tokens.</param>
         private static void RescanReplacedTokenTypes(Token firstOriginalToken, params Token[] replacedTokens)
         {
-            MultilineScanState scanState = FigureOutScanState(firstOriginalToken);
+            MultilineScanState scanState = firstOriginalToken.ScanStateSnapshot;
             if (scanState != null && replacedTokens.Any(MultilineScanState.IsScanStateDependent))
             {
                 StringBuilder sb = new StringBuilder();

--- a/TypeCobol/Compiler/Scanner/ITokensLine.cs
+++ b/TypeCobol/Compiler/Scanner/ITokensLine.cs
@@ -30,5 +30,11 @@ namespace TypeCobol.Compiler.Scanner
         /// True if the first token on this line continues the last token of the previous line
         /// </summary>
         bool HasTokenContinuationFromPreviousLine { get; }
+
+        /// <summary>
+        /// Internal state used by the Scanner to disambiguate context-sensitive keywords
+        /// </summary>
+        MultilineScanState ScanState { get; }
+
     }
 }

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -2006,21 +2006,20 @@ namespace TypeCobol.Compiler.Scanner
                 return new Token(TokenType.IS, startIndex, endIndex, tokensLine);
             }
             else
-            {
-                var picToken = new Token(TokenType.PictureCharacterString, startIndex, endIndex, tokensLine);
+            {                
                 var patternEndIndex = endIndex;
                 var replaceStartIndex = line.Substring(startIndex).IndexOf(":", StringComparison.Ordinal) + startIndex;
-                if (replaceStartIndex > picToken.StartIndex && picToken.EndColumn > replaceStartIndex && CheckForPartialCobolWordPattern(replaceStartIndex, out patternEndIndex)) 
+                if (replaceStartIndex > startIndex && (patternEndIndex + 1) > replaceStartIndex && CheckForPartialCobolWordPattern(replaceStartIndex, out patternEndIndex)) 
                 { //Check if there is cobol partial word inside the picture declaration. 
-                    picToken.TokenType = TokenType.PartialCobolWord; //Match the whole PictureCharecterString token as a partial cobol word. 
+                    //Match the whole PictureCharecterString token as a partial cobol word. 
+                    var picToken = new Token(TokenType.PartialCobolWord, startIndex, endIndex, tokensLine);
                     picToken.PreviousTokenType = TokenType.PictureCharacterString; //Save that the token was previously a picture character string token
-                    picToken.ScanStateSnapshot = picToken.ScanStateSnapshot ?? tokensLine.ScanState.Clone();
                     return picToken;
                 }
                 else
                 {
                     // Return a picture character string
-                    return picToken;
+                    return new Token(TokenType.PictureCharacterString, startIndex, endIndex, tokensLine);
                 }
                
             }
@@ -2450,7 +2449,6 @@ namespace TypeCobol.Compiler.Scanner
             currentIndex = endIndex + 1;
 
             Token t = new Token(TokenType.PartialCobolWord, startIndex, endIndex, tokensLine);
-            t.ScanStateSnapshot = t.ScanStateSnapshot ?? tokensLine.ScanState.Clone();
             return t;
         }
     }

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -2014,7 +2014,7 @@ namespace TypeCobol.Compiler.Scanner
                 { //Check if there is cobol partial word inside the picture declaration. 
                     picToken.TokenType = TokenType.PartialCobolWord; //Match the whole PictureCharecterString token as a partial cobol word. 
                     picToken.PreviousTokenType = TokenType.PictureCharacterString; //Save that the token was previously a picture character string token
-                    picToken.ScanStateSnapshot = tokensLine.ScanState.Clone();
+                    picToken.ScanStateSnapshot = picToken.ScanStateSnapshot ?? tokensLine.ScanState.Clone();
                     return picToken;
                 }
                 else
@@ -2450,7 +2450,7 @@ namespace TypeCobol.Compiler.Scanner
             currentIndex = endIndex + 1;
 
             Token t = new Token(TokenType.PartialCobolWord, startIndex, endIndex, tokensLine);
-            t.ScanStateSnapshot = tokensLine.ScanState.Clone();
+            t.ScanStateSnapshot = t.ScanStateSnapshot ?? tokensLine.ScanState.Clone();
             return t;
         }
     }

--- a/TypeCobol/Compiler/Scanner/Token.cs
+++ b/TypeCobol/Compiler/Scanner/Token.cs
@@ -78,7 +78,8 @@ namespace TypeCobol.Compiler.Scanner
             //Scan Dependent Tokens Inside DataDivision must have their scan state. see #428
             if (tokensLine is TokensLine tl && tl.ScanState != null && (tokenType == TokenType.PartialCobolWord || 
                     tl.ScanState.InsideDataDivision && MultilineScanState.IsScanStateDependent(this)))
-                ScanStateSnapshot = tl.ScanState.Clone();
+                scanStateSnapshot = tl.ScanState.Clone();
+
         }
 
         /// <summary>
@@ -302,7 +303,7 @@ namespace TypeCobol.Compiler.Scanner
         /// </summary>
         public LiteralTokenValue LiteralValue { get; set; }
 
-        private MultilineScanState scanStateSnapshot;
+        private readonly MultilineScanState scanStateSnapshot;
         /// <summary>
         /// ScanState associated to this token if any, null otherwise.
         /// This property is used to allow PartialCobolWords proper reconstruction.
@@ -312,10 +313,6 @@ namespace TypeCobol.Compiler.Scanner
             get
             {
                 return scanStateSnapshot ?? (this.TokensLine is TokensLine tl ? tl.ScanState : null);
-            }
-            private set
-            {
-                scanStateSnapshot = value;
             }
         }
 

--- a/TypeCobol/Compiler/Scanner/Token.cs
+++ b/TypeCobol/Compiler/Scanner/Token.cs
@@ -76,9 +76,9 @@ namespace TypeCobol.Compiler.Scanner
             UsesVirtualSpaceAtEndOfLine = usesVirtualSpaceAtEndOfLine;
 
             //Scan Dependent Tokens Inside DataDivision must have their scan state. see #428
-            if (tokensLine is TokensLine tl && tl.ScanState != null && (tokenType == TokenType.PartialCobolWord || 
-                    tl.ScanState.InsideDataDivision && MultilineScanState.IsScanStateDependent(this)))
-                scanStateSnapshot = tl.ScanState.Clone();
+            if (tokensLine.ScanState != null && (tokenType == TokenType.PartialCobolWord ||
+                    tokensLine.ScanState.InsideDataDivision && MultilineScanState.IsScanStateDependent(this)))
+                scanStateSnapshot = tokensLine.ScanState.Clone();
 
         }
 
@@ -312,7 +312,7 @@ namespace TypeCobol.Compiler.Scanner
         {
             get
             {
-                return scanStateSnapshot ?? (this.TokensLine is TokensLine tl ? tl.ScanState : null);
+                return scanStateSnapshot ?? tokensLine.ScanState;
             }
         }
 

--- a/TypeCobol/Compiler/Scanner/Token.cs
+++ b/TypeCobol/Compiler/Scanner/Token.cs
@@ -74,8 +74,13 @@ namespace TypeCobol.Compiler.Scanner
             HasClosingDelimiter = false;
 
             UsesVirtualSpaceAtEndOfLine = usesVirtualSpaceAtEndOfLine;
-        }  
-      
+
+            //Scan Dependent Tokens Inside DataDivision must have their scan state. see #428
+            if (tokensLine is TokensLine tl && tl.ScanState != null && tl.ScanState.InsideDataDivision
+                && MultilineScanState.IsScanStateDependent(this))
+                ScanStateSnapshot = tl.ScanState.Clone();
+        }
+
         /// <summary>
         /// Constructor for tokens with delimiters
         /// </summary>

--- a/TypeCobol/Compiler/Scanner/Token.cs
+++ b/TypeCobol/Compiler/Scanner/Token.cs
@@ -76,8 +76,8 @@ namespace TypeCobol.Compiler.Scanner
             UsesVirtualSpaceAtEndOfLine = usesVirtualSpaceAtEndOfLine;
 
             //Scan Dependent Tokens Inside DataDivision must have their scan state. see #428
-            if (tokensLine is TokensLine tl && tl.ScanState != null && tl.ScanState.InsideDataDivision
-                && MultilineScanState.IsScanStateDependent(this))
+            if (tokensLine is TokensLine tl && tl.ScanState != null && (tokenType == TokenType.PartialCobolWord || 
+                    tl.ScanState.InsideDataDivision && MultilineScanState.IsScanStateDependent(this)))
                 ScanStateSnapshot = tl.ScanState.Clone();
         }
 
@@ -302,11 +302,22 @@ namespace TypeCobol.Compiler.Scanner
         /// </summary>
         public LiteralTokenValue LiteralValue { get; set; }
 
+        private MultilineScanState scanStateSnapshot;
         /// <summary>
         /// ScanState associated to this token if any, null otherwise.
         /// This property is used to allow PartialCobolWords proper reconstruction.
         /// </summary>
-        public MultilineScanState ScanStateSnapshot { get; set; }
+        public MultilineScanState ScanStateSnapshot
+        {
+            get
+            {
+                return scanStateSnapshot ?? (this.TokensLine is TokensLine tl ? tl.ScanState : null);
+            }
+            private set
+            {
+                scanStateSnapshot = value;
+            }
+        }
 
         // --- Ambiguous tokens resolved after having been created ---
 


### PR DESCRIPTION
This fix handle the case when a replace occurs inside a DataDivision and the replaced token is scan state dependent:
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. TCOZCHKP.
       data division.
       working-storage section.
       REPLACE
                ==C-NBRPCB==      BY ==6==.  
       01  W-IDTPCB OCCURS C-NBRPCB    PIC X(8).      
      
       END PROGRAM TCOZCHKP.
```

