### PR TITLE
WI #1909 Avoid exception on incomplete SELECT statements

### DIFF
--- a/TypeCobol.Test/Parser/Programs/Cobol85/SelectFile.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/SelectFile.cbl
@@ -4,7 +4,9 @@
        ENVIRONMENT DIVISION. 
        INPUT-OUTPUT SECTION.
        FILE-CONTROL.
-                                                            
+           SELECT
+           SELECT ENT00A       ASSIGN
+           SELECT ENT00B       ASSIGN TO
            SELECT ENT010       ASSIGN TO ENT010
                   FILE STATUS WK-ST-ENT010.
        DATA DIVISION.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/SelectFilePGM.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/SelectFilePGM.txt
@@ -1,3 +1,8 @@
+--- Diagnostics ---
+Line 8[12,17] <27, Error, Syntax> - Syntax error : mismatched input 'SELECT' expecting {user defined word, OPTIONAL} RuleStack=codeElement>fileControlEntry>selectClause,  OffendingSymbol=[12,17:SELECT]<SELECT>
+Line 9[12,17] <27, Error, Syntax> - Syntax error : mismatched input 'SELECT' expecting {alphanumeric literal, hexadecimal alphanumeric literal, null terminated alphanumeric literal, user defined word, TO} RuleStack=codeElement>fileControlEntry>assignClause,  OffendingSymbol=[12,17:SELECT]<SELECT>
+Line 10[12,17] <27, Error, Syntax> - Syntax error : mismatched input 'SELECT' expecting {alphanumeric literal, hexadecimal alphanumeric literal, null terminated alphanumeric literal, user defined word} RuleStack=codeElement>fileControlEntry>assignClause,  OffendingSymbol=[12,17:SELECT]<SELECT>
+
 --- Program ---
 PROGRAM: SelectFile common:False initial:False recursive:False
  author: ? written: ? compiled: ? installation: ? security: ?

--- a/TypeCobol/Compiler/CodeElements/Entry/FileControlEntry.cs
+++ b/TypeCobol/Compiler/CodeElements/Entry/FileControlEntry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace TypeCobol.Compiler.CodeElements
 {
@@ -15,6 +16,7 @@ namespace TypeCobol.Compiler.CodeElements
         /// Name of the file in the Cobol program.
         /// Must be identified by an FD or SD entry in the DATA DIVISION.
         /// </summary>
+        [CanBeNull]
         public SymbolDefinition FileName { get; set; }
 
         /// <summary>
@@ -29,6 +31,7 @@ namespace TypeCobol.Compiler.CodeElements
         /// The name component of assignment-name-1 is initially treated as a ddname. 
         /// If no file has been allocated using this ddname, then name is treated as an environment variable
         /// </summary>
+        [CanBeNull]
         public ExternalName ExternalDataSet { get; set; }
 
         /// <summary>

--- a/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
@@ -342,7 +342,10 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
                 currentProg.FileConnectors = new Dictionary<SymbolDefinition, FileControlEntry>();
             }
 
-            currentProg.FileConnectors.Add(entry.FileName, entry);
+            if (entry.FileName != null)
+            {
+                currentProg.FileConnectors.Add(entry.FileName, entry);
+            }
 
             var fileControlEntry = new FileControlEntryNode(entry);
             Enter(fileControlEntry, entry);

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
@@ -638,7 +638,7 @@ namespace TypeCobol.Compiler.Parser
 			if (context.assignClause() != null && context.assignClause().Length > 0)
 			{
 				var assignClauseContext = context.assignClause()[0];
-				entry.ExternalDataSet = CobolWordsBuilder.CreateAssignmentName(assignClauseContext.assignmentName()[0]);
+                entry.ExternalDataSet = CobolWordsBuilder.CreateAssignmentName(assignClauseContext.assignmentName().FirstOrDefault());
 			}
 			if (context.reserveClause() != null && context.reserveClause().Length > 0)
 			{

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolWordsBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolWordsBuilder.cs
@@ -778,8 +778,10 @@ namespace TypeCobol.Compiler.Parser
             return reference;
         }
 
-        internal SymbolDefinition CreateFileNameDefinition(CodeElementsParser.FileNameDefinitionContext context)
+        [CanBeNull]
+        internal SymbolDefinition CreateFileNameDefinition([CanBeNull] CodeElementsParser.FileNameDefinitionContext context)
         {
+            if (context == null) return null;
             return CreateSymbolDefinition(context.UserDefinedWord(), SymbolType.FileName);
         }
 
@@ -1081,8 +1083,10 @@ namespace TypeCobol.Compiler.Parser
             }
         }
 
-        internal ExternalName CreateAssignmentName(CodeElementsParser.AssignmentNameContext context)
+        [CanBeNull]
+        internal ExternalName CreateAssignmentName([CanBeNull] CodeElementsParser.AssignmentNameContext context)
         {
+            if (context == null) return null;
             return CreateExternalName(context.externalName5(), SymbolType.AssignmentName);
         }
 


### PR DESCRIPTION
Fix #1909.
Also corrects same kind of problem with incomplete `ASSIGN` clause.