### PR TITLE
WI #1961 Add IsCopy property into TextSourceInfo object

### DIFF
--- a/TypeCobol.LanguageServer/Workspace.cs
+++ b/TypeCobol.LanguageServer/Workspace.cs
@@ -229,9 +229,9 @@ namespace TypeCobol.LanguageServer
 
             fileCompiler = new FileCompiler(initialTextDocumentLines, CompilationProject.SourceFileProvider,
                 CompilationProject, CompilationProject.CompilationOptions, arrangedCustomSymbol ?? _customSymbols,
-                docContext.IsCopy, CompilationProject);
+                CompilationProject);
 #else
-            fileCompiler = new FileCompiler(initialTextDocumentLines, CompilationProject.SourceFileProvider, CompilationProject, CompilationProject.CompilationOptions, _customSymbols, docContext.IsCopy, CompilationProject);
+            fileCompiler = new FileCompiler(initialTextDocumentLines, CompilationProject.SourceFileProvider, CompilationProject, CompilationProject.CompilationOptions, _customSymbols, CompilationProject);
 #endif
             //Set Any Language Server Connection Options.
             docContext.FileCompiler = fileCompiler;

--- a/TypeCobol.LanguageServer/Workspace.cs
+++ b/TypeCobol.LanguageServer/Workspace.cs
@@ -198,7 +198,7 @@ namespace TypeCobol.LanguageServer
         private FileCompiler OpenTextDocument(DocumentContext docContext, string sourceText, LsrTestingOptions lsrOptions)
         {
             string fileName = Path.GetFileName(docContext.Uri.LocalPath);
-            ITextDocument initialTextDocumentLines = new ReadOnlyTextDocument(fileName, Configuration.Format.Encoding, Configuration.Format.ColumnsLayout, sourceText);
+            ITextDocument initialTextDocumentLines = new ReadOnlyTextDocument(fileName, Configuration.Format.Encoding, Configuration.Format.ColumnsLayout, docContext.IsCopy, sourceText);
             FileCompiler fileCompiler = null;
 
 #if EUROINFO_RULES //Issue #583

--- a/TypeCobol.Test/Parser/FileFormat/TestCobolFile.cs
+++ b/TypeCobol.Test/Parser/FileFormat/TestCobolFile.cs
@@ -83,7 +83,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             {
                 try
                 {
-                    // Load the CobolFile in a TextDocumentl;
+                    // Load the CobolFile in a TextDocument;
                     ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormatWithBadChars.TXT", docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 }
                 catch(Exception e)

--- a/TypeCobol.Test/Parser/FileFormat/TestCobolFile.cs
+++ b/TypeCobol.Test/Parser/FileFormat/TestCobolFile.cs
@@ -27,7 +27,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile("EbcdicRefFormat", out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormat.TXT", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormat.TXT", docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();
@@ -83,8 +83,8 @@ namespace TypeCobol.Test.Parser.FileFormat
             {
                 try
                 {
-                    // Load the CobolFile in a TextDocument
-                    ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormatWithBadChars.TXT", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+                    // Load the CobolFile in a TextDocumentl;
+                    ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormatWithBadChars.TXT", docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 }
                 catch(Exception e)
                 {
@@ -117,7 +117,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile("AsciiRefFormat", out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCOUT.cpy", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCOUT.cpy", docFormat.Encoding, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();
@@ -172,7 +172,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile("AsciiLinuxFormat.14", out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("AsciiLinuxFormat.14", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("AsciiLinuxFormat.14", docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();
@@ -227,7 +227,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile("AsciiFreeFormat", out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("AsciiFreeFormat.cpy", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("AsciiFreeFormat.cpy", docFormat.Encoding, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();
@@ -307,7 +307,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile(filename, out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument(filename, docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument(filename, docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();

--- a/TypeCobol.Test/Parser/Performance/Performance.cs
+++ b/TypeCobol.Test/Parser/Performance/Performance.cs
@@ -235,13 +235,13 @@ namespace TypeCobol.Test.Parser.Performance
             CompilationProject project = new CompilationProject("test",
                 root.FullName, new[] { ".cbl", ".cpy" },
                 documentFormat, new TypeCobolOptions(), CreateAnalyzerProvider());
-            FileCompiler compiler = new FileCompiler(null, filename, project.SourceFileProvider, project, documentFormat.ColumnsLayout, new TypeCobolOptions(), null, false, project);
+            FileCompiler compiler = new FileCompiler(null, filename, documentFormat.ColumnsLayout, false, project.SourceFileProvider, project, new TypeCobolOptions(), null, project);
             //Make an incremental change to the source code
             TestUtils.CompilationStats stats = new TestUtils.CompilationStats();
             ExecuteIncremental(compiler, stats, newLineIndex, newLineText);
 
             // Display a performance report
-            TestUtils.CreateRunReport("Incremental", TestUtils.GetReportDirectoryPath(), compiler.CobolFile.Name, stats, compiler.CompilationResultsForProgram);
+            TestUtils.CreateRunReport("Incremental", TestUtils.GetReportDirectoryPath(), filename, stats, compiler.CompilationResultsForProgram);
         }
 
         private void ExecuteIncremental(FileCompiler compiler, TestUtils.CompilationStats stats, int newLineIndex, string newLineText)

--- a/TypeCobol.Test/Parser/Scanner/ScannerUtils.cs
+++ b/TypeCobol.Test/Parser/Scanner/ScannerUtils.cs
@@ -38,7 +38,7 @@ namespace TypeCobol.Test.Parser.Scanner
 
     internal static class ScannerUtils
     {
-        public static TextSourceInfo TextSourceInfo = new TextSourceInfo("test", IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147), ColumnsLayout.FreeTextFormat, false);
+        public static TextSourceInfo TextSourceInfo = new TextSourceInfo("test", IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147), ColumnsLayout.FreeTextFormat, false);//Assuming a program here, not a copy.
         public static TypeCobolOptions CompilerOptions = new TypeCobolOptions();
         public static List<RemarksDirective.TextNameVariation> CopyTextNameVariations = new List<RemarksDirective.TextNameVariation>();
 

--- a/TypeCobol.Test/Parser/Scanner/ScannerUtils.cs
+++ b/TypeCobol.Test/Parser/Scanner/ScannerUtils.cs
@@ -38,7 +38,7 @@ namespace TypeCobol.Test.Parser.Scanner
 
     internal static class ScannerUtils
     {
-        public static TextSourceInfo TextSourceInfo = new TextSourceInfo("test", IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147), ColumnsLayout.FreeTextFormat);
+        public static TextSourceInfo TextSourceInfo = new TextSourceInfo("test", IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147), ColumnsLayout.FreeTextFormat, false);
         public static TypeCobolOptions CompilerOptions = new TypeCobolOptions();
         public static List<RemarksDirective.TextNameVariation> CopyTextNameVariations = new List<RemarksDirective.TextNameVariation>();
 

--- a/TypeCobol.Test/Parser/Scanner/TestRealPrograms.cs
+++ b/TypeCobol.Test/Parser/Scanner/TestRealPrograms.cs
@@ -28,7 +28,7 @@ namespace TypeCobol.Test.Parser.Scanner
                 string textName = Path.GetFileNameWithoutExtension(fileName);
 
                 // Initialize a CompilationDocument
-                FileCompiler compiler = new FileCompiler(null, textName, project.SourceFileProvider, project, ColumnsLayout.CobolReferenceFormat, new TypeCobolOptions(), null, false, project);
+                FileCompiler compiler = new FileCompiler(null, textName, ColumnsLayout.CobolReferenceFormat, false, project.SourceFileProvider, project, new TypeCobolOptions(), null, project);
 
                 // Start compilation
                 try

--- a/TypeCobol.Test/Parser/TestParserRobustness.cs
+++ b/TypeCobol.Test/Parser/TestParserRobustness.cs
@@ -29,7 +29,7 @@ namespace TypeCobol.Test.Compiler.Parser
             var typeCobolOptions = new TypeCobolOptions();
             var project = new CompilationProject("test project", ".", new[] { ".cbl", ".cpy" },
                 DocumentFormat.FreeTextFormat, typeCobolOptions, null);
-            var compiler = new FileCompiler(textDocument, project.SourceFileProvider, project, typeCobolOptions, asPartOfACopy, project);
+            var compiler = new FileCompiler(textDocument, project.SourceFileProvider, project, typeCobolOptions, project);
 
             // Execute compilation - until the CodeElements phase ONLY
             compiler.CompilationResultsForProgram.UpdateTokensLines();

--- a/TypeCobol.Test/Parser/TestParserRobustness.cs
+++ b/TypeCobol.Test/Parser/TestParserRobustness.cs
@@ -22,7 +22,7 @@ namespace TypeCobol.Test.Compiler.Parser
         private static CodeElement[] ParseCodeElements(string cobolString, bool asPartOfACopy, out Diagnostic[] parserDiagnostics)
         {
             // Load text document from string
-            var textDocument = new ReadOnlyTextDocument("test string", Encoding.Default, ColumnsLayout.FreeTextFormat, "");
+            var textDocument = new ReadOnlyTextDocument("test string", Encoding.Default, ColumnsLayout.FreeTextFormat, asPartOfACopy, string.Empty);
             textDocument.LoadChars(cobolString);
 
             // Create a compilation project and a compiler for this document

--- a/TypeCobol.Test/Parser/Text/TestReadOnlyTextDocument.cs
+++ b/TypeCobol.Test/Parser/Text/TestReadOnlyTextDocument.cs
@@ -49,7 +49,7 @@ namespace TypeCobol.Test.Parser.Text
 
         public static void Check_EmptyDocument()
         {
-            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("empty", Encoding.Default, ColumnsLayout.CobolReferenceFormat, String.Empty);
+            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("empty", Encoding.Default, ColumnsLayout.CobolReferenceFormat, false, String.Empty);
 
             Exception resultException = null;
             try
@@ -176,7 +176,7 @@ namespace TypeCobol.Test.Parser.Text
             }
                 
             // Load the CobolFile in a TextDocument
-            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCOUT.cpy", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCOUT.cpy", docFormat.Encoding, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
             
             if(textDocument.CharAt(0) != '0')
             {
@@ -269,7 +269,7 @@ namespace TypeCobol.Test.Parser.Text
             }
 
             // Load the CobolFile in a TextDocument
-            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCINP free format.cpy", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCINP free format.cpy", docFormat.Encoding, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
 
             if (textDocument.CharAt(0) != '/')
             {

--- a/TypeCobol.Test/Utils/Comparator.cs
+++ b/TypeCobol.Test/Utils/Comparator.cs
@@ -57,7 +57,7 @@ namespace TypeCobol.Test.Utils
             
             string filename = Comparator.paths.SampleName;
             bool isCopy = copyExtensions.Contains(sampleExtension, StringComparer.OrdinalIgnoreCase);
-            Compiler = new FileCompiler(null, filename, project.SourceFileProvider, project, format.ColumnsLayout, options, null, isCopy, project);
+            Compiler = new FileCompiler(null, filename, format.ColumnsLayout, isCopy, project.SourceFileProvider, project, options, null, project);
 
             if (antlrProfiler)
             {

--- a/TypeCobol.Test/Utils/ParserUtils.cs
+++ b/TypeCobol.Test/Utils/ParserUtils.cs
@@ -31,7 +31,7 @@ namespace TypeCobol.Test.Utils
                 localDirectory.FullName, new string[] { ".cbl", ".cpy" },
                 documentFormat, new TypeCobolOptions(), null);
 
-            FileCompiler compiler = new FileCompiler(null, textName, project.SourceFileProvider, project, documentFormat.ColumnsLayout, new TypeCobolOptions(), null, isCopy, project);
+            FileCompiler compiler = new FileCompiler(null, textName, documentFormat.ColumnsLayout, isCopy, project.SourceFileProvider, project, new TypeCobolOptions(), null, project);
             compiler.CompileOnce(ExecutionStep.Preprocessor, false, false);
 
             return compiler.CompilationResultsForProgram;
@@ -51,7 +51,7 @@ namespace TypeCobol.Test.Utils
                 //First use *.cpy as tests will use file WITH extension for program but without extension for copy inside programs => small perf gain
                 localDirectory.FullName, new string[] { ".cpy", ".cbl" },
                 documentFormat, options, null);
-            FileCompiler compiler = new FileCompiler(null, textName, project.SourceFileProvider, project, documentFormat.ColumnsLayout, options, null, isCopy, project);
+            FileCompiler compiler = new FileCompiler(null, textName, documentFormat.ColumnsLayout, isCopy, project.SourceFileProvider, project, options, null, project);
             compiler.CompileOnce();
 
             return compiler.CompilationResultsForProgram;
@@ -67,7 +67,7 @@ namespace TypeCobol.Test.Utils
             var project = new CompilationProject("Empty project", ".", new[] { ".cbl", ".cpy" },
                 DocumentFormat.FreeTextFormat, typeCobolOptions, null);
 
-            var compiler = new FileCompiler(textDocument, project.SourceFileProvider, project, typeCobolOptions, asPartOfACopy, project);
+            var compiler = new FileCompiler(textDocument, project.SourceFileProvider, project, typeCobolOptions, project);
             compiler.CompileOnce();
 
             return compiler.CompilationResultsForProgram;

--- a/TypeCobol.Test/Utils/ParserUtils.cs
+++ b/TypeCobol.Test/Utils/ParserUtils.cs
@@ -60,7 +60,7 @@ namespace TypeCobol.Test.Utils
         public static CompilationUnit ParseCobolString(string cobolString, bool asPartOfACopy)
         {
             //Prepare
-            var textDocument = new ReadOnlyTextDocument("Empty doc", Encoding.Default, ColumnsLayout.FreeTextFormat, "");
+            var textDocument = new ReadOnlyTextDocument("Empty doc", Encoding.Default, ColumnsLayout.FreeTextFormat, asPartOfACopy, string.Empty);
             textDocument.LoadChars(cobolString);
 
             var typeCobolOptions = new TypeCobolOptions();

--- a/TypeCobol/Compiler/CompilationDocument.cs
+++ b/TypeCobol/Compiler/CompilationDocument.cs
@@ -152,6 +152,7 @@ namespace TypeCobol.Compiler
         public CompilationDocument(TextSourceInfo textSourceInfo, bool isImported, IEnumerable<ITextLine> initialTextLines, TypeCobolOptions compilerOptions, IDocumentImporter documentImporter,
             [NotNull] MultilineScanState initialScanState, List<RemarksDirective.TextNameVariation> copyTextNameVariations)
         {
+            //Cannot import a program
             if (isImported) Debug.Assert(textSourceInfo.IsCopy);
 
             TextSourceInfo = textSourceInfo;

--- a/TypeCobol/Compiler/CompilationProject.cs
+++ b/TypeCobol/Compiler/CompilationProject.cs
@@ -204,7 +204,7 @@ namespace TypeCobol.Compiler
 #endif
                 bool wasAlreadyInsideCopy = scanState.InsideCopy;
                 scanState.InsideCopy = true;
-                FileCompiler fileCompiler = new FileCompiler(libraryName, textName, SourceFileProvider, this, ColumnsLayout, CompilationOptions, null, true, scanState, this, copyTextNameVariations);
+                FileCompiler fileCompiler = new FileCompiler(libraryName, textName, ColumnsLayout, true, SourceFileProvider, this, CompilationOptions, null, scanState, this, copyTextNameVariations);
                 fileCompiler.CompileOnce();
                 scanState.InsideCopy = wasAlreadyInsideCopy;
 

--- a/TypeCobol/Compiler/CompilationUnit.cs
+++ b/TypeCobol/Compiler/CompilationUnit.cs
@@ -27,8 +27,8 @@ namespace TypeCobol.Compiler
         /// This method does not scan the inserted text lines to produce tokens.
         /// You must explicitly call UpdateTokensLines() to start an initial scan of the document.
         /// </summary>
-        public CompilationUnit(TextSourceInfo textSourceInfo, ParsingMode mode, IEnumerable<ITextLine> initialTextLines, TypeCobolOptions compilerOptions, IDocumentImporter documentImporter, MultilineScanState initialScanState, List<RemarksDirective.TextNameVariation> copyTextNameVariations, IAnalyzerProvider analyzerProvider) :
-            base(textSourceInfo, mode, initialTextLines, compilerOptions, documentImporter, initialScanState, copyTextNameVariations)
+        public CompilationUnit(TextSourceInfo textSourceInfo, bool isImported, IEnumerable<ITextLine> initialTextLines, TypeCobolOptions compilerOptions, IDocumentImporter documentImporter, MultilineScanState initialScanState, List<RemarksDirective.TextNameVariation> copyTextNameVariations, IAnalyzerProvider analyzerProvider) :
+            base(textSourceInfo, isImported, initialTextLines, compilerOptions, documentImporter, initialScanState, copyTextNameVariations)
         {
             // Initialize performance stats 
             PerfStatsForCodeElementsParser = new PerfStatsForParsingStep(CompilationStep.CodeElementsParser);
@@ -238,7 +238,6 @@ namespace TypeCobol.Compiler
                         CustomSymbols,
                         perfStatsForParserInvocation,
                         customAnalyzers,
-                        Mode == ParsingMode.CopyAsProgram,
                         out root,
                         out newDiagnostics,
                         out nodeCodeElementLinkers,
@@ -253,7 +252,7 @@ namespace TypeCobol.Compiler
                         typedVariablesOutsideTypedef, typeThatNeedTypeLinking, results);
 
                     //Direct copy parsing : remove redundant root 01 level if any.
-                    if (Mode == ParsingMode.CopyAsProgram)
+                    if (UseDirectCopyParsing)
                     {
                         var firstDataDefinition = root.MainProgram
                             .Children[0]  //Data Division

--- a/TypeCobol/Compiler/CupPreprocessor/CompilerDirectiveBuilder.cs
+++ b/TypeCobol/Compiler/CupPreprocessor/CompilerDirectiveBuilder.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Antlr4.Runtime;
-using TypeCobol.Compiler.AntlrUtils;
 using TypeCobol.Compiler.CupCommon;
 using TypeCobol.Compiler.Diagnostics;
 using TypeCobol.Compiler.Directives;
@@ -86,7 +82,6 @@ namespace TypeCobol.Compiler.CupPreprocessor
             TypeCobol.Compiler.Scanner.Token suppress, PairTokenListList replacingOperands)
         {
             var copy = (CopyDirective)CompilerDirective;
-            bool isCopy = copy.COPYToken.TokenType == TokenType.COPY;
             copy.TextName = GetName(qualifiedTextName.TextName);
             copy.TextNameSymbol = qualifiedTextName.TextName;
             {                

--- a/TypeCobol/Compiler/FileCompiler.cs
+++ b/TypeCobol/Compiler/FileCompiler.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
 using JetBrains.Annotations;
 using TypeCobol.Compiler.CodeModel;
 using TypeCobol.Compiler.Directives;
@@ -10,7 +8,6 @@ using TypeCobol.Compiler.File;
 using TypeCobol.Compiler.Preprocessor;
 using TypeCobol.Compiler.Scanner;
 using TypeCobol.Compiler.Text;
-using TypeCobol.Tools;
 
 namespace TypeCobol.Compiler
 {
@@ -186,8 +183,7 @@ namespace TypeCobol.Compiler
                 else
                 {
                     //Direct copy parsing, copy is assumed to be part of Data Division and using comma as the decimal point.
-                    var initialScanState = new MultilineScanState(TextDocument.Source.EncodingForAlphanumericLiterals, true, true);
-                    initialScanState.InsideCopy = true;
+                    var initialScanState = new MultilineScanState(TextDocument.Source.EncodingForAlphanumericLiterals, true, true, insideCopy: true);
                     CompilationResultsForProgram = new CompilationUnit(TextDocument.Source, CompilationDocument.ParsingMode.CopyAsProgram, TextDocument.Lines, compilerOptions, documentImporter, initialScanState, copyTextNameVariations, CompilationProject.AnalyzerProvider);
                     CompilationResultsForCopy = CompilationResultsForProgram;
                 }

--- a/TypeCobol/Compiler/FileCompiler.cs
+++ b/TypeCobol/Compiler/FileCompiler.cs
@@ -151,7 +151,7 @@ namespace TypeCobol.Compiler
             chrono.Start();
             if (textDocument == null)
             {
-                TextDocument = new ReadOnlyTextDocument(sourceFile?.Name, sourceFile?.Encoding, columnsLayout, sourceFile?.ReadChars());
+                TextDocument = new ReadOnlyTextDocument(sourceFile?.Name, sourceFile?.Encoding, columnsLayout, isCopyFile, sourceFile?.ReadChars());
             }
             // 2.b Load it in an existing text document in memory
             else if (sourceFile != null)

--- a/TypeCobol/Compiler/Parser/ProgramClassParserStep.cs
+++ b/TypeCobol/Compiler/Parser/ProgramClassParserStep.cs
@@ -50,7 +50,6 @@ namespace TypeCobol.Compiler.Parser
             SymbolTable customSymbols,
             PerfStatsForParserInvocation perfStatsForParserInvocation,
             ISyntaxDrivenAnalyzer[] customAnalyzers,
-            bool wrapCopyIntoProgram,
             out SourceFile root,
             out List<Diagnostic> diagnostics, 
             out Dictionary<CodeElement, Node> nodeCodeElementLinkers,
@@ -63,7 +62,7 @@ namespace TypeCobol.Compiler.Parser
 #endif
             IEnumerable<CodeElement> before = null;
             IEnumerable<CodeElement> after = null;
-            if (wrapCopyIntoProgram)
+            if (textSourceInfo.IsCopy)
             {
                 var programSkeleton = new CopyParsing.ProgramSkeleton(textSourceInfo);
                 before = programSkeleton.Before();

--- a/TypeCobol/Compiler/Scanner/MultilineScanState.cs
+++ b/TypeCobol/Compiler/Scanner/MultilineScanState.cs
@@ -69,7 +69,11 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// True if we are scanning inside a Copy.
         /// </summary>
-        public bool InsideCopy { get; set; }
+        public bool InsideCopy
+        {
+            get;
+            internal set; //Setter is used only at import time when we jump from including document to included copy.
+        }
 
         /// <summary>
         /// Encoding of the text file : used to decode the value of an hexadecimal alphanumeric literal
@@ -114,8 +118,8 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// Initialize scanner state for the first line
         /// </summary>
-        public MultilineScanState(Encoding encodingForAlphanumericLiterals, bool insideDataDivision = false, bool decimalPointIsComma = false, bool withDebuggingMode = false) :
-            this(insideDataDivision, false, false, false, false, false, false, decimalPointIsComma, withDebuggingMode, encodingForAlphanumericLiterals)
+        public MultilineScanState(Encoding encodingForAlphanumericLiterals, bool insideDataDivision = false, bool decimalPointIsComma = false, bool withDebuggingMode = false, bool insideCopy = false) :
+            this(insideDataDivision, false, false, false, false, false, false, decimalPointIsComma, withDebuggingMode, insideCopy, encodingForAlphanumericLiterals)
         { }
 
         /// <summary>
@@ -123,7 +127,7 @@ namespace TypeCobol.Compiler.Scanner
         /// </summary>
         private MultilineScanState(bool insideDataDivision, bool insideProcedureDivision, bool insidePseudoText, bool insideSymbolicCharacterDefinitions, 
                 bool insideFormalizedComment, bool insideMultilineComments, bool insideParamsField,
-                bool decimalPointIsComma, bool withDebuggingMode, Encoding encodingForAlphanumericLiterals)
+                bool decimalPointIsComma, bool withDebuggingMode, bool insideCopy, Encoding encodingForAlphanumericLiterals)
         {
             InsideDataDivision = insideDataDivision;
             InsideProcedureDivision = insideProcedureDivision;
@@ -134,6 +138,7 @@ namespace TypeCobol.Compiler.Scanner
             InsideSymbolicCharacterDefinitions = insideSymbolicCharacterDefinitions;
             DecimalPointIsComma = decimalPointIsComma;
             WithDebuggingMode = withDebuggingMode;
+            InsideCopy = insideCopy;
             EncodingForAlphanumericLiterals = encodingForAlphanumericLiterals;
         }
 
@@ -144,8 +149,7 @@ namespace TypeCobol.Compiler.Scanner
         {
             MultilineScanState clone = new MultilineScanState(InsideDataDivision, InsideProcedureDivision, InsidePseudoText, InsideSymbolicCharacterDefinitions,
                 InsideFormalizedComment, InsideMultilineComments, InsideParamsField, 
-                DecimalPointIsComma, WithDebuggingMode, EncodingForAlphanumericLiterals);
-            clone.InsideCopy = this.InsideCopy;
+                DecimalPointIsComma, WithDebuggingMode, InsideCopy, EncodingForAlphanumericLiterals);
             if (LastSignificantToken != null) clone.LastSignificantToken = LastSignificantToken;
             if (BeforeLastSignificantToken != null) clone.BeforeLastSignificantToken = BeforeLastSignificantToken;
             if (SymbolicCharacters != null)

--- a/TypeCobol/Compiler/Text/ReadOnlyTextDocument.cs
+++ b/TypeCobol/Compiler/Text/ReadOnlyTextDocument.cs
@@ -20,11 +20,14 @@ namespace TypeCobol.Compiler.Text
         /// Initialize a cobol document from any source of characters
         /// </summary> 
         /// <param name="fileName">Name of the file the document is stored in</param>
+        /// <param name="encodingForAlphanumericLiterals">Document encoding</param>
+        /// <param name="columnsLayout">Document layout</param>
+        /// <param name="isCopy">Document nature</param>
         /// <param name="textSource">Sequence of unicode characters with line delimiters (Cr? Lf)</param>
-        public ReadOnlyTextDocument(string fileName, Encoding encodingForAlphanumericLiterals, ColumnsLayout columnsLayout, IEnumerable<char> textSource)
+        public ReadOnlyTextDocument(string fileName, Encoding encodingForAlphanumericLiterals, ColumnsLayout columnsLayout, bool isCopy, IEnumerable<char> textSource)
         {
             // Document source name and text format
-            Source = new TextSourceInfo(fileName, encodingForAlphanumericLiterals, columnsLayout);
+            Source = new TextSourceInfo(fileName, encodingForAlphanumericLiterals, columnsLayout, isCopy);
 
             // Initialize document text lines
             LoadChars(textSource);

--- a/TypeCobol/Compiler/Text/TextSourceInfo.cs
+++ b/TypeCobol/Compiler/Text/TextSourceInfo.cs
@@ -1,34 +1,39 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 
 namespace TypeCobol.Compiler.Text
 {
     /// <summary>
-    /// Informations on the source file on disk, or the buffer in memory, from which a text document was loaded
+    /// Information on the source file on disk, or the buffer in memory, from which a text document was loaded
     /// </summary>
     public class TextSourceInfo
     {
-        public TextSourceInfo(string name, Encoding encodingForAlphanumericLiterals, ColumnsLayout columnsLayout)
+        public TextSourceInfo(string name, Encoding encodingForAlphanumericLiterals, ColumnsLayout columnsLayout, bool isCopy)
         {
             Name = name;
             EncodingForAlphanumericLiterals = encodingForAlphanumericLiterals;
             ColumnsLayout = columnsLayout;
+            IsCopy = isCopy;
         }
 
         /// <summary>
         /// Name of the source file on disk (or the buffer in memory) from which a text document was loaded.
         /// Could be null if no name has been set for an in-memory buffer.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Character set used to encode the hexadecimal alphanumeric literals in the text document
         /// </summary>
-        public Encoding EncodingForAlphanumericLiterals { get; private set; }
+        public Encoding EncodingForAlphanumericLiterals { get; }
 
         /// <summary>
         /// Format of the text document lines : Cobol reference format on 72 columns, or free text format
         /// </summary>
-        public ColumnsLayout ColumnsLayout { get; private set; }
+        public ColumnsLayout ColumnsLayout { get; }
+
+        /// <summary>
+        /// Nature of expected file content: True for copybook, False for program.
+        /// </summary>
+        public bool IsCopy { get; }
     }
 }

--- a/TypeCobol/LanguageServices/CodeAnalysis/Statistics/StatsGenerator.cs
+++ b/TypeCobol/LanguageServices/CodeAnalysis/Statistics/StatsGenerator.cs
@@ -91,7 +91,7 @@ namespace TypeCobol.LanguageServices.CodeAnalysis.Statistics
                     try
                     {
                         // Compile program
-                        FileCompiler fileCompiler = new FileCompiler(null, textName, project.SourceFileProvider, project, project.ColumnsLayout, project.CompilationOptions.Clone(), null, false, project);
+                        FileCompiler fileCompiler = new FileCompiler(null, textName, project.ColumnsLayout, false, project.SourceFileProvider, project, project.CompilationOptions.Clone(), null, project);
                         fileCompiler.CompileOnce();
                         CompilationUnit compilationResult = fileCompiler.CompilationResultsForProgram;
                         programCopiesNotFound = 0;

--- a/TypeCobol/Parser.cs
+++ b/TypeCobol/Parser.cs
@@ -54,7 +54,7 @@ namespace TypeCobol
 			foreach (var folder in copies) {
 				sourceFileProvider.AddLocalDirectoryLibrary(folder, false, Helpers.DEFAULT_COPY_EXTENSIONS, format.Encoding, format.EndOfLineDelimiter, format.FixedLineLength);
 			}
-			compiler = new FileCompiler(null, filename, project.SourceFileProvider, project, format.ColumnsLayout, options, CustomSymbols, isCopy, project);
+			compiler = new FileCompiler(null, filename, format.ColumnsLayout, isCopy, project.SourceFileProvider, project, options, CustomSymbols, project);
             
 			Compilers.Add(path, compiler);
 			Inits.Add(path, false);

--- a/TypeCobol/Tools/CommandLine/TypeCobolCompiler.cs
+++ b/TypeCobol/Tools/CommandLine/TypeCobolCompiler.cs
@@ -41,7 +41,7 @@ namespace TypeCobol.Tools.CommandLine
                     Console.Write(textName + " ... ");
                     try
                     {
-                        FileCompiler fileCompiler = new FileCompiler(null, textName, project.SourceFileProvider, project, ColumnsLayout.CobolReferenceFormat, compilerOptions.Clone(), null, false, project);
+                        FileCompiler fileCompiler = new FileCompiler(null, textName, ColumnsLayout.CobolReferenceFormat, false, project.SourceFileProvider, project, compilerOptions.Clone(), null, project);
                         fileCompiler.CompileOnce();
                         Console.WriteLine(" OK");
                     }


### PR DESCRIPTION
Fixes #1961.

No need to change `IAnalyzerProvider.CreateQualityAnalyzers` signature because a `TextSourceInfo` instance is available in each document passed in `Inspect` methods.
