### PR TITLE
V1.5.5

### DIFF
--- a/CLI/test/CLI.Test.csproj
+++ b/CLI/test/CLI.Test.csproj
@@ -85,10 +85,6 @@
       <Link>ressources\ycopylist\input\YXXXFAL.cpy</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="..\..\TypeCobol.Test\Parser\EILegacy\YXXXFAL.cpy">
-      <Link>ressources\ycopylist\input\YXXXFAL.cpy</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Include="..\..\TypeCobol.Test\Parser\EILegacy\YXXXFAS.cpy">
       <Link>ressources\ycopylist\input\YXXXFAS.cpy</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Codegen/src/Generators/DefaultGenerator.cs
+++ b/Codegen/src/Generators/DefaultGenerator.cs
@@ -10,9 +10,9 @@ using TypeCobol.Compiler.Source;
 using TypeCobol.Compiler.Text;
 using TypeCobol.Compiler.Diagnostics;
 using TypeCobol.Compiler.Scanner;
-using TypeCobol.Compiler.File;
 using System.Runtime.CompilerServices;
 using TypeCobol.Compiler;
+using TypeCobol.Compiler.Directives;
 
 using static TypeCobol.Codegen.Generators.LinearNodeSourceCodeMapper;
 
@@ -864,6 +864,7 @@ namespace TypeCobol.Codegen.Generators
             //Take interessting scan state values from the original input
             TypeCobol.Compiler.Parser.CodeElementsLine cel = Input[FirstGSLine] as TypeCobol.Compiler.Parser.CodeElementsLine;
             //first true argument => we are in a DataDivision.
+            var scannerOptions = new TypeCobolOptions();
             System.Diagnostics.Debug.Assert(cel.ScanState.InsideDataDivision);
             string gsText = gsSrcText.GetTextAt(0, gsSrcText.Size);
             using (StringReader sr = new StringReader(gsText))
@@ -893,7 +894,7 @@ namespace TypeCobol.Codegen.Generators
                     }
 
                     tempTokensLine.InitializeScanState(cel.ScanState);
-                    Scanner scanner = new Scanner(line, startIndex, line.Length - 1, tempTokensLine, null, true);
+                    Scanner scanner = new Scanner(line, startIndex, line.Length - 1, tempTokensLine, scannerOptions, true);
                     Token t = null;
 
                     while ((t = scanner.GetNextToken()) != null)

--- a/TypeCobol.LanguageServer.Test/LSRTest.cs
+++ b/TypeCobol.LanguageServer.Test/LSRTest.cs
@@ -254,6 +254,7 @@ namespace TypeCobol.LanguageServer.Test
         public void SimpleMoveToCompletion()
         {
             LSRTestHelper.Test("SimpleMoveToCompletion", LsrTestingOptions.NoLsrTesting, true);
+            LSRTestHelper.Test("SimpleMoveToCompletionNoTC", LsrTestingOptions.NoLsrTesting, true, pureCobol: true);
         }
 
         [TestMethod]
@@ -317,6 +318,7 @@ namespace TypeCobol.LanguageServer.Test
         public void DisplayCompletion()
         {
             LSRTestHelper.Test("DisplayCompletion", LsrTestingOptions.NoLsrTesting, true);
+            LSRTestHelper.Test("DisplayCompletionNoTC", LsrTestingOptions.NoLsrTesting, true, pureCobol: true);
         }
 
         [TestMethod]

--- a/TypeCobol.LanguageServer.Test/LSRTestHelper.cs
+++ b/TypeCobol.LanguageServer.Test/LSRTestHelper.cs
@@ -29,7 +29,7 @@ namespace TypeCobol.LanguageServer.Test
         /// </summary>
         public const int LSR_TEST_TIMEOUT = 1000 * 30;
 
-        public static void Test(string testFolderName, LsrTestingOptions lsrTestingOption, bool activateTdOption = false, bool useSyntaxColoring = false, bool useOutline = false, string copyFolder = null, string customIntrinsicFile = null, string customDependenciesFolder = null, bool useCfg = false)
+        public static void Test(string testFolderName, LsrTestingOptions lsrTestingOption, bool activateTdOption = false, bool useSyntaxColoring = false, bool useOutline = false, string copyFolder = null, string customIntrinsicFile = null, string customDependenciesFolder = null, bool useCfg = false, bool pureCobol = false)
         {
             var workingDirectory = "LSRTests";
             var testWorkingDirectory = workingDirectory + Path.DirectorySeparatorChar + testFolderName;
@@ -57,6 +57,7 @@ namespace TypeCobol.LanguageServer.Test
                                   Path.DirectorySeparatorChar + copyFolder).FullName.Replace(@"\", @"\\"));
             String testOptions = "";
             testOptions += useOutline ? "" : ",\"-dol\"";
+            testOptions += pureCobol ? ",\"-cob\"" : "";
             configFileContent = configFileContent.Replace("{TestOptions}", testOptions);
 
             configFileContent = configFileContent.Replace("{IntrinsicFile}",

--- a/TypeCobol.LanguageServer.Test/LSRTests/DisplayCompletionNoTC/input/DisplayCompletionNoTC.tlsp
+++ b/TypeCobol.LanguageServer.Test/LSRTests/DisplayCompletionNoTC/input/DisplayCompletionNoTC.tlsp
@@ -1,0 +1,103 @@
+{
+  "name": "DisplayCompletionNoTC.tlsp",
+  "session": "C:\\Users\\COLLARBE\\AppData\\Roaming\\TypeCobol.LanguageServerRobot\\Repository\\Session2018_03_19_09_44_28_703\\TestSuite_2018_03_19_09_44_28_703.slsp",
+  "user": "COLLARBE",
+  "date": "2018/03/19 09:44:28 705",
+  "uri": "file:///C:/Users/COLLARBE/Desktop/DisplayCompletionNoTC.tlsp",
+  "initialize": "{\"jsonrpc\":\"2.0\",\"id\":\"0\",\"method\":\"initialize\",\"params\":{\"processId\":-1,\"rootPath\":\"C:\\\\Users\\\\COLLARBE\\\\Source\\\\Repos\\\\TypeCobol\\\\bin\\\\EI_Debug\",\"rootUri\":\"file:/C:/Users/COLLARBE/Source/Repos/TypeCobol/bin/EI_Debug/\",\"capabilities\":{\"workspace\":{\"applyEdit\":true,\"didChangeConfiguration\":{\"dynamicRegistration\":true},\"didChangeWatchedFiles\":{\"dynamicRegistration\":false},\"symbol\":{\"dynamicRegistration\":true},\"executeCommand\":{\"dynamicRegistration\":true}},\"textDocument\":{\"synchronization\":{\"willSave\":true,\"willSaveWaitUntil\":true,\"dynamicRegistration\":true},\"completion\":{\"completionItem\":{\"snippetSupport\":true},\"dynamicRegistration\":true},\"hover\":{\"dynamicRegistration\":true},\"signatureHelp\":{\"dynamicRegistration\":true},\"references\":{\"dynamicRegistration\":true},\"documentHighlight\":{\"dynamicRegistration\":true},\"documentSymbol\":{\"dynamicRegistration\":true},\"formatting\":{\"dynamicRegistration\":true},\"rangeFormatting\":{\"dynamicRegistration\":true},\"onTypeFormatting\":{\"dynamicRegistration\":true},\"definition\":{\"dynamicRegistration\":true},\"codeAction\":{\"dynamicRegistration\":true},\"codeLens\":{\"dynamicRegistration\":true},\"documentLink\":{\"dynamicRegistration\":true},\"rename\":{\"dynamicRegistration\":true}}},\"trace\":\"off\"}}",
+  "initialize_result": "{\"jsonrpc\":\"2.0\",\"id\":\"0\",\"result\":{\"capabilities\":{\"textDocumentSync\":2,\"hoverProvider\":true,\"completionProvider\":{\"resolveProvider\":false,\"triggerCharacters\":[\"::\"]},\"signatureHelpProvider\":{\"triggerCharacters\":[]},\"definitionProvider\":true,\"referencesProvider\":false,\"documentHighlightProvider\":false,\"documentSymbolProvider\":false,\"workspaceSymbolProvider\":false,\"codeActionProvider\":false,\"documentFormattingProvider\":false,\"documentRangeFormattingProvider\":false,\"renameProvider\":false}}}",
+  "did_change_configuation": "{\"jsonrpc\":\"2.0\",\"method\":\"workspace/didChangeConfiguration\",\"params\":{\"settings\":[\"C:\\\\Users\\\\COLLARBE\\\\Source\\\\Repos\\\\TypeCobol\\\\bin\\\\EI_Debug\\\\TypeCobol.CLI.exe\",\"-1\",\"-e\",\"rdz\",\"-y\",\"C:\\\\Users\\\\COLLARBE\\\\Source\\\\Repos\\\\TypeCobol\\\\TypeCobol.LanguageServer.Test\\\\LSRTests\\\\DefaultIntrinsic.txt\",\"-md\",\"30\"]}}",
+  "didOpen": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didOpen\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"languageId\":\"__lsp4j_TypeCobol\",\"version\":0,\"text\":\"       IDENTIFICATION DIVISION.\\r\\n       PROGRAM-ID. TestingPgm.\\r\\n\\r\\n       DATA DIVISION.\\r\\n       WORKING-STORAGE SECTION.\\r\\n       01 W-Date TYPE DATE.\\r\\n       01 W-Bool TYPE Bool.\\r\\n       01 W-Numeric PIC 9(10).\\r\\n       01 W-Alphabetic PIC A(10).\\r\\n       01 W-Alphanum PIC X(10).\\r\\n       01 W-OutDate TYPE Date.\\r\\n       01 TestLevel.\\r\\n           88 TestLevel88 VALUE 1.\\r\\n       01 Level1.\\r\\n          05 Level2.\\r\\n            06 VarLevel2 PIC 10.\\r\\n          05 Level2-2.\\r\\n            06 VarLevel2-2 PIC 10.\\r\\n          05 MyBool TYPE BOOL.\\r\\n       PROCEDURE DIVISION.\\r\\n\\r\\n\\r\\n       .\\r\\n       END PROGRAM TestingPgm.\"}}}",
+  "messages": [
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:///C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"diagnostics\":[]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didSave\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"text\":\"       IDENTIFICATION DIVISION.\\r\\n       PROGRAM-ID. TestingPgm.\\r\\n\\r\\n       DATA DIVISION.\\r\\n       WORKING-STORAGE SECTION.\\r\\n       01 W-Date TYPE DATE.\\r\\n       01 W-Bool TYPE Bool.\\r\\n       01 W-Numeric PIC 9(10).\\r\\n       01 W-Alphabetic PIC A(10).\\r\\n       01 W-Alphanum PIC X(10).\\r\\n       01 W-OutDate TYPE Date.\\r\\n       01 TestLevel.\\r\\n           88 TestLevel88 VALUE 1.\\r\\n       01 Level1.\\r\\n          05 Level2.\\r\\n            06 VarLevel2 PIC 10.\\r\\n          05 Level2-2.\\r\\n            06 VarLevel2-2 PIC 10.\\r\\n          05 MyBool TYPE BOOL.\\r\\n       PROCEDURE DIVISION.\\r\\n\\r\\n\\r\\n\\r\\n\\r\\n\\r\\n       .\\r\\n       END PROGRAM TestingPgm.\"}}"
+    },
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:///C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"diagnostics\":[]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":0},\"end\":{\"line\":21,\"character\":0}},\"rangeLength\":0,\"text\":\"       \"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":7},\"end\":{\"line\":21,\"character\":7}},\"rangeLength\":0,\"text\":\"D\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":8},\"end\":{\"line\":21,\"character\":8}},\"rangeLength\":0,\"text\":\"I\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":9},\"end\":{\"line\":21,\"character\":9}},\"rangeLength\":0,\"text\":\"S\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":10},\"end\":{\"line\":21,\"character\":10}},\"rangeLength\":0,\"text\":\"P\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":11},\"end\":{\"line\":21,\"character\":11}},\"rangeLength\":0,\"text\":\"L\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":12},\"end\":{\"line\":21,\"character\":12}},\"rangeLength\":0,\"text\":\"A\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":13},\"end\":{\"line\":21,\"character\":13}},\"rangeLength\":0,\"text\":\"Y\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":14},\"end\":{\"line\":21,\"character\":14}},\"rangeLength\":0,\"text\":\" \"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"56\",\"method\":\"typecobol/refreshNodesRequest\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"}}}"
+    },
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:///C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"diagnostics\":[{\"range\":{\"start\":{\"line\":26,\"character\":8},\"end\":{\"line\":26,\"character\":8}},\"severity\":1,\"code\":\"27\",\"source\":\"Find the syntax diagram describing the statement in error in the language reference\",\"message\":\"Syntax error : mismatched input '' expecting {alphanumeric literal, numeric literal, symbol, special register, figurative constant, keyword}\"}]}}"
+    },
+    {
+      "category": 2,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"56\",\"result\":true}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"57\",\"method\":\"textDocument/completion\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"position\":{\"line\":21,\"character\":15}}}"
+    },
+    {
+      "category": 2,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"57\",\"result\":[{\"label\":\"W-Date (DATE) (W-Date)\",\"kind\":6,\"insertText\":\"W-Date\"},{\"label\":\"W-Bool (BOOL) (W-Bool)\",\"kind\":6,\"insertText\":\"W-Bool\"},{\"label\":\"W-Numeric (Numeric) (W-Numeric)\",\"kind\":6,\"insertText\":\"W-Numeric\"},{\"label\":\"W-Alphabetic (Alphabetic) (W-Alphabetic)\",\"kind\":6,\"insertText\":\"W-Alphabetic\"},{\"label\":\"W-Alphanum (Alphanumeric) (W-Alphanum)\",\"kind\":6,\"insertText\":\"W-Alphanum\"},{\"label\":\"W-OutDate (DATE) (W-OutDate)\",\"kind\":6,\"insertText\":\"W-OutDate\"},{\"label\":\"TestLevel (Alphanumeric) (TestLevel)\",\"kind\":6,\"insertText\":\"TestLevel\"},{\"label\":\"Level1 (Alphanumeric) (Level1)\",\"kind\":6,\"insertText\":\"Level1\"},{\"label\":\"Level2 (Alphanumeric) (Level2 OF Level1)\",\"kind\":6,\"insertText\":\"Level2 OF Level1\"},{\"label\":\"VarLevel2 (NumericEdited) (VarLevel2 OF Level2 OF Level1)\",\"kind\":6,\"insertText\":\"VarLevel2 OF Level2 OF Level1\"},{\"label\":\"Level2-2 (Alphanumeric) (Level2-2 OF Level1)\",\"kind\":6,\"insertText\":\"Level2-2 OF Level1\"},{\"label\":\"VarLevel2-2 (NumericEdited) (VarLevel2-2 OF Level2-2 OF Level1)\",\"kind\":6,\"insertText\":\"VarLevel2-2 OF Level2-2 OF Level1\"},{\"label\":\"MyBool (BOOL) (MyBool OF Level1)\",\"kind\":6,\"insertText\":\"MyBool OF Level1\"}]}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":15},\"end\":{\"line\":21,\"character\":15}},\"rangeLength\":0,\"text\":\"W-Date\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":21},\"end\":{\"line\":21,\"character\":21}},\"rangeLength\":0,\"text\":\".\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"58\",\"method\":\"typecobol/refreshNodesRequest\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"}}}"
+    },
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:///C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"diagnostics\":[]}}"
+    },
+    {
+      "category": 2,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"58\",\"result\":true}"
+    }
+  ],
+  "didClose": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didClose\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"}}}",
+  "IsValid": true
+}

--- a/TypeCobol.LanguageServer.Test/LSRTests/DisplayCompletionNoTC/output_expected/DisplayCompletionNoTC.rlsp
+++ b/TypeCobol.LanguageServer.Test/LSRTests/DisplayCompletionNoTC/output_expected/DisplayCompletionNoTC.rlsp
@@ -1,0 +1,6 @@
+{
+  "success": true,
+  "diff_index": [
+    -1
+  ]
+}

--- a/TypeCobol.LanguageServer.Test/LSRTests/ProcedureCompletionNoParam/input/ProcedureCompletionNoParam.tlsp
+++ b/TypeCobol.LanguageServer.Test/LSRTests/ProcedureCompletionNoParam/input/ProcedureCompletionNoParam.tlsp
@@ -75,10 +75,6 @@
       "message": "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"textDocument/completion\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/LANOYDO/AppData/Local/Temp/1/tcbl/DVZZDLY1103830253336368444.cee\"},\"uri\":\"file:/C:/Users/LANOYDO/AppData/Local/Temp/1/tcbl/DVZZDLY1103830253336368444.cee\",\"position\":{\"line\":5,\"character\":21}}}"
     },
     {
-      "category": 1,
-      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:///C:/Users/LANOYDO/AppData/Local/Temp/1/tcbl/DVZZDLY1103830253336368444.cee\",\"diagnostics\":[{\"range\":{\"start\":{\"line\":6,\"character\":12},\"end\":{\"line\":6,\"character\":21}},\"severity\":1,\"code\":\"27\",\"source\":\"Find the syntax diagram describing the statement in error in the language reference\",\"message\":\"Syntax error : No function or variable found for 'DVZZS'(no arguments)\"}]}}"
-    },
-    {
       "category": 2,
       "message": "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":[{\"label\":\"DVZZSTKD.Foo   \",\"kind\":3,\"insertText\":\"DVZZSTKD::Foo\",\"data\":[{\"start\":{\"line\":5,\"character\":16},\"end\":{\"line\":5,\"character\":21}},{\"label\":\"DVZZSTKD.Foo\",\"parameters\":[]},null]},{\"label\":\"DVZZSTKD\",\"kind\":9,\"data\":{\"start\":{\"line\":5,\"character\":16},\"end\":{\"line\":5,\"character\":21}}}]}"
     },

--- a/TypeCobol.LanguageServer.Test/LSRTests/SimpleMoveToCompletionNoTC/input/SimpleMoveToCompletionNoTC.tlsp
+++ b/TypeCobol.LanguageServer.Test/LSRTests/SimpleMoveToCompletionNoTC/input/SimpleMoveToCompletionNoTC.tlsp
@@ -1,0 +1,135 @@
+{
+  "name": "SimpleMoveToCompletionNoTC.tlsp",
+  "session": "C:\\Users\\COLLARBE\\AppData\\Roaming\\TypeCobol.LanguageServerRobot\\Repository\\Session2018_03_19_09_10_47_109\\TestSuite_2018_03_19_09_10_47_109.slsp",
+  "user": "COLLARBE",
+  "date": "2018/03/19 09:10:47 122",
+  "uri": "file:///C:/Users/COLLARBE/Desktop/SimpleMoveToCompletionNoTC.tlsp",
+  "initialize": "{\"jsonrpc\":\"2.0\",\"id\":\"0\",\"method\":\"initialize\",\"params\":{\"processId\":-1,\"rootPath\":\"C:\\\\Users\\\\COLLARBE\\\\Source\\\\Repos\\\\TypeCobol\\\\bin\\\\EI_Debug\",\"rootUri\":\"file:/C:/Users/COLLARBE/Source/Repos/TypeCobol/bin/EI_Debug/\",\"capabilities\":{\"workspace\":{\"applyEdit\":true,\"didChangeConfiguration\":{\"dynamicRegistration\":true},\"didChangeWatchedFiles\":{\"dynamicRegistration\":false},\"symbol\":{\"dynamicRegistration\":true},\"executeCommand\":{\"dynamicRegistration\":true}},\"textDocument\":{\"synchronization\":{\"willSave\":true,\"willSaveWaitUntil\":true,\"dynamicRegistration\":true},\"completion\":{\"completionItem\":{\"snippetSupport\":true},\"dynamicRegistration\":true},\"hover\":{\"dynamicRegistration\":true},\"signatureHelp\":{\"dynamicRegistration\":true},\"references\":{\"dynamicRegistration\":true},\"documentHighlight\":{\"dynamicRegistration\":true},\"documentSymbol\":{\"dynamicRegistration\":true},\"formatting\":{\"dynamicRegistration\":true},\"rangeFormatting\":{\"dynamicRegistration\":true},\"onTypeFormatting\":{\"dynamicRegistration\":true},\"definition\":{\"dynamicRegistration\":true},\"codeAction\":{\"dynamicRegistration\":true},\"codeLens\":{\"dynamicRegistration\":true},\"documentLink\":{\"dynamicRegistration\":true},\"rename\":{\"dynamicRegistration\":true}}},\"trace\":\"off\"}}",
+  "initialize_result": "{\"jsonrpc\":\"2.0\",\"id\":\"0\",\"result\":{\"capabilities\":{\"textDocumentSync\":2,\"hoverProvider\":true,\"completionProvider\":{\"resolveProvider\":false,\"triggerCharacters\":[\"::\"]},\"signatureHelpProvider\":{\"triggerCharacters\":[]},\"definitionProvider\":true,\"referencesProvider\":false,\"documentHighlightProvider\":false,\"documentSymbolProvider\":false,\"workspaceSymbolProvider\":false,\"codeActionProvider\":false,\"documentFormattingProvider\":false,\"documentRangeFormattingProvider\":false,\"renameProvider\":false}}}",
+  "did_change_configuation": "{\"jsonrpc\":\"2.0\",\"method\":\"workspace/didChangeConfiguration\",\"params\":{\"settings\":[\"C:\\\\Users\\\\COLLARBE\\\\Source\\\\Repos\\\\TypeCobol\\\\bin\\\\EI_Debug\\\\TypeCobol.CLI.exe\",\"-1\",\"-e\",\"rdz\",\"-y\",\"C:\\\\Users\\\\COLLARBE\\\\Source\\\\Repos\\\\TypeCobol\\\\TypeCobol.LanguageServer.Test\\\\LSRTests\\\\DefaultIntrinsic.txt\",\"-md\",\"30\"]}}",
+  "didOpen": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didOpen\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"languageId\":\"__lsp4j_TypeCobol\",\"version\":0,\"text\":\"       IDENTIFICATION DIVISION.\\r\\n       PROGRAM-ID. TestingPgm.\\r\\n\\r\\n       DATA DIVISION.\\r\\n       WORKING-STORAGE SECTION.\\r\\n       01 W-Date TYPE DATE.\\r\\n       01 W-Bool TYPE Bool.\\r\\n       01 W-Numeric PIC 9(10).\\r\\n       01 W-Alphabetic PIC A(10).\\r\\n       01 W-Alphanum PIC X(10).\\r\\n       01 W-OutDate TYPE Date.\\r\\n       01 TestLevel.\\r\\n           88 TestLevel88 VALUE 1.\\r\\n       01 Level1.\\r\\n          05 Level2.\\r\\n            06 VarLevel2 PIC 10.\\r\\n          05 Level2-2.\\r\\n            06 VarLevel2-2 PIC 10.\\r\\n          05 MyBool TYPE BOOL.\\r\\n       PROCEDURE DIVISION.\\r\\n\\r\\n\\r\\n       .\\r\\n       END PROGRAM TestingPgm.\"}}}",
+  "messages": [
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:///C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"diagnostics\":[]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didSave\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"text\":\"       IDENTIFICATION DIVISION.\\r\\n       PROGRAM-ID. TestingPgm.\\r\\n\\r\\n       DATA DIVISION.\\r\\n       WORKING-STORAGE SECTION.\\r\\n       01 W-Date TYPE DATE.\\r\\n       01 W-Bool TYPE Bool.\\r\\n       01 W-Numeric PIC 9(10).\\r\\n       01 W-Alphabetic PIC A(10).\\r\\n       01 W-Alphanum PIC X(10).\\r\\n       01 W-OutDate TYPE Date.\\r\\n       01 TestLevel.\\r\\n           88 TestLevel88 VALUE 1.\\r\\n       01 Level1.\\r\\n          05 Level2.\\r\\n            06 VarLevel2 PIC 10.\\r\\n          05 Level2-2.\\r\\n            06 VarLevel2-2 PIC 10.\\r\\n          05 MyBool TYPE BOOL.\\r\\n       PROCEDURE DIVISION.\\r\\n\\r\\n\\r\\n       .\\r\\n       END PROGRAM TestingPgm.\"}}"
+    },
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:///C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"diagnostics\":[]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":19,\"character\":26},\"end\":{\"line\":19,\"character\":26}},\"rangeLength\":0,\"text\":\"\\r\\n       \"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":20,\"character\":7},\"end\":{\"line\":20,\"character\":7}},\"rangeLength\":0,\"text\":\"\\r\\n       \"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":7},\"end\":{\"line\":21,\"character\":7}},\"rangeLength\":0,\"text\":\"M\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":8},\"end\":{\"line\":21,\"character\":8}},\"rangeLength\":0,\"text\":\"O\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":9},\"end\":{\"line\":21,\"character\":9}},\"rangeLength\":0,\"text\":\"V\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":10},\"end\":{\"line\":21,\"character\":10}},\"rangeLength\":0,\"text\":\"E\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":11},\"end\":{\"line\":21,\"character\":11}},\"rangeLength\":0,\"text\":\" \"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"3\",\"method\":\"typecobol/refreshNodesRequest\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"}}}"
+    },
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:///C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"diagnostics\":[{\"range\":{\"start\":{\"line\":25,\"character\":8},\"end\":{\"line\":25,\"character\":8}},\"severity\":1,\"code\":\"27\",\"source\":\"Find the syntax diagram describing the statement in error in the language reference\",\"message\":\"Syntax error : no viable alternative at input 'MOVE ... '\"}]}}"
+    },
+    {
+      "category": 2,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"3\",\"result\":true}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"4\",\"method\":\"textDocument/completion\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"position\":{\"line\":21,\"character\":12}}}"
+    },
+    {
+      "category": 2,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"4\",\"result\":[{\"label\":\"W-Date (DATE) (W-Date)\",\"kind\":6,\"insertText\":\"W-Date\"},{\"label\":\"W-Bool (BOOL) (W-Bool)\",\"kind\":6,\"insertText\":\"W-Bool\"},{\"label\":\"W-Numeric (Numeric) (W-Numeric)\",\"kind\":6,\"insertText\":\"W-Numeric\"},{\"label\":\"W-Alphabetic (Alphabetic) (W-Alphabetic)\",\"kind\":6,\"insertText\":\"W-Alphabetic\"},{\"label\":\"W-Alphanum (Alphanumeric) (W-Alphanum)\",\"kind\":6,\"insertText\":\"W-Alphanum\"},{\"label\":\"W-OutDate (DATE) (W-OutDate)\",\"kind\":6,\"insertText\":\"W-OutDate\"},{\"label\":\"TestLevel (Alphanumeric) (TestLevel)\",\"kind\":6,\"insertText\":\"TestLevel\"},{\"label\":\"Level1 (Alphanumeric) (Level1)\",\"kind\":6,\"insertText\":\"Level1\"},{\"label\":\"Level2 (Alphanumeric) (Level2 OF Level1)\",\"kind\":6,\"insertText\":\"Level2 OF Level1\"},{\"label\":\"VarLevel2 (NumericEdited) (VarLevel2 OF Level2 OF Level1)\",\"kind\":6,\"insertText\":\"VarLevel2 OF Level2 OF Level1\"},{\"label\":\"Level2-2 (Alphanumeric) (Level2-2 OF Level1)\",\"kind\":6,\"insertText\":\"Level2-2 OF Level1\"},{\"label\":\"VarLevel2-2 (NumericEdited) (VarLevel2-2 OF Level2-2 OF Level1)\",\"kind\":6,\"insertText\":\"VarLevel2-2 OF Level2-2 OF Level1\"},{\"label\":\"MyBool (BOOL) (MyBool OF Level1)\",\"kind\":6,\"insertText\":\"MyBool OF Level1\"}]}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":12},\"end\":{\"line\":21,\"character\":12}},\"rangeLength\":0,\"text\":\"MyBool OF Level1\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":28},\"end\":{\"line\":21,\"character\":28}},\"rangeLength\":0,\"text\":\" \"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":29},\"end\":{\"line\":21,\"character\":29}},\"rangeLength\":0,\"text\":\"T\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":30},\"end\":{\"line\":21,\"character\":30}},\"rangeLength\":0,\"text\":\"O\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":31},\"end\":{\"line\":21,\"character\":31}},\"rangeLength\":0,\"text\":\" \"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"5\",\"method\":\"typecobol/refreshNodesRequest\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"}}}"
+    },
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:///C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"diagnostics\":[{\"range\":{\"start\":{\"line\":25,\"character\":8},\"end\":{\"line\":25,\"character\":8}},\"severity\":1,\"code\":\"27\",\"source\":\"Find the syntax diagram describing the statement in error in the language reference\",\"message\":\"Syntax error : mismatched input '' expecting {symbol, special register, keyword}\"}]}}"
+    },
+    {
+      "category": 2,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"5\",\"result\":true}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"6\",\"method\":\"textDocument/completion\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"position\":{\"line\":21,\"character\":32}}}"
+    },
+    {
+      "category": 2,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"6\",\"result\":[{\"label\":\"W-Bool (BOOL) (W-Bool)\",\"kind\":6,\"insertText\":\"W-Bool\"},{\"label\":\"W-Alphanum (Alphanumeric) (W-Alphanum)\",\"kind\":6,\"insertText\":\"W-Alphanum\"},{\"label\":\"TestLevel (Alphanumeric) (TestLevel)\",\"kind\":6,\"insertText\":\"TestLevel\"},{\"label\":\"Level1 (Alphanumeric) (Level1)\",\"kind\":6,\"insertText\":\"Level1\"},{\"label\":\"Level2 (Alphanumeric) (Level2 OF Level1)\",\"kind\":6,\"insertText\":\"Level2 OF Level1\"},{\"label\":\"Level2-2 (Alphanumeric) (Level2-2 OF Level1)\",\"kind\":6,\"insertText\":\"Level2-2 OF Level1\"}]}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":32},\"end\":{\"line\":21,\"character\":32}},\"rangeLength\":0,\"text\":\"W-Bool\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"},\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"contentChanges\":[{\"range\":{\"start\":{\"line\":21,\"character\":38},\"end\":{\"line\":21,\"character\":38}},\"rangeLength\":0,\"text\":\".\"}]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"7\",\"method\":\"typecobol/refreshNodesRequest\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"}}}"
+    },
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:///C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\",\"diagnostics\":[]}}"
+    },
+    {
+      "category": 2,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"7\",\"result\":true}"
+    }
+  ],
+  "didClose": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didClose\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/COLLARBE/AppData/Local/Temp/tcbl/PROCCALL1017554363682126440.cee\"}}}",
+  "IsValid": true
+}

--- a/TypeCobol.LanguageServer.Test/LSRTests/SimpleMoveToCompletionNoTC/output_expected/SimpleMoveToCompletionNoTC.rlsp
+++ b/TypeCobol.LanguageServer.Test/LSRTests/SimpleMoveToCompletionNoTC/output_expected/SimpleMoveToCompletionNoTC.rlsp
@@ -1,0 +1,6 @@
+{
+  "success": true,
+  "diff_index": [
+    -1
+  ]
+}

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionFactory.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionFactory.cs
@@ -1,14 +1,12 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
-using System.Threading.Tasks;
 using TypeCobol.Compiler;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.CodeElements.Expressions;
 using TypeCobol.Compiler.CodeModel;
+using TypeCobol.Compiler.Directives;
 using TypeCobol.Compiler.Nodes;
 using TypeCobol.Compiler.Scanner;
 using TypeCobol.LanguageServer.VsCodeProtocol;
@@ -17,7 +15,6 @@ namespace TypeCobol.LanguageServer
 {
     public static class CompletionFactory
     {
-
         #region Paragraph Completion
 
         /// <summary>
@@ -28,7 +25,7 @@ namespace TypeCobol.LanguageServer
         /// <returns></returns>
         public static IEnumerable<CompletionItem> GetCompletionPerformParagraph(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken)
         {
-            var performNode = GetMatchingNode(fileCompiler, codeElement);
+            var performNode = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
             IEnumerable<Paragraph> pargraphs = null;
             IEnumerable<DataDefinition> variables = null;
             var completionItems = new List<CompletionItem>();
@@ -74,7 +71,7 @@ namespace TypeCobol.LanguageServer
             IEnumerable<FunctionDeclaration> procedures = null;
             IEnumerable<DataDefinition> variables = null;
             var completionItems = new List<CompletionItem>();
-            var node = GetMatchingNode(fileCompiler, codeElement);
+            var node = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
             if(node == null)
                 return completionItems;
 
@@ -116,7 +113,7 @@ namespace TypeCobol.LanguageServer
         {
             var completionItems = new List<CompletionItem>();
             var arrangedCodeElement = codeElement as CodeElementWrapper;
-            var node = GetMatchingNode(fileCompiler, codeElement);
+            var node = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
             if (node == null)
                 return completionItems;
 
@@ -236,7 +233,7 @@ namespace TypeCobol.LanguageServer
             if (potentialVariablesForCompletion == null) return completionItems;
 
             foreach (var potentialVariable in potentialVariablesForCompletion.Where(v => v.Name.StartsWith(userFilterText, StringComparison.InvariantCultureIgnoreCase)).Distinct())
-                SearchVariableInTypesAndLevels(node, potentialVariable, ref completionItems); //Add potential variables to completionItems*           
+                SearchVariableInTypesAndLevels(node, potentialVariable, fileCompiler.CompilerOptions, completionItems); //Add potential variables to completionItems*           
 
             CompletionFactoryHelpers.Case textCase = CompletionFactoryHelpers.GetTextCase(codeElement.ConsumedTokens.First(t => t.TokenType == TokenType.CALL).Text);
             Dictionary<ParameterDescription.PassingTypes, string> paramWithCase = CompletionFactoryHelpers.GetParamsWithCase(textCase);
@@ -319,7 +316,7 @@ namespace TypeCobol.LanguageServer
         #region Library Completion
         public static IEnumerable<CompletionItem> GetCompletionForLibrary(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken)
         {
-            var callNode = GetMatchingNode(fileCompiler, codeElement);
+            var callNode = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
             IEnumerable<Program> programs = null;
             if (callNode?.SymbolTable != null)
             {
@@ -335,7 +332,7 @@ namespace TypeCobol.LanguageServer
         #region Types Completion
         public static IEnumerable<CompletionItem> GetCompletionForType(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken)
         {
-            var node = GetMatchingNode(fileCompiler, codeElement);
+            var node = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
             IEnumerable<TypeDefinition> types = null;
             if (node?.SymbolTable == null)
                 return new List<CompletionItem>();
@@ -361,7 +358,7 @@ namespace TypeCobol.LanguageServer
         {
             var completionItems = new List<CompletionItem>();
             var arrangedCodeElement = codeElement as CodeElementWrapper;
-            var node = GetMatchingNode(fileCompiler, codeElement);
+            var node = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
             if (node == null)
                 return completionItems;
             var userFilterText = userFilterToken == null ? string.Empty : userFilterToken.Text;
@@ -446,7 +443,7 @@ namespace TypeCobol.LanguageServer
                         completionItems.AddRange(CompletionFactoryHelpers.CreateCompletionItemsForVariables(
                             computedChildrenList.Where(
                                     c => c.Name != null && c.Name.StartsWith(userFilterText, StringComparison.InvariantCultureIgnoreCase)) //Filter on user text
-                                .Select(child => child as DataDefinition), false));
+                                .Select(child => child as DataDefinition), fileCompiler.CompilerOptions, false));
                     }
                 }
                 else
@@ -475,7 +472,7 @@ namespace TypeCobol.LanguageServer
                     completionItems.AddRange(CompletionFactoryHelpers.CreateCompletionItemsForVariables(
                         children.Where(
                                 c => c.Name.StartsWith(userFilterText, StringComparison.InvariantCultureIgnoreCase)) //Filter on user text
-                            .Select(child => child as DataDefinition), false));
+                            .Select(child => child as DataDefinition), fileCompiler.CompilerOptions, false));
                 }
 
                 if (firstSignificantToken != null)
@@ -535,12 +532,12 @@ namespace TypeCobol.LanguageServer
         public static IEnumerable<CompletionItem> GetCompletionForVariable(FileCompiler fileCompiler, CodeElement codeElement, Expression<Func<DataDefinition, bool>> predicate)
         {
             var completionItems = new List<CompletionItem>();
-            var node = GetMatchingNode(fileCompiler, codeElement);
+            var node = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
             if (node == null)
                 return completionItems;
 
             var variables = node.SymbolTable.GetVariables(predicate, SymbolTable.Scope.Program);
-            completionItems.AddRange(CompletionFactoryHelpers.CreateCompletionItemsForVariables(variables));
+            completionItems.AddRange(CompletionFactoryHelpers.CreateCompletionItemsForVariables(variables, fileCompiler.CompilerOptions));
 
             return completionItems;
         }
@@ -549,88 +546,108 @@ namespace TypeCobol.LanguageServer
         #region TO Completion
         public static IEnumerable<CompletionItem> GetCompletionForTo(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken, Token lastSignificantToken)
         {
-            List<DataType> seekedDataTypes = new List<DataType>();
+            var compatibleDataTypes = new HashSet<DataType>();
             var completionItems = new List<CompletionItem>();
             var arrangedCodeElement = codeElement as CodeElementWrapper;
             if (arrangedCodeElement == null)
                 return completionItems;
-            var node = GetMatchingNode(fileCompiler, codeElement);
+            var node = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
             if (node == null)
                 return completionItems;
 
-            var potentialVariables = Enumerable.Empty<DataDefinition>();
             var userFilterText = userFilterToken == null ? string.Empty : userFilterToken.Text;
             Expression<Func<DataDefinition, bool>> variablePredicate =
                 da =>
                     (da.CodeElement != null && (da.CodeElement).LevelNumber.Value < 88) ||
                     (da.CodeElement == null && da is IndexDefinition); //Ignore variable of level 88.
 
-            //Look if the sending variable is like litteral Alpha / Numeric
-
-            if (node.CodeElement is MoveSimpleStatement)
+            //Look if the sending variable is compatible with Alpha / Numeric
+            if (node.CodeElement is MoveSimpleStatement moveSimpleStatement)
             {
-                var sendingItem = ((MoveSimpleStatement)node.CodeElement).SendingItem;
-                var sendingVar = ((MoveSimpleStatement)node.CodeElement).SendingVariable;
+                var sendingItem = moveSimpleStatement.SendingItem;
+                var sendingVar = moveSimpleStatement.SendingVariable;
                 if (sendingItem != null)
                 {
                     if (!(sendingItem is QualifiedName))
                     {
-                        if (sendingItem is bool?) seekedDataTypes.Add(DataType.Boolean);
-                        if (sendingItem is double?) seekedDataTypes.Add(DataType.Numeric);
-                        if (sendingItem is string) seekedDataTypes.Add(DataType.Alphanumeric);
+                        if (sendingItem is bool) compatibleDataTypes.Add(DataType.Boolean);
+                        else if (sendingItem is double) compatibleDataTypes.Add(DataType.Numeric);
+                        else if (sendingItem is string) compatibleDataTypes.Add(DataType.Alphanumeric);
                     }
 
-                    if (sendingVar != null && sendingVar.IsLiteral == true && sendingItem is double? &&
-                        (sendingVar.NumericValue.Token.TokenType == TokenType.ZERO
-                         || sendingVar.NumericValue.Token.TokenType == TokenType.ZEROS
-                         || sendingVar.NumericValue.Token.TokenType == TokenType.ZEROES))
+                    if (sendingVar != null && sendingVar.IsLiteral && sendingItem is double)
                     {
-                        //See #845, ZERO support Alphabetic/Numeric/Alphanumeric datatype
-                        seekedDataTypes.Add(DataType.Alphanumeric);
-                        seekedDataTypes.Add(DataType.Alphabetic); 
+                        switch (sendingVar.NumericValue.Token.TokenType)
+                        {
+                            case TokenType.ZERO:
+                            case TokenType.ZEROS:
+                            case TokenType.ZEROES:
+                                //See #845, ZERO support Alphabetic/Numeric/Alphanumeric DataType
+                                compatibleDataTypes.Add(DataType.Alphanumeric);
+                                compatibleDataTypes.Add(DataType.Alphabetic);
+                                break;
+                        }
                     }
                 }
 
                 var tokenType = sendingVar?.RepeatedCharacterValue?.Token?.TokenType;
-                if (tokenType != null)
+                switch (tokenType)
                 {
-                    if (tokenType == TokenType.SPACE || tokenType == TokenType.SPACES || tokenType == TokenType.QUOTE || tokenType == TokenType.QUOTES)
-                    {
-                        seekedDataTypes.Add(DataType.Alphanumeric);
-                        seekedDataTypes.Add(DataType.Alphabetic);
-                    }
+                    case TokenType.SPACE:
+                    case TokenType.SPACES:
+                    case TokenType.QUOTE:
+                    case TokenType.QUOTES:
+                        compatibleDataTypes.Add(DataType.Alphanumeric);
+                        compatibleDataTypes.Add(DataType.Alphabetic);
+                        break;
                 }
             }
 
-
             bool unsafeContext = arrangedCodeElement.ArrangedConsumedTokens.Any(t => t != null && t.TokenType == TokenType.UNSAFE);
             var filteredTokens = arrangedCodeElement.ArrangedConsumedTokens.SkipWhile(t => t.TokenType != TokenType.UserDefinedWord);
-            bool needTailReverse = filteredTokens.Any(t => t.TokenType == TokenType.OF);
-            var qualifiedNameTokens = filteredTokens.TakeWhile(t => t != lastSignificantToken).Where(t => !(t.TokenType == TokenType.QualifiedNameSeparator || t.TokenType == TokenType.OF) && t != userFilterToken);
-            if (!qualifiedNameTokens.Any() && seekedDataTypes.Count == 0)
+            bool needTailReverse = false;
+            List<string> qualifiedNameParts = new List<string>();
+            foreach (var token in filteredTokens)
+            {
+                if (token ==  lastSignificantToken) break; //No need to go further
+                if (token == userFilterToken) continue;
+                switch (token.TokenType)
+                {
+                    case TokenType.QualifiedNameSeparator:
+                        continue;
+                    case TokenType.OF:
+                    case TokenType.IN:
+                        needTailReverse = true;
+                        continue;
+                    default:
+                        qualifiedNameParts.Add(token.Text);
+                        break;
+                }
+            }
+
+            if (!qualifiedNameParts.Any() && compatibleDataTypes.Count == 0)
                 return completionItems;
 
-            if (needTailReverse)
-                qualifiedNameTokens = qualifiedNameTokens.Reverse();
+            if (needTailReverse) qualifiedNameParts.Reverse();
 
+            var potentialVariables = Enumerable.Empty<DataDefinition>();
             if (!unsafeContext) //Search for variable that match the DataType
             {
-                if (seekedDataTypes.Count == 0) //If a Datatype hasn't be found yet. 
+                if (compatibleDataTypes.Count == 0) //If a Datatype hasn't be found yet. 
                 {
-                    var foundedVar = node.SymbolTable.GetVariablesExplicit(new URI(qualifiedNameTokens.Select(t => t.Text))).FirstOrDefault();
-
+                    var foundedVar = node.SymbolTable.GetVariablesExplicit(new URI(qualifiedNameParts)).FirstOrDefault();
                     if (foundedVar != null)
                     {
-                        seekedDataTypes.Add(foundedVar.DataType);
+                        compatibleDataTypes.Add(foundedVar.DataType);
 
                         // Add PrimitiveDataType to extend the search to compatible types, if null default to Alphanumeric
-                        seekedDataTypes.Add(foundedVar.PrimitiveDataType ?? DataType.Alphanumeric);
+                        compatibleDataTypes.Add(foundedVar.PrimitiveDataType ?? DataType.Alphanumeric);
                     }
                 }
 
-                foreach (var seekedDataType in seekedDataTypes.Distinct())
+                foreach (var compatibleDataType in compatibleDataTypes)
                 {
-                    potentialVariables = node.SymbolTable.GetVariablesByType(seekedDataType, potentialVariables, SymbolTable.Scope.Program);
+                    potentialVariables = node.SymbolTable.GetVariablesByType(compatibleDataType, potentialVariables, SymbolTable.Scope.Program);
                 }
 
                 potentialVariables = potentialVariables.AsQueryable().Where(variablePredicate);
@@ -642,13 +659,9 @@ namespace TypeCobol.LanguageServer
 
             foreach (var potentialVariable in potentialVariables) //Those variables could be inside a typedef or a level, we need to check to rebuild the qualified name correctly.
             {
-                SearchVariableInTypesAndLevels(node, potentialVariable, ref completionItems);
+                if (potentialVariable.VisualQualifiedNameWithoutProgram.SequenceEqual(qualifiedNameParts)) continue;
+                SearchVariableInTypesAndLevels(node, potentialVariable, fileCompiler.CompilerOptions, completionItems);
             }
-
-            if (qualifiedNameTokens.Any())
-                completionItems.Remove(
-                    completionItems.FirstOrDefault(
-                        c => c.label.Contains(string.Join("::", qualifiedNameTokens.Select(t => t.Text)))));
 
             return completionItems.Where(c => c.insertText.IndexOf(userFilterText, StringComparison.InvariantCultureIgnoreCase) >= 0);
         }
@@ -667,7 +680,7 @@ namespace TypeCobol.LanguageServer
             IEnumerable<CompletionItem> completionItems = new List<CompletionItem>();
             var userFilterText = userFilterToken == null ? string.Empty : userFilterToken.Text;
             var arrangedCodeElement = codeElement as CodeElementWrapper;
-            var node = GetMatchingNode(fileCompiler, codeElement);
+            var node = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
             if(node == null)
                 return completionItems;
 
@@ -686,12 +699,12 @@ namespace TypeCobol.LanguageServer
                 case TokenType.ADDRESS:
                 {
                     var contextToken = tokensUntilCursor.Skip(2).FirstOrDefault(); //Try to get the token that may define the completion context
-                    completionItems = GetCompletionForAddressOf(node, contextToken, userFilterText);
+                    completionItems = GetCompletionForAddressOf(node, contextToken, userFilterText, fileCompiler.CompilerOptions);
                     break;
                 }
                 case TokenType.UserDefinedWord:
                 {
-                    completionItems = GetCompletionForOfParent(node, tokenBeforeOf, userFilterText);
+                    completionItems = GetCompletionForOfParent(node, tokenBeforeOf, userFilterText, fileCompiler.CompilerOptions);
                     break;
                 }
             }
@@ -707,7 +720,8 @@ namespace TypeCobol.LanguageServer
         /// <param name="node">Node found on cursor position</param>
         /// <param name="contextToken">ContextToken to select if it's a SET or something else</param>
         /// <param name="userFilterText">Variable Name Filter</param>
-        public static IEnumerable<CompletionItem> GetCompletionForAddressOf(Node node, Token contextToken, string userFilterText)
+        /// <param name="options">Current TypeCobolOptions</param>
+        public static IEnumerable<CompletionItem> GetCompletionForAddressOf(Node node, Token contextToken, string userFilterText, TypeCobolOptions options)
         {
             IEnumerable<DataDefinition> potentialVariable = null;
             if (node == null)
@@ -735,12 +749,11 @@ namespace TypeCobol.LanguageServer
                         SymbolTable.Scope.Program);
             }
 
-            return CompletionFactoryHelpers.CreateCompletionItemsForVariables(potentialVariable);
+            return CompletionFactoryHelpers.CreateCompletionItemsForVariables(potentialVariable, options);
         }
 
 
-        public static IEnumerable<CompletionItem> GetCompletionForOfParent(Node node, Token variableNameToken,
-            string userFilterText)
+        public static IEnumerable<CompletionItem> GetCompletionForOfParent(Node node, Token variableNameToken, string userFilterText, TypeCobolOptions options)
         {
             var completionItems = new List<CompletionItem>();
             if (node == null)
@@ -756,18 +769,16 @@ namespace TypeCobol.LanguageServer
             var currentParent = currentVariable.Parent as DataDefinition;
             if (currentParent != null)
             {
-                completionItems.Add(CompletionFactoryHelpers.CreateCompletionItemForVariable(currentParent));
+                completionItems.Add(CompletionFactoryHelpers.CreateCompletionItemForVariable(currentParent, options));
             }
             return completionItems;
         }
 
         #endregion
 
-
-
         #region Helpers
 
-        public static IReadOnlyList<Node> GetTypeChildren(SymbolTable symbolTable, DataDefinition dataDefNode)
+        private static IReadOnlyList<Node> GetTypeChildren(SymbolTable symbolTable, DataDefinition dataDefNode)
         {
             if (symbolTable == null || dataDefNode == null)
                 return null;
@@ -782,66 +793,45 @@ namespace TypeCobol.LanguageServer
             return type?.Children;
         }
 
-        /// <summary>
-        /// Get the matchig node for a given Token and a gien completion mode. Returning a matching Node or null.
-        /// </summary>
-        /// <param name="fileCompiler"></param>
-        /// <param name="codeElement"></param>
-        /// <returns></returns>
-        public static Node GetMatchingNode(FileCompiler fileCompiler, CodeElement codeElement)
-        {
-            if (fileCompiler.CompilationResultsForProgram.ProgramClassDocumentSnapshot != null
-                && fileCompiler.CompilationResultsForProgram.ProgramClassDocumentSnapshot.NodeCodeElementLinkers != null)
-            {
-                return
-                    fileCompiler.CompilationResultsForProgram.ProgramClassDocumentSnapshot.NodeCodeElementLinkers
-                        .FirstOrDefault(t => t.Key.Equals(codeElement)).Value;
-            }
-
-            return null;
-        }
-
-        private static void SearchVariableInTypesAndLevels(Node node, DataDefinition variable, ref List<CompletionItem> completionItems)
+        private static void SearchVariableInTypesAndLevels(Node node, DataDefinition variable, TypeCobolOptions options, List<CompletionItem> completionItems)
         {
             var symbolTable = node.SymbolTable;
-            if (!variable.IsPartOfATypeDef)  //Variable is not comming from a type. 
+            if (!variable.IsPartOfATypeDef)  //Variable is not coming from a type. 
             {
                 if (symbolTable.GetVariablesExplicit(new URI(variable.Name)).Any())   //Check if this variable is present locally. 
                 {
-                    completionItems.Add(CompletionFactoryHelpers.CreateCompletionItemForVariable(variable));
+                    completionItems.Add(CompletionFactoryHelpers.CreateCompletionItemForVariable(variable, options));
                 }
             }
             else
             {
-                if (symbolTable.TypesReferences != null) //We are in a typedef, get references of this type
+                var type = variable.ParentTypeDefinition;
+                var typesReferences = symbolTable.TypesReferences;
+                if (type != null && typesReferences != null && typesReferences.TryGetValue(type, out var references)) //We are in a typedef, get references of this type
                 {
-                    var type = variable.ParentTypeDefinition;
-                    IEnumerable<DataDefinition> references = null;
-                    references = symbolTable.TypesReferences.Where(t => t.Key == type).SelectMany(r => r.Value);
-
                     foreach (var reference in references)
                     {
                         if (symbolTable.GetVariablesExplicit(new URI(reference.Name)).Any())  //Check if this variable is present locally. If not just ignore it
                         {
-                            if (reference.ParentTypeDefinition == null) //Check if the variable is inside a typedef or not, if not it's a final varaible
+                            if (reference.ParentTypeDefinition == null) //Check if the variable is inside a typedef or not, if not it's a final variable
                             {
-                                var referenceArrangedQualifiedName = string.Join("::", reference.VisualQualifiedName.ToString().Split(reference.VisualQualifiedName.Separator).Skip(1)); //Skip Program Name
-                                var finalQualifiedName = string.Format("{0}::{1}", referenceArrangedQualifiedName, variable.VisualQualifiedName.Head);
-                                var variableDisplay = string.Format("{0} ({1}) ({2})", variable.Name, variable.DataType.Name, finalQualifiedName);
+                                var referenceArrangedQualifiedName = string.Join("::", reference.VisualQualifiedNameWithoutProgram);
+                                var finalQualifiedName = $"{referenceArrangedQualifiedName}::{variable.VisualQualifiedName.Head}";
+                                var variableDisplay = $"{variable.Name} ({variable.DataType.Name}) ({finalQualifiedName})";
                                 completionItems.Add(new CompletionItem(variableDisplay) { insertText = finalQualifiedName, kind = CompletionItemKind.Variable });
                             }
-                            else //If the reference is always in a typedef, let's loop and ride up until we are in a final variable
+                            else //If the reference is still in a typedef, let's loop and ride up until we are in a final variable
                             {
-                                var tempCompletionItems = new List<CompletionItem>();
-                                SearchVariableInTypesAndLevels(node, reference, ref tempCompletionItems);
+                                var completionItemsForReference = new List<CompletionItem>();
+                                SearchVariableInTypesAndLevels(node, reference, options, completionItemsForReference);
 
-                                if (tempCompletionItems.Count > 0)
+                                if (completionItemsForReference.Count > 0)
                                 {
-                                    foreach (var tempComp in tempCompletionItems)
+                                    foreach (var completionItem in completionItemsForReference)
                                     {
-                                        tempComp.insertText += "::" + variable.VisualQualifiedName.Head;
-                                        tempComp.label = string.Format("{0} ({1}) ({2})", variable.Name, variable.DataType.Name, tempComp.insertText);
-                                        completionItems.Add(tempComp);
+                                        completionItem.insertText += $"::{variable.VisualQualifiedName.Head}";
+                                        completionItem.label = $"{variable.Name} ({variable.DataType.Name}) ({completionItem.insertText})";
+                                        completionItems.Add(completionItem);
                                     }
                                 }
                             }

--- a/TypeCobol.LanguageServer/TypeCobolServer.cs
+++ b/TypeCobol.LanguageServer/TypeCobolServer.cs
@@ -808,7 +808,7 @@ namespace TypeCobol.LanguageServer
             if (wrappedCodeElement == null) //No codeelements found
                 return null;
 
-            var node = CompletionFactory.GetMatchingNode(docContext.FileCompiler, wrappedCodeElement);
+            var node = CompletionFactoryHelpers.GetMatchingNode(docContext.FileCompiler, wrappedCodeElement);
 
             //Get procedure name or qualified name
             string procedureName = CompletionFactoryHelpers.GetProcedureNameFromTokens(wrappedCodeElement.ArrangedConsumedTokens);

--- a/TypeCobol.LanguageServer/Workspace.cs
+++ b/TypeCobol.LanguageServer/Workspace.cs
@@ -245,7 +245,7 @@ namespace TypeCobol.LanguageServer
                     CloseSourceFile(docContext.Uri); //Close and remove the previous opened file.
 
                 _openedDocuments.Add(docContext.Uri, docContext);
-                fileCompiler.CompilationResultsForProgram.ProgramClassChanged += ProgramClassChanged;
+                fileCompiler.CompilationResultsForProgram.CodeAnalysisCompleted += FinalCompilationStepCompleted;
             }
 
             fileCompiler.CompilationResultsForProgram.SetOwnerThread(Thread.CurrentThread);
@@ -501,7 +501,7 @@ namespace TypeCobol.LanguageServer
                     var contextToClose = _openedDocuments[fileUri];
                     FileCompiler fileCompilerToClose = contextToClose.FileCompiler;
                     _openedDocuments.Remove(fileUri);
-                    fileCompilerToClose.CompilationResultsForProgram.ProgramClassChanged -= ProgramClassChanged;
+                    fileCompilerToClose.CompilationResultsForProgram.CodeAnalysisCompleted -= FinalCompilationStepCompleted;
                 }
             }            
         }
@@ -702,11 +702,11 @@ namespace TypeCobol.LanguageServer
         }
 
         /// <summary>
-        /// Called by a ProgramClass changed event trigger. 
+        /// CodeAnalysis completion event handler.
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void ProgramClassChanged(object cUnit, ProgramClassEvent programEvent)
+        /// <param name="cUnit">Sender of the event is the CompilationUnit.</param>
+        /// <param name="programEvent">Event arg, contains the version number of the most up-to-date InspectedProgramClassDocument.</param>
+        private void FinalCompilationStepCompleted(object cUnit, ProgramClassEvent programEvent)
         {
             var compilationUnit = cUnit as CompilationUnit;
 

--- a/TypeCobol.LanguageServer/Workspace.cs
+++ b/TypeCobol.LanguageServer/Workspace.cs
@@ -198,7 +198,7 @@ namespace TypeCobol.LanguageServer
         private FileCompiler OpenTextDocument(DocumentContext docContext, string sourceText, LsrTestingOptions lsrOptions)
         {
             string fileName = Path.GetFileName(docContext.Uri.LocalPath);
-            ITextDocument initialTextDocumentLines = new ReadOnlyTextDocument(fileName, Configuration.Format.Encoding, Configuration.Format.ColumnsLayout, sourceText);
+            ITextDocument initialTextDocumentLines = new ReadOnlyTextDocument(fileName, Configuration.Format.Encoding, Configuration.Format.ColumnsLayout, docContext.IsCopy, sourceText);
             FileCompiler fileCompiler = null;
 
 #if EUROINFO_RULES //Issue #583
@@ -229,9 +229,9 @@ namespace TypeCobol.LanguageServer
 
             fileCompiler = new FileCompiler(initialTextDocumentLines, CompilationProject.SourceFileProvider,
                 CompilationProject, CompilationProject.CompilationOptions, arrangedCustomSymbol ?? _customSymbols,
-                docContext.IsCopy, CompilationProject);
+                CompilationProject);
 #else
-            fileCompiler = new FileCompiler(initialTextDocumentLines, CompilationProject.SourceFileProvider, CompilationProject, CompilationProject.CompilationOptions, _customSymbols, docContext.IsCopy, CompilationProject);
+            fileCompiler = new FileCompiler(initialTextDocumentLines, CompilationProject.SourceFileProvider, CompilationProject, CompilationProject.CompilationOptions, _customSymbols, CompilationProject);
 #endif
             //Set Any Language Server Connection Options.
             docContext.FileCompiler = fileCompiler;

--- a/TypeCobol.Test/Misc/Expressions-expected.txt
+++ b/TypeCobol.Test/Misc/Expressions-expected.txt
@@ -1,0 +1,356 @@
+RelationCondition: X Z EqualTo →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Z →
+        NumericVariable: Z
+________________________________________
+RelationCondition: X Z EqualTo →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Z →
+        NumericVariable: Z
+________________________________________
+RelationCondition: X Z EqualTo not →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Z →
+        NumericVariable: Z
+________________________________________
+RelationCondition: X Z EqualTo not →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Z →
+        NumericVariable: Z
+________________________________________
+RelationCondition: X Y LessThan →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Y →
+        NumericVariable: Y
+________________________________________
+RelationCondition: X Y LessThan →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Y →
+        NumericVariable: Y
+________________________________________
+RelationCondition: X Y GreaterThan →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Y →
+        NumericVariable: Y
+________________________________________
+RelationCondition: X Y GreaterThan →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Y →
+        NumericVariable: Y
+________________________________________
+RelationCondition: X Y LessThanOrEqualTo →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Y →
+        NumericVariable: Y
+________________________________________
+RelationCondition: X Y LessThanOrEqualTo →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Y →
+        NumericVariable: Y
+________________________________________
+RelationCondition: X Y GreaterThan not →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Y →
+        NumericVariable: Y
+________________________________________
+RelationCondition: X Y GreaterThanOrEqualTo →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Y →
+        NumericVariable: Y
+________________________________________
+RelationCondition: X Y GreaterThanOrEqualTo →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Y →
+        NumericVariable: Y
+________________________________________
+RelationCondition: X Y LessThan not →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: Y →
+        NumericVariable: Y
+________________________________________
+LogicalOperation: X Z EqualTo X Y EqualTo AND →
+    RelationCondition: X Z EqualTo →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: Z →
+            NumericVariable: Z
+    RelationCondition: X Y EqualTo →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: Y →
+            NumericVariable: Y
+________________________________________
+LogicalOperation: X Z EqualTo X Y EqualTo OR →
+    RelationCondition: X Z EqualTo →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: Z →
+            NumericVariable: Z
+    RelationCondition: X Y EqualTo →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: Y →
+            NumericVariable: Y
+________________________________________
+LogicalOperation: <?> X Z EqualTo NOT →
+    RelationCondition: X Z EqualTo →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: Z →
+            NumericVariable: Z
+________________________________________
+ArithmeticOperation: Y Z ÷ →
+    NumericVariable: Y
+    NumericVariable: Z
+________________________________________
+ArithmeticOperation: Y Z - →
+    NumericVariable: Y
+    NumericVariable: Z
+________________________________________
+ArithmeticOperation: Y Z + →
+    NumericVariable: Y
+    NumericVariable: Z
+________________________________________
+ArithmeticOperation: Y Z × →
+    NumericVariable: Y
+    NumericVariable: Z
+________________________________________
+ArithmeticOperation: Y Z ^ →
+    NumericVariable: Y
+    NumericVariable: Z
+________________________________________
+ArithmeticOperation: 0 Y - →
+    NumericVariable: Y
+________________________________________
+NumericVariable: Z
+________________________________________
+SignCondition: X IS Zero ? →
+    ConditionOperand: X →
+        NumericVariable: X
+________________________________________
+SignCondition: X IS Positive ? →
+    ConditionOperand: X →
+        NumericVariable: X
+________________________________________
+SignCondition: X IS Negative ? →
+    ConditionOperand: X →
+        NumericVariable: X
+________________________________________
+SignCondition: X IS NOT Zero ? →
+    ConditionOperand: X →
+        NumericVariable: X
+________________________________________
+ClassCondition: Var-txt Numeric ?
+________________________________________
+ClassCondition: Var-txt Alphabetic ?
+________________________________________
+ClassCondition: Var-txt AlphabeticLower ?
+________________________________________
+ClassCondition: Var-txt AlphabeticUpper ?
+________________________________________
+ClassCondition: Var-DBCS DBCS ?
+________________________________________
+ClassCondition: Var-DBCS Kanji ?
+________________________________________
+ClassCondition: Var-txt MYCLASS ?
+________________________________________
+ClassCondition: Var-txt NOT Numeric ?
+________________________________________
+ConditionNameConditionOrSwitchStatusCondition: GREEN
+________________________________________
+ConditionNameConditionOrSwitchStatusCondition: MYSWITCH-ON
+________________________________________
+LogicalOperation: X 3 GreaterThan 5 X LessThan Y 4 LessThan AND OR Y X + 3 EqualTo not Y 5 - Z 2 + LessThan NOT AND Y X LessThanOrEqualTo AND X Y EqualTo not AND OR 9 Y GreaterThan X Z ÷ 2 EqualTo AND OR Y Y + 50 GreaterThan OR Y X 30 - LessThan OR →
+    LogicalOperation: X 3 GreaterThan 5 X LessThan Y 4 LessThan AND OR Y X + 3 EqualTo not Y 5 - Z 2 + LessThan NOT AND Y X LessThanOrEqualTo AND X Y EqualTo not AND OR 9 Y GreaterThan X Z ÷ 2 EqualTo AND OR Y Y + 50 GreaterThan OR →
+        LogicalOperation: X 3 GreaterThan 5 X LessThan Y 4 LessThan AND OR Y X + 3 EqualTo not Y 5 - Z 2 + LessThan NOT AND Y X LessThanOrEqualTo AND X Y EqualTo not AND OR 9 Y GreaterThan X Z ÷ 2 EqualTo AND OR →
+            LogicalOperation: X 3 GreaterThan 5 X LessThan Y 4 LessThan AND OR Y X + 3 EqualTo not Y 5 - Z 2 + LessThan NOT AND Y X LessThanOrEqualTo AND X Y EqualTo not AND OR →
+                LogicalOperation: X 3 GreaterThan 5 X LessThan Y 4 LessThan AND OR →
+                    RelationCondition: X 3 GreaterThan →
+                        ConditionOperand: X →
+                            NumericVariable: X
+                        ConditionOperand: 3 →
+                            NumericVariable: 3
+                    LogicalOperation: 5 X LessThan Y 4 LessThan AND →
+                        RelationCondition: 5 X LessThan →
+                            ConditionOperand: 5 →
+                                NumericVariable: 5
+                            ConditionOperand: X →
+                                NumericVariable: X
+                        RelationCondition: Y 4 LessThan →
+                            ConditionOperand: Y →
+                                NumericVariable: Y
+                            ConditionOperand: 4 →
+                                NumericVariable: 4
+                LogicalOperation: Y X + 3 EqualTo not Y 5 - Z 2 + LessThan NOT AND Y X LessThanOrEqualTo AND X Y EqualTo not AND →
+                    LogicalOperation: Y X + 3 EqualTo not Y 5 - Z 2 + LessThan NOT AND Y X LessThanOrEqualTo AND →
+                        LogicalOperation: Y X + 3 EqualTo not Y 5 - Z 2 + LessThan NOT AND →
+                            RelationCondition: Y X + 3 EqualTo not →
+                                ConditionOperand: Y X + →
+                                    ArithmeticOperation: Y X + →
+                                        NumericVariable: Y
+                                        NumericVariable: X
+                                ConditionOperand: 3 →
+                                    NumericVariable: 3
+                            RelationCondition: Y 5 - Z 2 + LessThan NOT →
+                                ConditionOperand: Y 5 - →
+                                    ArithmeticOperation: Y 5 - →
+                                        NumericVariable: Y
+                                        NumericVariable: 5
+                                ConditionOperand: Z 2 + →
+                                    ArithmeticOperation: Z 2 + →
+                                        NumericVariable: Z
+                                        NumericVariable: 2
+                        RelationCondition: Y X LessThanOrEqualTo →
+                            ConditionOperand: Y →
+                                NumericVariable: Y
+                            ConditionOperand: X →
+                                NumericVariable: X
+                    RelationCondition: X Y EqualTo not →
+                        ConditionOperand: X →
+                            NumericVariable: X
+                        ConditionOperand: Y →
+                            NumericVariable: Y
+            LogicalOperation: 9 Y GreaterThan X Z ÷ 2 EqualTo AND →
+                RelationCondition: 9 Y GreaterThan →
+                    ConditionOperand: 9 →
+                        NumericVariable: 9
+                    ConditionOperand: Y →
+                        NumericVariable: Y
+                RelationCondition: X Z ÷ 2 EqualTo →
+                    ConditionOperand: X Z ÷ →
+                        ArithmeticOperation: X Z ÷ →
+                            NumericVariable: X
+                            NumericVariable: Z
+                    ConditionOperand: 2 →
+                        NumericVariable: 2
+        RelationCondition: Y Y + 50 GreaterThan →
+            ConditionOperand: Y Y + →
+                ArithmeticOperation: Y Y + →
+                    NumericVariable: Y
+                    NumericVariable: Y
+            ConditionOperand: 50 →
+                NumericVariable: 50
+    RelationCondition: Y X 30 - LessThan →
+        ConditionOperand: Y →
+            NumericVariable: Y
+        ConditionOperand: X 30 - →
+            ArithmeticOperation: X 30 - →
+                NumericVariable: X
+                NumericVariable: 30
+________________________________________
+LogicalOperation: X 3 GreaterThan X 4 GreaterThan OR →
+    RelationCondition: X 3 GreaterThan →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: 3 →
+            NumericVariable: 3
+    RelationCondition: X 4 GreaterThan →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: 4 →
+            NumericVariable: 4
+________________________________________
+LogicalOperation: X 3 GreaterThan 5 Y LessThan AND 5 Y LessThan X 3 GreaterThan AND OR →
+    LogicalOperation: X 3 GreaterThan 5 Y LessThan AND →
+        RelationCondition: X 3 GreaterThan →
+            ConditionOperand: X →
+                NumericVariable: X
+            ConditionOperand: 3 →
+                NumericVariable: 3
+        RelationCondition: 5 Y LessThan →
+            ConditionOperand: 5 →
+                NumericVariable: 5
+            ConditionOperand: Y →
+                NumericVariable: Y
+    LogicalOperation: 5 Y LessThan X 3 GreaterThan AND →
+        RelationCondition: 5 Y LessThan →
+            ConditionOperand: 5 →
+                NumericVariable: 5
+            ConditionOperand: Y →
+                NumericVariable: Y
+        RelationCondition: X 3 GreaterThan →
+            ConditionOperand: X →
+                NumericVariable: X
+            ConditionOperand: 3 →
+                NumericVariable: 3
+________________________________________
+LogicalOperation: X 3 GreaterThan X 3 GreaterThan OR →
+    RelationCondition: X 3 GreaterThan →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: 3 →
+            NumericVariable: 3
+    RelationCondition: X 3 GreaterThan →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: 3 →
+            NumericVariable: 3
+________________________________________
+LogicalOperation: X Y EqualTo not Y X EqualTo not OR →
+    RelationCondition: X Y EqualTo not →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: Y →
+            NumericVariable: Y
+    RelationCondition: Y X EqualTo not →
+        ConditionOperand: Y →
+            NumericVariable: Y
+        ConditionOperand: X →
+            NumericVariable: X
+________________________________________
+LogicalOperation: X 3 GreaterThan X 3 GreaterThan OR →
+    RelationCondition: X 3 GreaterThan →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: 3 →
+            NumericVariable: 3
+    RelationCondition: X 3 GreaterThan →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: 3 →
+            NumericVariable: 3
+________________________________________
+LogicalOperation: X 3 GreaterThan X 3 GreaterThan OR →
+    RelationCondition: X 3 GreaterThan →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: 3 →
+            NumericVariable: 3
+    RelationCondition: X 3 GreaterThan →
+        ConditionOperand: X →
+            NumericVariable: X
+        ConditionOperand: 3 →
+            NumericVariable: 3
+________________________________________
+RelationCondition: X X EqualTo not →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: X →
+        NumericVariable: X
+________________________________________
+RelationCondition: X X EqualTo not →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: X →
+        NumericVariable: X
+________________________________________
+RelationCondition: X X EqualTo not →
+    ConditionOperand: X →
+        NumericVariable: X
+    ConditionOperand: X →
+        NumericVariable: X
+________________________________________

--- a/TypeCobol.Test/Misc/ExpressionsEquivalence.rdz.cbl
+++ b/TypeCobol.Test/Misc/ExpressionsEquivalence.rdz.cbl
@@ -1,0 +1,177 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID.  Pgm.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SPECIAL-NAMES.
+           UPSI-0 IS MYSWITCH
+             ON STATUS IS MYSWITCH-ON
+             OFF STATUS IS MYSWITCH-OFF
+           CLASS MYCLASS IS "G" THRU "O".
+      
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 X                    PIC 9.
+       01 Y                    PIC 9.
+       01 Z                    PIC 9.
+       01 Var-txt              PIC X.
+       01 Var-txt2             PIC X.
+       01 Var-DBCS             PIC G DISPLAY-1.
+       01  COLORS              PIC  X(9).
+         88  BLUE          VALUE 'BLUE'.
+         88  GREEN         VALUE 'GREEN'.
+         88  TURQUOISE     VALUE 'BLUE' 'GREEN'.
+       PROCEDURE DIVISION.
+      * RelationalOperator
+      * 0 and ConditionOperands and NumericVariableOperands
+           IF X = Z
+             CONTINUE
+           END-IF
+      * 1 and NumericVariableOperand
+           IF X equal Y
+             CONTINUE
+           END-IF
+      * 2
+           IF X not = Z
+             CONTINUE
+           END-IF
+      * 3
+           IF X not equal Y
+             CONTINUE
+           END-IF
+      * 4
+           IF X < Z
+             CONTINUE
+           END-IF
+      * 5
+           IF X greater than or equal to Y
+             CONTINUE
+           END-IF
+      * 6
+           IF X not less than Y
+             CONTINUE
+           END-IF
+      
+      * LogicalOperators
+      * 0
+           IF X = Z AND X = Y
+             CONTINUE
+           END-IF.
+      * 1
+           IF X = Y AND Z = Y
+             CONTINUE
+           END-IF.
+      * 2 
+           IF X = Z OR X = Y
+             CONTINUE
+           END-IF.
+      * 3 
+           IF NOT (X = Z)
+             CONTINUE
+           END-IF.
+      
+      * ArithmeticOperator
+      * 0
+           COMPUTE X = Y / Z
+      * 1
+           COMPUTE Z = X / Y
+      * 2
+           COMPUTE X = Y + Z
+      * 3
+           COMPUTE X = - Y
+
+      
+      * Sign condition
+      * 0
+           IF X IS ZERO
+             CONTINUE
+           END-IF.
+      * 1
+           IF Y IS ZERO
+             CONTINUE
+           END-IF.
+      * 2
+           IF X IS NOT ZERO
+             CONTINUE
+           END-IF.
+      * 3
+           IF X IS NOT ZERO
+             CONTINUE
+           END-IF.
+      * 4
+           IF X IS POSITIVE
+             CONTINUE
+           END-IF.
+      * 5
+           IF X IS NEGATIVE
+             CONTINUE
+           END-IF.           
+      
+      * Class condition
+      * 0
+           IF Var-txt2 IS NUMERIC
+             CONTINUE
+           END-IF.
+      * 1
+           IF Var-txt IS NUMERIC
+             CONTINUE
+           END-IF.
+      * 2
+           IF Var-txt IS NOT NUMERIC
+             CONTINUE
+           END-IF.
+      * 3
+           IF Var-txt IS ALPHABETIC
+             CONTINUE
+           END-IF.
+      * 4
+           IF Var-txt IS ALPHABETIC-LOWER
+             CONTINUE
+           END-IF.
+      * 5
+           IF Var-txt IS ALPHABETIC-UPPER
+             CONTINUE
+           END-IF.
+      * 6
+           IF Var-txt IS MYCLASS
+             CONTINUE
+           END-IF.
+      
+      * Condition-name condition
+      * 0
+           IF GREEN
+             CONTINUE
+           END-IF.
+      * 1     
+           IF GREEN
+             CONTINUE
+           END-IF.
+      * 2     
+           IF BLUE
+             CONTINUE
+           END-IF.
+      
+      *     Switch-status condition
+      * 3
+           IF MYSWITCH-ON
+             CONTINUE
+           END-IF.
+      * 4
+           IF MYSWITCH-ON
+             CONTINUE
+           END-IF.      
+
+      * Other expressions
+      *     Abbreviated expression
+      * 0
+           IF X > 3 OR 4
+             CONTINUE
+           END-IF
+      * 1
+           IF Y < 6 OR 12
+             CONTINUE
+           END-IF
+      
+           GOBACK
+           .
+      
+       END PROGRAM Pgm.

--- a/TypeCobol.Test/Misc/TestExpressions.cs
+++ b/TypeCobol.Test/Misc/TestExpressions.cs
@@ -1,0 +1,219 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using TypeCobol.Compiler.CodeElements;
+using TypeCobol.Test.Utils;
+
+namespace TypeCobol.Test.Misc
+{
+    [TestClass]
+    public class TestExpressions
+    {
+        /// <summary>
+        /// Issue #1939, check the Expression trees
+        /// </summary>
+        [TestMethod]
+        [TestCategory("Parsing")]
+        [TestProperty("Time", "fast")]
+        public void CheckExpressionEquivalence()
+        {
+            var folder = Path.Combine("Misc");
+            var fileName = "ExpressionsEquivalence";
+            var compilationUnit = ParserUtils.ParseCobolFile(fileName, folder, execToStep: ExecutionStep.CrossCheck);
+            var root = compilationUnit.TemporaryProgramClassDocumentSnapshot.Root;
+
+            // Get all expressions
+            var expCollector = new ExpressionCollector();
+            root.AcceptASTVisitor(expCollector);
+            var expressionList = expCollector.Expressions;
+
+            // Relational
+            var firstRelational = expressionList.FindIndex(e => e.NodeType == ExpressionNodeType.RelationCondition);
+            AssertEquivalence(0, 1, firstRelational);
+            AssertNotEquivalent(1, 2, firstRelational);
+            AssertEquivalence(2, 3, firstRelational);
+            AssertNotEquivalent(3, 4, firstRelational);
+            AssertNotEquivalent(4, 5, firstRelational);
+            AssertNotEquivalent(4, 6, firstRelational);
+            AssertEquivalence(5, 6, firstRelational);
+
+            // Logical
+            var firstLogical = expressionList.FindIndex(e => e.NodeType == ExpressionNodeType.LogicalOperation);
+            AssertEquivalence(0, 1, firstLogical);
+            AssertNotEquivalent(1, 2, firstLogical);
+            AssertNotEquivalent(2, 3, firstLogical);
+
+            // Arithmetic
+            var firstArithmetic = expressionList.FindIndex(e => e.NodeType == ExpressionNodeType.ArithmeticOperation);
+            AssertEquivalence(0, 1, firstArithmetic);
+            AssertNotEquivalent(1, 2, firstArithmetic);
+            AssertNotEquivalent(2, 3, firstArithmetic);
+
+            // Sign
+            var firstSign = expressionList.FindIndex(e => e.NodeType == ExpressionNodeType.SignCondition);
+            AssertEquivalence(0, 1, firstSign);
+            AssertNotEquivalent(1, 2, firstSign);
+            AssertEquivalence(2, 3, firstSign);
+            AssertNotEquivalent(3, 4, firstSign);
+            AssertNotEquivalent(4, 5, firstSign);
+
+            // Class
+            var firstClass = expressionList.FindIndex(e => e.NodeType == ExpressionNodeType.ClassCondition);
+            AssertEquivalence(0, 1, firstClass);
+            AssertNotEquivalent(1, 2, firstClass);
+            AssertNotEquivalent(2, 3, firstClass);
+            AssertNotEquivalent(3, 4, firstClass);
+            AssertNotEquivalent(4, 5, firstClass);
+            AssertNotEquivalent(5, 6, firstClass);
+
+            // ConditionNameConditionOrSwitchStatusCondition
+            var firstConditionName = expressionList.FindIndex(e => e.NodeType == ExpressionNodeType.ConditionNameConditionOrSwitchStatusCondition);
+            AssertEquivalence(0, 1, firstConditionName);
+            AssertNotEquivalent(1, 2, firstConditionName);
+            AssertNotEquivalent(2, 3, firstConditionName);
+            AssertEquivalence(3, 4, firstConditionName);
+
+            // ConditionOperand
+            var (operand1, operand2) = expressionList[firstRelational].GetOperands();
+            var conditionOperand1 = operand1 as ConditionOperand;
+            var conditionOperand2 = operand2 as ConditionOperand;
+            Assert.IsNotNull(conditionOperand1);
+            Assert.IsNotNull(conditionOperand2);
+            Assert.IsTrue(conditionOperand1.IsEquivalent(conditionOperand2));
+
+            // NumericVariable
+            operand1 = conditionOperand1.ArithmeticExpression;
+            operand2 = conditionOperand2.ArithmeticExpression;
+            var numericVariableOp1 = operand1 as NumericVariableOperand;
+            var numericVariableOp2 = operand2 as NumericVariableOperand;
+            Assert.IsNotNull(numericVariableOp1);
+            Assert.IsNotNull(numericVariableOp2);
+            Assert.IsFalse(numericVariableOp1.IsEquivalent(numericVariableOp2));
+
+            var numericVariableOp3 = expressionList[firstRelational].GetOperands().Item1.GetOperands().Item1 as NumericVariableOperand;
+            Assert.IsNotNull(numericVariableOp3);
+            Assert.IsTrue(numericVariableOp3.IsEquivalent(numericVariableOp1));
+
+            // Other
+            var firstOther = expressionList.FindLastIndex(e => e.NodeType == ExpressionNodeType.ConditionNameConditionOrSwitchStatusCondition) + 1;
+            AssertEquivalence(0, 1, firstOther);
+
+            // Cross expression type
+            var allFirst = new []
+            {
+                firstLogical,
+                firstRelational,
+                firstArithmetic,
+                firstClass,
+                firstConditionName,
+                firstSign
+            };
+
+            foreach (var exp1 in allFirst)
+            {
+                foreach (var exp2 in allFirst)
+                {
+                    if (exp1 != exp2)
+                    {
+                        AssertNotEquivalent(exp1, exp2, 0);
+                    }
+                }
+            }
+
+
+            void AssertEquivalence(int indexA, int indexB, int indexShift)
+            {
+                var expA = expressionList[indexShift + indexA];
+                var expB = expressionList[indexShift + indexB];
+                Assert.IsTrue(expA.IsEquivalent(expB), $"Expressions were not equivalent: '{expA}', '{expB}'");
+            }
+
+            void AssertNotEquivalent(int indexA, int indexB, int indexShift)
+            {
+                var expA = expressionList[indexShift + indexA];
+                var expB = expressionList[indexShift + indexB];
+                Assert.IsFalse(expA.IsEquivalent(expB), $"Expressions were equivalent: '{expA}', '{expB}'");
+            }
+        }
+
+
+
+        /// <summary>
+        /// Issue #1939, check the Expression trees
+        /// </summary>
+        [TestMethod]
+        [TestCategory("Parsing")]
+        [TestProperty("Time", "fast")]
+        public void CheckExpressionTrees()
+        {
+            var folder = Path.Combine("Parser", "Programs", "Cobol85");
+            var fileName = "Expressions";
+            var compilationUnit = ParserUtils.ParseCobolFile(fileName, folder, execToStep: ExecutionStep.CrossCheck);
+            var root = compilationUnit.TemporaryProgramClassDocumentSnapshot.Root;
+
+            // TODO: Correct the error on switch conditions and set the number of diagnostics to 0
+            var diagnostics = compilationUnit.AllDiagnostics();
+            Assert.AreEqual(1, diagnostics.Count);
+            Assert.AreEqual("Line 169[15,25] <30, Error, Semantics> - Semantic error: Symbol MYSWITCH-ON is not referenced", diagnostics[0].ToString());
+
+            // Get all expressions
+            var expCollector = new ExpressionCollector();
+            root.AcceptASTVisitor(expCollector);
+
+            // Create the expression trees in a string
+            var strToString = new StringBuilder();
+            foreach (var expression in expCollector.Expressions)
+            {
+                strToString.AppendLine(ExpressionToTree(expression));
+                strToString.AppendLine("________________________________________");
+            }
+
+            var expectedPath = Path.ChangeExtension(Path.Combine("Misc", "Expressions-expected"), "txt");
+            var expected = File.ReadAllText(expectedPath);
+            // ensure the string and the file are the same 
+            TestUtils.compareLines("CheckExpressions", strToString.ToString(), expected, PlatformUtils.GetPathForProjectFile(expectedPath));
+        }
+
+        /// <summary>
+        /// Return the tree of the expression in form of a string
+        /// </summary>
+        private static string ExpressionToTree(Expression expression, int depth = 0)
+        {
+            if (expression == null) return string.Empty;
+            var (expA, expB) = expression.GetOperands();
+            var paddedExpression = $"{new string(' ', depth * 4)}{expression.NodeType}: {expression}";
+
+            if (expA == null && expB == null)
+            {
+                return paddedExpression;
+            }
+
+            if (expA != null && expB != null)
+            {
+                return $"{paddedExpression} →\n{ExpressionToTree(expA, depth + 1)}\n{ExpressionToTree(expB, depth + 1)}";
+            }
+
+            return $"{paddedExpression} →\n{(expA == null ? ExpressionToTree(expB, depth + 1) : ExpressionToTree(expA, depth + 1))}";
+        }
+
+        /// <summary>
+        /// Visit the nodes and return all top-most expressions found
+        /// </summary>
+        private class ExpressionCollector : AbstractAstVisitor
+        {
+            /// <summary>
+            /// List of all top-most expressions found
+            /// </summary>
+            public readonly List<Expression> Expressions = new List<Expression>();
+
+            public override bool Visit(Expression expression)
+            {
+                Expressions.Add(expression);
+                // False to avoid having children expressions
+                return false;
+            }
+        }
+    }
+}

--- a/TypeCobol.Test/Parser/CodeElements/START.txt
+++ b/TypeCobol.Test/Parser/CodeElements/START.txt
@@ -1,12 +1,12 @@
 ﻿--- Diagnostics ---
 Line 20[13,14] <27, Error, Syntax> - Syntax error : START: Illegal operator LessThan RuleStack=codeElement>startStatement>relationalOperator,  OffendingSymbol=[13,14:< ]<LessThanOperator>
 Line 21[13,16] <27, Error, Syntax> - Syntax error : START: Illegal operator LessThan RuleStack=codeElement>startStatement>relationalOperator,  OffendingSymbol=[13,16:LESS]<LESS>
-Line 22[13,15] <27, Error, Syntax> - Syntax error : START: Illegal operator LessThanOrEqualTo RuleStack=codeElement>startStatement>relationalOperator,  OffendingSymbol=[13,15:NOT]<NOT>
-Line 23[13,15] <27, Error, Syntax> - Syntax error : START: Illegal operator LessThanOrEqualTo RuleStack=codeElement>startStatement>relationalOperator,  OffendingSymbol=[13,15:NOT]<NOT>
+Line 22[13,15] <27, Error, Syntax> - Syntax error : START: Illegal operator GreaterThan NOT RuleStack=codeElement>startStatement>relationalOperator,  OffendingSymbol=[13,15:NOT]<NOT>
+Line 23[13,15] <27, Error, Syntax> - Syntax error : START: Illegal operator GreaterThan NOT RuleStack=codeElement>startStatement>relationalOperator,  OffendingSymbol=[13,15:NOT]<NOT>
 Line 24[13,15] <27, Error, Syntax> - Syntax error : START: Illegal operator LessThanOrEqualTo RuleStack=codeElement>startStatement>relationalOperator,  OffendingSymbol=[13,15:<= ]<LessThanOrEqualOperator>
 Line 25[13,16] <27, Error, Syntax> - Syntax error : START: Illegal operator LessThanOrEqualTo RuleStack=codeElement>startStatement>relationalOperator,  OffendingSymbol=[13,16:LESS]<LESS>
-Line 26[13,15] <27, Error, Syntax> - Syntax error : START: Illegal operator NotEqualTo RuleStack=codeElement>startStatement>relationalOperator,  OffendingSymbol=[13,15:NOT]<NOT>
-Line 27[13,15] <27, Error, Syntax> - Syntax error : START: Illegal operator NotEqualTo RuleStack=codeElement>startStatement>relationalOperator,  OffendingSymbol=[13,15:NOT]<NOT>
+Line 26[13,15] <27, Error, Syntax> - Syntax error : START: Illegal operator EqualTo NOT RuleStack=codeElement>startStatement>relationalOperator,  OffendingSymbol=[13,15:NOT]<NOT>
+Line 27[13,15] <27, Error, Syntax> - Syntax error : START: Illegal operator EqualTo NOT RuleStack=codeElement>startStatement>relationalOperator,  OffendingSymbol=[13,15:NOT]<NOT>
 --- Code Elements ---
 [[StartStatement]] [1,5:START]<START> --> [7,7:f]<UserDefinedWord>
 

--- a/TypeCobol.Test/Parser/FileFormat/TestCobolFile.cs
+++ b/TypeCobol.Test/Parser/FileFormat/TestCobolFile.cs
@@ -27,7 +27,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile("EbcdicRefFormat", out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormat.TXT", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormat.TXT", docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();
@@ -83,8 +83,8 @@ namespace TypeCobol.Test.Parser.FileFormat
             {
                 try
                 {
-                    // Load the CobolFile in a TextDocument
-                    ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormatWithBadChars.TXT", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+                    // Load the CobolFile in a TextDocument;
+                    ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormatWithBadChars.TXT", docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 }
                 catch(Exception e)
                 {
@@ -117,7 +117,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile("AsciiRefFormat", out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCOUT.cpy", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCOUT.cpy", docFormat.Encoding, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();
@@ -172,7 +172,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile("AsciiLinuxFormat.14", out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("AsciiLinuxFormat.14", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("AsciiLinuxFormat.14", docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();
@@ -227,7 +227,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile("AsciiFreeFormat", out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("AsciiFreeFormat.cpy", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("AsciiFreeFormat.cpy", docFormat.Encoding, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();
@@ -307,7 +307,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile(filename, out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument(filename, docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument(filename, docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();

--- a/TypeCobol.Test/Parser/Performance/Performance.cs
+++ b/TypeCobol.Test/Parser/Performance/Performance.cs
@@ -235,13 +235,13 @@ namespace TypeCobol.Test.Parser.Performance
             CompilationProject project = new CompilationProject("test",
                 root.FullName, new[] { ".cbl", ".cpy" },
                 documentFormat, new TypeCobolOptions(), CreateAnalyzerProvider());
-            FileCompiler compiler = new FileCompiler(null, filename, project.SourceFileProvider, project, documentFormat.ColumnsLayout, new TypeCobolOptions(), null, false, project);
+            FileCompiler compiler = new FileCompiler(null, filename, documentFormat.ColumnsLayout, false, project.SourceFileProvider, project, new TypeCobolOptions(), null, project);
             //Make an incremental change to the source code
             TestUtils.CompilationStats stats = new TestUtils.CompilationStats();
             ExecuteIncremental(compiler, stats, newLineIndex, newLineText);
 
             // Display a performance report
-            TestUtils.CreateRunReport("Incremental", TestUtils.GetReportDirectoryPath(), compiler.CobolFile.Name, stats, compiler.CompilationResultsForProgram);
+            TestUtils.CreateRunReport("Incremental", TestUtils.GetReportDirectoryPath(), filename, stats, compiler.CompilationResultsForProgram);
         }
 
         private void ExecuteIncremental(FileCompiler compiler, TestUtils.CompilationStats stats, int newLineIndex, string newLineText)

--- a/TypeCobol.Test/Parser/Programs/Cobol85/Expressions.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/Expressions.rdz.cbl
@@ -1,0 +1,233 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID.  Pgm.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SPECIAL-NAMES.
+           UPSI-0 IS MYSWITCH
+             ON STATUS IS MYSWITCH-ON
+             OFF STATUS IS MYSWITCH-OFF
+           CLASS MYCLASS IS "G" THRU "O".
+      
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 X                    PIC 9.
+       01 Y                    PIC 9.
+       01 Z                    PIC 9.
+       01 Var-txt              PIC X.
+       01 Var-DBCS             PIC G DISPLAY-1.
+       01  COLORS              PIC  X(9).
+         88  BLUE          VALUE 'BLUE'.
+         88  GREEN         VALUE 'GREEN'.
+         88  TURQUOISE     VALUE 'BLUE' 'GREEN'.
+       PROCEDURE DIVISION.
+      * RelationalOperator
+           IF X = Z
+             CONTINUE
+           END-IF
+      
+           IF X equal Z
+             CONTINUE
+           END-IF
+      
+           IF X not = Z
+             CONTINUE
+           END-IF
+      
+           IF X not equal Z
+             CONTINUE
+           END-IF
+      
+           IF X < Y
+             CONTINUE
+           END-IF
+      
+           IF X less than Y
+             CONTINUE
+           END-IF
+      
+           IF X > Y
+             CONTINUE
+           END-IF
+      
+           IF X greater than Y
+             CONTINUE
+           END-IF
+      
+           IF X <= Y
+             CONTINUE
+           END-IF
+      
+           IF X less than or equal to Y
+             CONTINUE
+           END-IF
+      
+           IF X not greater than Y
+             CONTINUE
+           END-IF
+      
+           IF X >= Y
+             CONTINUE
+           END-IF
+      
+           IF X greater than or equal to Y
+             CONTINUE
+           END-IF
+      
+           IF X not less than Y
+             CONTINUE
+           END-IF
+      
+      * LogicalOperators
+           IF X = Z AND X = Y
+             CONTINUE
+           END-IF.
+      
+           IF X = Z OR X = Y
+             CONTINUE
+           END-IF.
+      
+           IF NOT (X = Z)
+             CONTINUE
+           END-IF.
+      
+      * ArithmeticOperator
+           COMPUTE X = Y / Z
+      
+           COMPUTE X = Y - Z
+      
+           COMPUTE X = Y + Z
+      
+           COMPUTE X = Y * Z
+      
+           COMPUTE X = Y ** Z
+      
+           COMPUTE X = - Y
+
+           COMPUTE X ROUNDED = Z
+
+           ADD Y TO X ROUNDED
+           SUBTRACT Y FROM X ROUNDED
+           MULTIPLY Y BY Z GIVING X ROUNDED
+           DIVIDE Y BY Z GIVING X ROUNDED
+      
+      * Sign condition
+           IF X IS ZERO
+             CONTINUE
+           END-IF.
+      
+           IF X IS POSITIVE
+             CONTINUE
+           END-IF.
+      
+           IF X IS NEGATIVE
+             CONTINUE
+           END-IF.
+      
+           IF X IS NOT ZERO
+             CONTINUE
+           END-IF.
+      
+      * Class condition
+           IF Var-txt IS NUMERIC
+             CONTINUE
+           END-IF.
+      
+           IF Var-txt IS ALPHABETIC
+             CONTINUE
+           END-IF.
+      
+           IF Var-txt IS ALPHABETIC-LOWER
+             CONTINUE
+           END-IF.
+      
+           IF Var-txt IS ALPHABETIC-UPPER
+             CONTINUE
+           END-IF.
+      
+           IF Var-DBCS IS DBCS
+             CONTINUE
+           END-IF.
+      
+           IF Var-DBCS IS KANJI
+             CONTINUE
+           END-IF.
+      
+           IF Var-txt IS MYCLASS
+             CONTINUE
+           END-IF.
+      
+           IF Var-txt IS NOT NUMERIC
+             CONTINUE
+           END-IF.
+      
+      * Condition-name condition
+           IF GREEN
+             CONTINUE
+           END-IF.
+      
+      * Switch-status condition
+           IF MYSWITCH-ON
+             CONTINUE
+           END-IF.
+      
+      * Big expression
+           IF X > 3 OR 5 < X AND Y < 4 OR Y + X not = 3
+            AND Y - 5 NOT LESS Z + 2 AND Y <= X
+            AND X not = Y OR 9 > Y AND X / Z EQUAL 2 OR Y + Y > 50
+            OR Y < X - 30
+             CONTINUE
+           END-IF
+      
+      
+      * Abbreviated expression
+           IF X > 3 OR 4
+             CONTINUE
+           END-IF
+      
+      * Multiline
+           IF X > 3 AND 5 < Y
+             OR 5 < Y AND X > 3
+             CONTINUE
+           END-IF
+      
+           IF X > 3
+             OR 3
+             CONTINUE
+           END-IF
+      
+           IF X not = Y
+            OR Y not = X
+             CONTINUE
+           END-IF
+      
+      * Multiline and spaced
+           IF                 X > 3
+             OR 3
+             CONTINUE
+           END-IF
+      
+           IF X > 3
+                      OR 3
+             CONTINUE
+           END-IF
+      
+      * Not at begining and spaced
+           IF X
+             not = X
+             CONTINUE
+           END-IF
+      
+           IF          X
+             not = X
+             CONTINUE
+           END-IF
+      
+           IF X
+                  not = X
+             CONTINUE
+           END-IF
+      
+           GOBACK
+           .
+      
+       END PROGRAM Pgm.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/Expressions.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/Expressions.rdzPGM.txt
@@ -1,0 +1,23 @@
+﻿--- Diagnostics ---
+Line 169[15,25] <30, Error, Semantics> - Semantic error: Symbol MYSWITCH-ON is not referenced OffendingSymbol=[15,25:MYSWITCH-ON]<UserDefinedWord>
+
+--- Program ---
+PROGRAM: Pgm common:False initial:False recursive:False
+ author: ? written: ? compiled: ? installation: ? security: ?
+--- Intrinsic:Namespace:Program:Global:Local
+-- DATA --------
+  X:Numeric
+  Y:Numeric
+  Z:Numeric
+  Var-txt:Alphanumeric
+  Var-DBCS:DBCS
+  COLORS:Alphanumeric
+  BLUE:Level88
+  GREEN:Level88
+  TURQUOISE:Level88
+--- Intrinsic
+-- TYPES -------
+  BOOL:BOOL
+  DATE:DATE
+  CURRENCY:CURRENCY
+  STRING:STRING

--- a/TypeCobol.Test/Parser/Programs/Cobol85/UnsupportedKeywords.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/UnsupportedKeywords.rdz.cbl
@@ -1,0 +1,15 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Pgm.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 WS-FOO PIC X.
+       01 WS-BAR PIC X.
+      *EXHIBIT, NAMED and CHANGED are not reserved keywords
+       01 EXHIBIT PIC X.
+       01 CHANGED PIC X.
+       01 NAMED PIC X.
+       PROCEDURE DIVISION.
+      *EXHIBIT statement is not supported
+           EXHIBIT NAMED WS-FOO WS-BAR
+           .
+       END PROGRAM Pgm.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/UnsupportedKeywords.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/UnsupportedKeywords.rdzMix.txt
@@ -1,0 +1,16 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Pgm.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 WS-FOO PIC X.
+       01 WS-BAR PIC X.
+      *EXHIBIT, NAMED and CHANGED are not reserved keywords
+       01 EXHIBIT PIC X.
+       01 CHANGED PIC X.
+       01 NAMED PIC X.
+       PROCEDURE DIVISION.
+      *EXHIBIT statement is not supported
+Line 13[20,24] <27, Error, Syntax> - Syntax error : 'EXHIBIT' is not supported
+           EXHIBIT NAMED WS-FOO WS-BAR
+           .
+       END PROGRAM Pgm.

--- a/TypeCobol.Test/Parser/Programs/TypeCobol/ProcedureInput.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/ProcedureInput.rdzMix.txt
@@ -78,12 +78,12 @@ Line 52[29,32] <27, Error, Syntax> - Syntax error : Input variable 'var1' is mod
                - var1 pic X
       %>>>
        declare InvalidParamProc private
-Line 75[32,37] <27, Error, Syntax> - Syntax error : 'occurs' is not supported yet
+Line 75[32,37] <27, Error, Syntax> - Syntax error : 'occurs' is not supported
               input var1 pic X occurs 5.
        end-declare.
       
        declare InvalidParamProc2 private
-Line 79[33,38] <27, Error, Syntax> - Syntax error : 'occurs' is not supported yet
+Line 79[33,38] <27, Error, Syntax> - Syntax error : 'occurs' is not supported
                input var1 pic X occurs 5.
        end-declare.
       

--- a/TypeCobol.Test/Parser/Scanner/ResultFiles/TCKeywords-AsCobol85.txt
+++ b/TypeCobol.Test/Parser/Scanner/ResultFiles/TCKeywords-AsCobol85.txt
@@ -1,0 +1,50 @@
+-- Line 1 --
+[1,7:TYPEDEF]<UserDefinedWord>
+[8,8: ]<SpaceSeparator>
+[9,14:STRONG]<UserDefinedWord>
+[15,15: ]<SpaceSeparator>
+[16,21:UNSAFE]<UserDefinedWord>
+[22,22: ]<SpaceSeparator>
+[23,28:PUBLIC]<UserDefinedWord>
+[29,29: ]<SpaceSeparator>
+[30,36:PRIVATE]<UserDefinedWord>
+[37,37: ]<SpaceSeparator>
+[38,43:IN-OUT]<UserDefinedWord>
+[44,44: ]<SpaceSeparator>
+[45,50:STRICT]<UserDefinedWord>
+
+-- Line 2 --
+[1,7:TyPeDeF]<UserDefinedWord>
+[8,8: ]<SpaceSeparator>
+[9,14:StRoNg]<UserDefinedWord>
+[15,15: ]<SpaceSeparator>
+[16,21:UnSaFe]<UserDefinedWord>
+[22,22: ]<SpaceSeparator>
+[23,28:PuBlIc]<UserDefinedWord>
+[29,29: ]<SpaceSeparator>
+[30,36:PrIvAtE]<UserDefinedWord>
+[37,37: ]<SpaceSeparator>
+[38,43:In-oUt]<UserDefinedWord>
+[44,44: ]<SpaceSeparator>
+[45,50:StRiCt]<UserDefinedWord>
+
+-- Line 3 --
+[1,4:MOVE]<MOVE>
+[5,5: ]<SpaceSeparator>
+[6,11:public]<UserDefinedWord>
+[12,12: ]<SpaceSeparator>
+[13,14:TO]<TO>
+[15,15: ]<SpaceSeparator>
+[16,22:private]<UserDefinedWord>
+
+-- Line 4 --
+[1,4:MOVE]<MOVE>
+[5,5: ]<SpaceSeparator>
+[6,11:UNSAFE]<UserDefinedWord>
+[12,12: ]<SpaceSeparator>
+[13,18:strong]<UserDefinedWord>
+[19,19: ]<SpaceSeparator>
+[20,21:TO]<TO>
+[22,22: ]<SpaceSeparator>
+[23,28:strict]<UserDefinedWord>
+

--- a/TypeCobol.Test/Parser/Scanner/ResultFiles/TCKeywords-AsTypeCobol.txt
+++ b/TypeCobol.Test/Parser/Scanner/ResultFiles/TCKeywords-AsTypeCobol.txt
@@ -1,0 +1,50 @@
+-- Line 1 --
+[1,7:TYPEDEF]<TYPEDEF>
+[8,8: ]<SpaceSeparator>
+[9,14:STRONG]<STRONG>
+[15,15: ]<SpaceSeparator>
+[16,21:UNSAFE]<UNSAFE>
+[22,22: ]<SpaceSeparator>
+[23,28:PUBLIC]<PUBLIC>
+[29,29: ]<SpaceSeparator>
+[30,36:PRIVATE]<PRIVATE>
+[37,37: ]<SpaceSeparator>
+[38,43:IN-OUT]<IN_OUT>
+[44,44: ]<SpaceSeparator>
+[45,50:STRICT]<STRICT>
+
+-- Line 2 --
+[1,7:TyPeDeF]<TYPEDEF>
+[8,8: ]<SpaceSeparator>
+[9,14:StRoNg]<STRONG>
+[15,15: ]<SpaceSeparator>
+[16,21:UnSaFe]<UNSAFE>
+[22,22: ]<SpaceSeparator>
+[23,28:PuBlIc]<PUBLIC>
+[29,29: ]<SpaceSeparator>
+[30,36:PrIvAtE]<PRIVATE>
+[37,37: ]<SpaceSeparator>
+[38,43:In-oUt]<IN_OUT>
+[44,44: ]<SpaceSeparator>
+[45,50:StRiCt]<STRICT>
+
+-- Line 3 --
+[1,4:MOVE]<MOVE>
+[5,5: ]<SpaceSeparator>
+[6,11:public]<PUBLIC>
+[12,12: ]<SpaceSeparator>
+[13,14:TO]<TO>
+[15,15: ]<SpaceSeparator>
+[16,22:private]<PRIVATE>
+
+-- Line 4 --
+[1,4:MOVE]<MOVE>
+[5,5: ]<SpaceSeparator>
+[6,11:UNSAFE]<UNSAFE>
+[12,12: ]<SpaceSeparator>
+[13,18:strong]<STRONG>
+[19,19: ]<SpaceSeparator>
+[20,21:TO]<TO>
+[22,22: ]<SpaceSeparator>
+[23,28:strict]<STRICT>
+

--- a/TypeCobol.Test/Parser/Scanner/ScannerUtils.cs
+++ b/TypeCobol.Test/Parser/Scanner/ScannerUtils.cs
@@ -38,7 +38,7 @@ namespace TypeCobol.Test.Parser.Scanner
 
     internal static class ScannerUtils
     {
-        public static TextSourceInfo TextSourceInfo = new TextSourceInfo("test", IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147), ColumnsLayout.FreeTextFormat);
+        public static TextSourceInfo TextSourceInfo = new TextSourceInfo("test", IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147), ColumnsLayout.FreeTextFormat, false);//Assuming a program here, not a copy.
         public static TypeCobolOptions CompilerOptions = new TypeCobolOptions();
         public static List<RemarksDirective.TextNameVariation> CopyTextNameVariations = new List<RemarksDirective.TextNameVariation>();
 

--- a/TypeCobol.Test/Parser/Scanner/TestRealPrograms.cs
+++ b/TypeCobol.Test/Parser/Scanner/TestRealPrograms.cs
@@ -28,7 +28,7 @@ namespace TypeCobol.Test.Parser.Scanner
                 string textName = Path.GetFileNameWithoutExtension(fileName);
 
                 // Initialize a CompilationDocument
-                FileCompiler compiler = new FileCompiler(null, textName, project.SourceFileProvider, project, ColumnsLayout.CobolReferenceFormat, new TypeCobolOptions(), null, false, project);
+                FileCompiler compiler = new FileCompiler(null, textName, ColumnsLayout.CobolReferenceFormat, false, project.SourceFileProvider, project, new TypeCobolOptions(), null, project);
 
                 // Start compilation
                 try

--- a/TypeCobol.Test/Parser/Scanner/TestTokenTypes.cs
+++ b/TypeCobol.Test/Parser/Scanner/TestTokenTypes.cs
@@ -222,6 +222,25 @@ namespace TypeCobol.Test.Parser.Scanner
             };
             result = ScannerUtils.ScanLines(testLines);
             ScannerUtils.CheckWithResultFile(result, testName);
+
+            testName = "TCKeywords";
+            testLines = new string[]
+                        {
+                            "TYPEDEF STRONG UNSAFE PUBLIC PRIVATE IN-OUT STRICT",
+                            "TyPeDeF StRoNg UnSaFe PuBlIc PrIvAtE In-oUt StRiCt",
+                            "MOVE public TO private",
+                            "MOVE UNSAFE strong TO strict"
+                        };
+
+            //Scan as pure cobol
+            ScannerUtils.CompilerOptions.IsCobolLanguage = true;
+            result = ScannerUtils.ScanLines(testLines);
+            ScannerUtils.CheckWithResultFile(result, testName + "-AsCobol85");
+
+            //Scan as TypeCobol
+            ScannerUtils.CompilerOptions.IsCobolLanguage = false;
+            result = ScannerUtils.ScanLines(testLines);
+            ScannerUtils.CheckWithResultFile(result, testName + "-AsTypeCobol");
         }
 
         /// <summary>

--- a/TypeCobol.Test/Parser/TestParserRobustness.cs
+++ b/TypeCobol.Test/Parser/TestParserRobustness.cs
@@ -22,14 +22,14 @@ namespace TypeCobol.Test.Compiler.Parser
         private static CodeElement[] ParseCodeElements(string cobolString, bool asPartOfACopy, out Diagnostic[] parserDiagnostics)
         {
             // Load text document from string
-            var textDocument = new ReadOnlyTextDocument("test string", Encoding.Default, ColumnsLayout.FreeTextFormat, "");
+            var textDocument = new ReadOnlyTextDocument("test string", Encoding.Default, ColumnsLayout.FreeTextFormat, asPartOfACopy, string.Empty);
             textDocument.LoadChars(cobolString);
 
             // Create a compilation project and a compiler for this document
             var typeCobolOptions = new TypeCobolOptions();
             var project = new CompilationProject("test project", ".", new[] { ".cbl", ".cpy" },
                 DocumentFormat.FreeTextFormat, typeCobolOptions, null);
-            var compiler = new FileCompiler(textDocument, project.SourceFileProvider, project, typeCobolOptions, asPartOfACopy, project);
+            var compiler = new FileCompiler(textDocument, project.SourceFileProvider, project, typeCobolOptions, project);
 
             // Execute compilation - until the CodeElements phase ONLY
             compiler.CompilationResultsForProgram.UpdateTokensLines();

--- a/TypeCobol.Test/Parser/Text/TestReadOnlyTextDocument.cs
+++ b/TypeCobol.Test/Parser/Text/TestReadOnlyTextDocument.cs
@@ -49,7 +49,7 @@ namespace TypeCobol.Test.Parser.Text
 
         public static void Check_EmptyDocument()
         {
-            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("empty", Encoding.Default, ColumnsLayout.CobolReferenceFormat, String.Empty);
+            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("empty", Encoding.Default, ColumnsLayout.CobolReferenceFormat, false, String.Empty);
 
             Exception resultException = null;
             try
@@ -176,7 +176,7 @@ namespace TypeCobol.Test.Parser.Text
             }
                 
             // Load the CobolFile in a TextDocument
-            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCOUT.cpy", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCOUT.cpy", docFormat.Encoding, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
             
             if(textDocument.CharAt(0) != '0')
             {
@@ -269,7 +269,7 @@ namespace TypeCobol.Test.Parser.Text
             }
 
             // Load the CobolFile in a TextDocument
-            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCINP free format.cpy", docFormat.Encoding, docFormat.ColumnsLayout, cobolFile.ReadChars());
+            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCINP free format.cpy", docFormat.Encoding, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
 
             if (textDocument.CharAt(0) != '/')
             {

--- a/TypeCobol.Test/TypeCobol.Test.csproj
+++ b/TypeCobol.Test/TypeCobol.Test.csproj
@@ -46,6 +46,9 @@
     <Compile Include="**\*.cs" />
     <Content Include="Parser\**\*" Exclude="Parser\**\*.cs" />
     <None Include="packages.config" />
+    <None Include="Misc\**\*" Exclude="Misc\**\*.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Report\Input\**">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/TypeCobol.Test/Utils/Comparator.cs
+++ b/TypeCobol.Test/Utils/Comparator.cs
@@ -57,7 +57,7 @@ namespace TypeCobol.Test.Utils
             
             string filename = Comparator.paths.SampleName;
             bool isCopy = copyExtensions.Contains(sampleExtension, StringComparer.OrdinalIgnoreCase);
-            Compiler = new FileCompiler(null, filename, project.SourceFileProvider, project, format.ColumnsLayout, options, null, isCopy, project);
+            Compiler = new FileCompiler(null, filename, format.ColumnsLayout, isCopy, project.SourceFileProvider, project, options, null, project);
 
             if (antlrProfiler)
             {

--- a/TypeCobol.Test/Utils/ParserUtils.cs
+++ b/TypeCobol.Test/Utils/ParserUtils.cs
@@ -31,7 +31,7 @@ namespace TypeCobol.Test.Utils
                 localDirectory.FullName, new string[] { ".cbl", ".cpy" },
                 documentFormat, new TypeCobolOptions(), null);
 
-            FileCompiler compiler = new FileCompiler(null, textName, project.SourceFileProvider, project, documentFormat.ColumnsLayout, new TypeCobolOptions(), null, isCopy, project);
+            FileCompiler compiler = new FileCompiler(null, textName, documentFormat.ColumnsLayout, isCopy, project.SourceFileProvider, project, new TypeCobolOptions(), null, project);
             compiler.CompileOnce(ExecutionStep.Preprocessor, false, false);
 
             return compiler.CompilationResultsForProgram;
@@ -51,7 +51,7 @@ namespace TypeCobol.Test.Utils
                 //First use *.cpy as tests will use file WITH extension for program but without extension for copy inside programs => small perf gain
                 localDirectory.FullName, new string[] { ".cpy", ".cbl" },
                 documentFormat, options, null);
-            FileCompiler compiler = new FileCompiler(null, textName, project.SourceFileProvider, project, documentFormat.ColumnsLayout, options, null, isCopy, project);
+            FileCompiler compiler = new FileCompiler(null, textName, documentFormat.ColumnsLayout, isCopy, project.SourceFileProvider, project, options, null, project);
             compiler.CompileOnce();
 
             return compiler.CompilationResultsForProgram;
@@ -60,14 +60,14 @@ namespace TypeCobol.Test.Utils
         public static CompilationUnit ParseCobolString(string cobolString, bool asPartOfACopy)
         {
             //Prepare
-            var textDocument = new ReadOnlyTextDocument("Empty doc", Encoding.Default, ColumnsLayout.FreeTextFormat, "");
+            var textDocument = new ReadOnlyTextDocument("Empty doc", Encoding.Default, ColumnsLayout.FreeTextFormat, asPartOfACopy, string.Empty);
             textDocument.LoadChars(cobolString);
 
             var typeCobolOptions = new TypeCobolOptions();
             var project = new CompilationProject("Empty project", ".", new[] { ".cbl", ".cpy" },
                 DocumentFormat.FreeTextFormat, typeCobolOptions, null);
 
-            var compiler = new FileCompiler(textDocument, project.SourceFileProvider, project, typeCobolOptions, asPartOfACopy, project);
+            var compiler = new FileCompiler(textDocument, project.SourceFileProvider, project, typeCobolOptions, project);
             compiler.CompileOnce();
 
             return compiler.CompilationResultsForProgram;

--- a/TypeCobol/Compiler/CodeElements/CobolLanguageLevelVisitor.cs
+++ b/TypeCobol/Compiler/CodeElements/CobolLanguageLevelVisitor.cs
@@ -207,6 +207,7 @@ namespace TypeCobol.Compiler.CodeElements
         bool Visit([NotNull] ConditionalExpression conditionalExpression);
         bool Visit([NotNull] SignCondition signCondition);
         bool Visit([NotNull] RelationCondition relationCondition);
+        bool Visit([NotNull] RelationalOperator relationalOperator);
         bool Visit([NotNull] LogicalOperation logicalOperation);
         bool Visit([NotNull] ClassCondition classCondition);
         bool Visit([NotNull] ConditionNameConditionOrSwitchStatusCondition conditionNameConditionOrSwitchStatusCondition);
@@ -826,6 +827,11 @@ namespace TypeCobol.Compiler.CodeElements
         }
 
         public virtual bool Visit(RelationCondition relationCondition) {
+            return true;
+        }
+
+        public virtual bool Visit(RelationalOperator relationalOperator)
+        {
             return true;
         }
 

--- a/TypeCobol/Compiler/CodeElements/Statement/StartStatement.cs
+++ b/TypeCobol/Compiler/CodeElements/Statement/StartStatement.cs
@@ -28,7 +28,7 @@ namespace TypeCobol.Compiler.CodeElements
         /// When the START statement is executed, a comparison is made between the current
         /// value in the key data-name and the corresponding key field in the file's index.
         /// </summary>
-        public SyntaxProperty<RelationalOperator> RelationalOperator { get; set; }
+        public RelationalOperator RelationalOperator { get; set; }
 
         /// <summary>
         /// p429:

--- a/TypeCobol/Compiler/CompilationDocument.cs
+++ b/TypeCobol/Compiler/CompilationDocument.cs
@@ -21,27 +21,6 @@ namespace TypeCobol.Compiler
     public class CompilationDocument
     {
         /// <summary>
-        /// Parsing modes
-        /// </summary>
-        public enum ParsingMode
-        {
-            /// <summary>
-            /// Default mode, input document is considered as a full Cobol Program.
-            /// </summary>
-            Program,
-
-            /// <summary>
-            /// Mode for copybooks imported into another document via COPY (or EXEC SQL INCLUDE) instruction.
-            /// </summary>
-            ImportedCopy,
-
-            /// <summary>
-            /// Special mode for 'direct' copy parsing. Copy content is parsed within a fake wrapper program.
-            /// </summary>
-            CopyAsProgram
-        }
-
-        /// <summary>
         /// Text source name and format
         /// </summary>
         public TextSourceInfo TextSourceInfo { get; private set; }
@@ -67,7 +46,6 @@ namespace TypeCobol.Compiler
         // - accessing an element by index requires traversing the tree from its root, a O(log n) operation
         private ImmutableList<CodeElementsLine>.Builder compilationDocumentLines;
 
-
         /// <summary>
         /// Text names variations declared in REMARKS compiler directives or automaticly detected in CompilerDirectiveBuilder.
         /// </summary>
@@ -81,9 +59,9 @@ namespace TypeCobol.Compiler
         private MultilineScanState InitialScanState { get; }
 
         /// <summary>
-        /// Parsing mode of this document
+        /// Special compilation mode for copies that are not imported from another document.
         /// </summary>
-        public ParsingMode Mode { get; }
+        protected bool UseDirectCopyParsing { get; }
 
         /// <summary>
         /// Informations used to track the performance of each compilation step
@@ -171,9 +149,12 @@ namespace TypeCobol.Compiler
         /// This method does not scan the inserted text lines to produce tokens.
         /// You must explicitely call UpdateTokensLines() to start an initial scan of the document.
         /// </summary>
-        public CompilationDocument(TextSourceInfo textSourceInfo, ParsingMode mode, IEnumerable<ITextLine> initialTextLines, TypeCobolOptions compilerOptions, IDocumentImporter documentImporter,
+        public CompilationDocument(TextSourceInfo textSourceInfo, bool isImported, IEnumerable<ITextLine> initialTextLines, TypeCobolOptions compilerOptions, IDocumentImporter documentImporter,
             [NotNull] MultilineScanState initialScanState, List<RemarksDirective.TextNameVariation> copyTextNameVariations)
         {
+            //Cannot import a program
+            if (isImported) Debug.Assert(textSourceInfo.IsCopy);
+
             TextSourceInfo = textSourceInfo;
             CompilerOptions = compilerOptions;
             CopyTextNamesVariations = copyTextNameVariations ?? new List<RemarksDirective.TextNameVariation>();
@@ -201,7 +182,7 @@ namespace TypeCobol.Compiler
             PerfStatsForPreprocessor = new PerfStatsForParsingStep(CompilationStep.Preprocessor);
 
             InitialScanState = initialScanState;
-            Mode = mode;
+            UseDirectCopyParsing = textSourceInfo.IsCopy && !isImported;
         }
 
         /// <summary>
@@ -679,7 +660,7 @@ namespace TypeCobol.Compiler
                 ProcessedTokensDocument CreateProcessedTokensDocument(DocumentVersion<IProcessedTokensLine> version, ISearchableReadOnlyList<CodeElementsLine> lines)
                 {
                     //Apply automatic replacing of partial-words for direct copy parsing mode
-                    return Mode == ParsingMode.CopyAsProgram
+                    return UseDirectCopyParsing
                         ? new AutoReplacePartialWordsTokensDocument(tokensDocument, version, lines, CompilerOptions)
                         : new ProcessedTokensDocument(tokensDocument, version, lines, CompilerOptions);
                 }

--- a/TypeCobol/Compiler/CompilationProject.cs
+++ b/TypeCobol/Compiler/CompilationProject.cs
@@ -204,7 +204,7 @@ namespace TypeCobol.Compiler
 #endif
                 bool wasAlreadyInsideCopy = scanState.InsideCopy;
                 scanState.InsideCopy = true;
-                FileCompiler fileCompiler = new FileCompiler(libraryName, textName, SourceFileProvider, this, ColumnsLayout, CompilationOptions, null, true, scanState, this, copyTextNameVariations);
+                FileCompiler fileCompiler = new FileCompiler(libraryName, textName, ColumnsLayout, true, SourceFileProvider, this, CompilationOptions, null, scanState, this, copyTextNameVariations);
                 fileCompiler.CompileOnce();
                 scanState.InsideCopy = wasAlreadyInsideCopy;
 

--- a/TypeCobol/Compiler/CompilationUnit.cs
+++ b/TypeCobol/Compiler/CompilationUnit.cs
@@ -27,8 +27,8 @@ namespace TypeCobol.Compiler
         /// This method does not scan the inserted text lines to produce tokens.
         /// You must explicitly call UpdateTokensLines() to start an initial scan of the document.
         /// </summary>
-        public CompilationUnit(TextSourceInfo textSourceInfo, ParsingMode mode, IEnumerable<ITextLine> initialTextLines, TypeCobolOptions compilerOptions, IDocumentImporter documentImporter, MultilineScanState initialScanState, List<RemarksDirective.TextNameVariation> copyTextNameVariations, IAnalyzerProvider analyzerProvider) :
-            base(textSourceInfo, mode, initialTextLines, compilerOptions, documentImporter, initialScanState, copyTextNameVariations)
+        public CompilationUnit(TextSourceInfo textSourceInfo, bool isImported, IEnumerable<ITextLine> initialTextLines, TypeCobolOptions compilerOptions, IDocumentImporter documentImporter, MultilineScanState initialScanState, List<RemarksDirective.TextNameVariation> copyTextNameVariations, IAnalyzerProvider analyzerProvider) :
+            base(textSourceInfo, isImported, initialTextLines, compilerOptions, documentImporter, initialScanState, copyTextNameVariations)
         {
             // Initialize performance stats 
             PerfStatsForCodeElementsParser = new PerfStatsForParsingStep(CompilationStep.CodeElementsParser);
@@ -238,7 +238,6 @@ namespace TypeCobol.Compiler
                         CustomSymbols,
                         perfStatsForParserInvocation,
                         customAnalyzers,
-                        Mode == ParsingMode.CopyAsProgram,
                         out root,
                         out newDiagnostics,
                         out nodeCodeElementLinkers,
@@ -253,7 +252,7 @@ namespace TypeCobol.Compiler
                         typedVariablesOutsideTypedef, typeThatNeedTypeLinking, results);
 
                     //Direct copy parsing : remove redundant root 01 level if any.
-                    if (Mode == ParsingMode.CopyAsProgram)
+                    if (UseDirectCopyParsing)
                     {
                         var firstDataDefinition = root.MainProgram
                             .Children[0]  //Data Division

--- a/TypeCobol/Compiler/CupPreprocessor/CompilerDirectiveBuilder.cs
+++ b/TypeCobol/Compiler/CupPreprocessor/CompilerDirectiveBuilder.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Antlr4.Runtime;
-using TypeCobol.Compiler.AntlrUtils;
 using TypeCobol.Compiler.CupCommon;
 using TypeCobol.Compiler.Diagnostics;
 using TypeCobol.Compiler.Directives;
@@ -86,7 +82,6 @@ namespace TypeCobol.Compiler.CupPreprocessor
             TypeCobol.Compiler.Scanner.Token suppress, PairTokenListList replacingOperands)
         {
             var copy = (CopyDirective)CompilerDirective;
-            bool isCopy = copy.COPYToken.TokenType == TokenType.COPY;
             copy.TextName = GetName(qualifiedTextName.TextName);
             copy.TextNameSymbol = qualifiedTextName.TextName;
             {                

--- a/TypeCobol/Compiler/Diagnostics/CodeElementCheckers.cs
+++ b/TypeCobol/Compiler/Diagnostics/CodeElementCheckers.cs
@@ -358,10 +358,10 @@ namespace TypeCobol.Compiler.Diagnostics
         public static void OnCodeElement(StartStatement statement, CodeElementsParser.StartStatementContext context)
         {
             if (context?.relationalOperator() != null)
-                if (statement.RelationalOperator.Value != RelationalOperator.EqualTo &&
-                    statement.RelationalOperator.Value != RelationalOperator.GreaterThan &&
-                    statement.RelationalOperator.Value != RelationalOperator.GreaterThanOrEqualTo)
-                    DiagnosticUtils.AddError(statement, "START: Illegal operator " + statement.RelationalOperator.Value,
+                if (statement.RelationalOperator.SemanticOperator != RelationalOperatorSymbol.EqualTo &&
+                    statement.RelationalOperator.SemanticOperator != RelationalOperatorSymbol.GreaterThan &&
+                    statement.RelationalOperator.SemanticOperator != RelationalOperatorSymbol.GreaterThanOrEqualTo)
+                    DiagnosticUtils.AddError(statement, "START: Illegal operator " + statement.RelationalOperator,
                         context.relationalOperator());
         }
     }

--- a/TypeCobol/Compiler/FileCompiler.cs
+++ b/TypeCobol/Compiler/FileCompiler.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
 using JetBrains.Annotations;
 using TypeCobol.Compiler.CodeModel;
 using TypeCobol.Compiler.Directives;
@@ -10,7 +8,6 @@ using TypeCobol.Compiler.File;
 using TypeCobol.Compiler.Preprocessor;
 using TypeCobol.Compiler.Scanner;
 using TypeCobol.Compiler.Text;
-using TypeCobol.Tools;
 
 namespace TypeCobol.Compiler
 {
@@ -19,11 +16,6 @@ namespace TypeCobol.Compiler
     /// </summary>
     public class FileCompiler
     {
-        /// <summary>
-        /// Source text file on disk
-        /// </summary>
-        public CobolFile CobolFile { get; private set; }
-
         /// <summary>
         /// Source text buffer in memory
         /// </summary>
@@ -81,42 +73,61 @@ namespace TypeCobol.Compiler
         /// <summary>
         /// Load a Cobol source file in memory
         /// </summary>
-        public FileCompiler([NotNull] CompilationProject compilationProject, string fileName, bool isCopyFile) :
-            this(null, fileName, null, compilationProject.SourceFileProvider, compilationProject, compilationProject.ColumnsLayout, null, compilationProject.CompilationOptions, null, isCopyFile, null, compilationProject, null)
+        public FileCompiler([NotNull] CompilationProject compilationProject, string fileName, bool isCopyFile)
+            : this(null, fileName, compilationProject.ColumnsLayout, isCopyFile,
+                compilationProject.SourceFileProvider, compilationProject, compilationProject.CompilationOptions, null,
+                compilationProject)
         { }
 
         /// <summary>
         /// Load a Cobol source file in memory
         /// </summary>
-        public FileCompiler(string libraryName, string fileName, SourceFileProvider sourceFileProvider, IDocumentImporter documentImporter, ColumnsLayout columnsLayout, TypeCobolOptions compilerOptions, CodeModel.SymbolTable customSymbols, bool isCopyFile, CompilationProject compilationProject) :
-            this(libraryName, fileName, null, sourceFileProvider, documentImporter, columnsLayout, null, compilerOptions, customSymbols, isCopyFile, null, compilationProject, null)
+        public FileCompiler(string libraryName, string fileName, ColumnsLayout columnsLayout, bool isCopyFile,
+            SourceFileProvider sourceFileProvider, IDocumentImporter documentImporter, TypeCobolOptions compilerOptions, SymbolTable customSymbols,
+            CompilationProject compilationProject)
+            : this(libraryName, fileName, columnsLayout, isCopyFile,
+                sourceFileProvider, documentImporter, compilerOptions, customSymbols,
+                null, compilationProject, null)
+        { }
+
+        /// <summary>
+        /// Load a Cobol source file in memory
+        /// </summary>
+        public FileCompiler(string libraryName, string fileName, ColumnsLayout columnsLayout, bool isCopyFile,
+            SourceFileProvider sourceFileProvider, IDocumentImporter documentImporter, TypeCobolOptions compilerOptions, SymbolTable customSymbols,
+            MultilineScanState scanState, CompilationProject compilationProject, List<RemarksDirective.TextNameVariation> copyTextNameVariations)
+            : this(new Tuple<string, string, ColumnsLayout, bool>(libraryName, fileName, columnsLayout, isCopyFile), null,
+                sourceFileProvider, documentImporter, compilerOptions, customSymbols,
+                scanState, compilationProject, copyTextNameVariations)
         { }
 
         /// <summary>
         /// Use a pre-existing text document, not yet associated with a Cobol file
         /// </summary>
-        public FileCompiler(ITextDocument textDocument, SourceFileProvider sourceFileProvider, IDocumentImporter documentImporter, TypeCobolOptions compilerOptions, bool isCopyFile, CompilationProject compilationProject) :
-            this(null, null, null, sourceFileProvider, documentImporter, default(ColumnsLayout), textDocument, compilerOptions, null, isCopyFile, null, compilationProject, null)
+        public FileCompiler(ITextDocument textDocument,
+            SourceFileProvider sourceFileProvider, IDocumentImporter documentImporter, TypeCobolOptions compilerOptions,
+            CompilationProject compilationProject)
+            : this(textDocument,
+                sourceFileProvider, documentImporter, compilerOptions, null,
+                compilationProject)
         { }
 
         /// <summary>
         /// Use a pre-existing text document, not yet associated with a Cobol file + Existing SymbolTable
         /// </summary>
-        public FileCompiler(ITextDocument textDocument, SourceFileProvider sourceFileProvider, IDocumentImporter documentImporter, TypeCobolOptions compilerOptions, SymbolTable customSymbols, bool isCopyFile, CompilationProject compilationProject) :
-            this(null, null, null, sourceFileProvider, documentImporter, default(ColumnsLayout), textDocument, compilerOptions, customSymbols, isCopyFile, null, compilationProject, null)
-        { }
-
-        /// <summary>
-        /// Use a pre-existing text document, already initialized from a Cobol file
-        /// </summary>
-        public FileCompiler(string libraryName, string fileName, SourceFileProvider sourceFileProvider, IDocumentImporter documentImporter, ColumnsLayout columnsLayout, TypeCobolOptions compilerOptions, CodeModel.SymbolTable customSymbols, bool isCopyFile, MultilineScanState scanState, CompilationProject compilationProject, List<RemarksDirective.TextNameVariation> copyTextNameVariations) :
-            this(libraryName, fileName, null, sourceFileProvider, documentImporter, columnsLayout, null, compilerOptions, customSymbols, isCopyFile, scanState, compilationProject, copyTextNameVariations)
+        public FileCompiler(ITextDocument textDocument,
+            SourceFileProvider sourceFileProvider, IDocumentImporter documentImporter, TypeCobolOptions compilerOptions, SymbolTable customSymbols,
+            CompilationProject compilationProject)
+            : this(null, textDocument,
+                sourceFileProvider, documentImporter, compilerOptions, customSymbols,
+                null, compilationProject, null)
         { }
 
         /// <summary>
         /// Common internal implementation for all constructors above
         /// </summary>
-        private FileCompiler(string libraryName, string fileName, CobolFile loadedCobolFile, SourceFileProvider sourceFileProvider, IDocumentImporter documentImporter, ColumnsLayout columnsLayout, ITextDocument textDocument, TypeCobolOptions compilerOptions, SymbolTable customSymbols, bool isCopyFile,
+        private FileCompiler(Tuple<string, string, ColumnsLayout, bool> fileInfo, ITextDocument textDocument,
+            SourceFileProvider sourceFileProvider, IDocumentImporter documentImporter, TypeCobolOptions compilerOptions, SymbolTable customSymbols,
             [CanBeNull] MultilineScanState scanState, CompilationProject compilationProject, List<RemarksDirective.TextNameVariation> copyTextNameVariations)
         {
             var chrono = new Stopwatch();
@@ -126,47 +137,40 @@ namespace TypeCobol.Compiler
             CobolFile sourceFile = null;
             CompilationProject = compilationProject;
 
-            if (fileName != null)
+            if (textDocument == null)
             {
-                if (sourceFileProvider.TryGetFile(libraryName, fileName, out sourceFile))
+                //No textDocument provided, use fileInfo to find the file
+                Debug.Assert(fileInfo != null);
+                string libraryName = fileInfo.Item1;
+                string fileName = fileInfo.Item2;
+                if (!sourceFileProvider.TryGetFile(libraryName, fileName, out sourceFile))
                 {
-                    CobolFile = sourceFile;
-                }
-                else
-                {
-                    var message = string.IsNullOrEmpty(libraryName) ? string.Format("Cobol source file not found: {0}", fileName)
-                                                                    : string.Format("Cobol source file not found: {0} in {1}", fileName, libraryName);
+                    var message = string.IsNullOrEmpty(libraryName)
+                        ? $"Cobol source file not found: {fileName}"
+                        : $"Cobol source file not found: {fileName} in {libraryName}";
                     throw new Exception(message);
                 }
-
             }
-            // 1.b Register a Cobol source file which was already loaded
-            else if (loadedCobolFile != null)
+            else
             {
-                CobolFile = loadedCobolFile;
+                Debug.Assert(fileInfo == null);
             }
 
             chrono.Stop();
             SourceFileSearchTime = (int)chrono.ElapsedMilliseconds;
             chrono.Reset();
 
-            // 2.a Load it in a new text document in memory
             chrono.Start();
+
             if (textDocument == null)
             {
-                TextDocument = new ReadOnlyTextDocument(sourceFile?.Name, sourceFile?.Encoding, columnsLayout, sourceFile?.ReadChars());
+                // 2.a Load it in a new text document in memory
+                Debug.Assert(sourceFile != null);
+                TextDocument = new ReadOnlyTextDocument(sourceFile.Name, sourceFile.Encoding, fileInfo.Item3, fileInfo.Item4, sourceFile.ReadChars());
             }
-            // 2.b Load it in an existing text document in memory
-            else if (sourceFile != null)
+            else
             {
-                TextDocument = textDocument;
-                textDocument.LoadChars(sourceFile.ReadChars());
-            }
-            // 2.c Use a pre-existing text document 
-            //     - not yet associated with a Cobol source file
-            //     - with a Cobol source file already loaded
-            else if (sourceFile == null || loadedCobolFile != null)
-            {
+                // 2.b Use existing text document in memory, assuming that source is already loaded
                 TextDocument = textDocument;
             }
 
@@ -175,20 +179,19 @@ namespace TypeCobol.Compiler
             chrono.Reset();
 
             // 3. Prepare the data structures used by the different steps of the compiler
-            if (isCopyFile)
+            if (TextDocument.Source.IsCopy)
             {
                 if (scanState != null)
                 {
                     //This is an imported copy
                     Debug.Assert(scanState.InsideCopy);
-                    CompilationResultsForCopy = new CompilationDocument(TextDocument.Source, CompilationDocument.ParsingMode.ImportedCopy, TextDocument.Lines, compilerOptions, documentImporter, scanState, copyTextNameVariations);
+                    CompilationResultsForCopy = new CompilationDocument(TextDocument.Source, true, TextDocument.Lines, compilerOptions, documentImporter, scanState, copyTextNameVariations);
                 }
                 else
                 {
                     //Direct copy parsing, copy is assumed to be part of Data Division and using comma as the decimal point.
-                    var initialScanState = new MultilineScanState(TextDocument.Source.EncodingForAlphanumericLiterals, true, true);
-                    initialScanState.InsideCopy = true;
-                    CompilationResultsForProgram = new CompilationUnit(TextDocument.Source, CompilationDocument.ParsingMode.CopyAsProgram, TextDocument.Lines, compilerOptions, documentImporter, initialScanState, copyTextNameVariations, CompilationProject.AnalyzerProvider);
+                    var initialScanState = new MultilineScanState(TextDocument.Source.EncodingForAlphanumericLiterals, true, true, insideCopy: true);
+                    CompilationResultsForProgram = new CompilationUnit(TextDocument.Source, false, TextDocument.Lines, compilerOptions, documentImporter, initialScanState, copyTextNameVariations, CompilationProject.AnalyzerProvider);
                     CompilationResultsForCopy = CompilationResultsForProgram;
                 }
 
@@ -199,7 +202,7 @@ namespace TypeCobol.Compiler
                 //This is a regular program
                 Debug.Assert(scanState == null);
                 var initialScanState = new MultilineScanState(TextDocument.Source.EncodingForAlphanumericLiterals);
-                CompilationResultsForProgram = new CompilationUnit(TextDocument.Source, CompilationDocument.ParsingMode.Program, TextDocument.Lines, compilerOptions, documentImporter, initialScanState, copyTextNameVariations, CompilationProject.AnalyzerProvider);
+                CompilationResultsForProgram = new CompilationUnit(TextDocument.Source, false, TextDocument.Lines, compilerOptions, documentImporter, initialScanState, copyTextNameVariations, CompilationProject.AnalyzerProvider);
                 CompilationResultsForProgram.CustomSymbols = customSymbols;
             }
             CompilerOptions = compilerOptions;

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolExpressionsBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolExpressionsBuilder.cs
@@ -4,6 +4,7 @@ using TypeCobol.Compiler.AntlrUtils;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.Parser.Generated;
 using System.Collections.Generic;
+using TypeCobol.Compiler.Scanner;
 
 namespace TypeCobol.Compiler.Parser
 {
@@ -720,16 +721,16 @@ namespace TypeCobol.Compiler.Parser
 		internal ConditionalExpression CreateRelationCondition(CodeElementsParser.RelationConditionContext context)
 		{
 			ConditionOperand subjectOperand = CreateConditionOperand(context.conditionOperand());
-			SyntaxProperty<RelationalOperator> relationalOperator = CreateRelationalOperator(context.relationalOperator());
+			RelationalOperator relationalOperator = CreateRelationalOperator(context.relationalOperator());
 			return CreateAbbreviatedExpression(subjectOperand, relationalOperator, context.abbreviatedExpression());
 		}
 
-		private ConditionalExpression CreateAbbreviatedExpression(ConditionOperand subjectOperand, SyntaxProperty<RelationalOperator> distributedRelationalOperator, CodeElementsParser.AbbreviatedExpressionContext context)
+		private ConditionalExpression CreateAbbreviatedExpression(ConditionOperand subjectOperand, RelationalOperator distributedRelationalOperator, CodeElementsParser.AbbreviatedExpressionContext context)
 		{
 			if (context.conditionOperand() != null)
 			{
 				ConditionOperand objectOperand = CreateConditionOperand(context.conditionOperand());
-				SyntaxProperty<RelationalOperator> relationalOperator = distributedRelationalOperator;
+				RelationalOperator relationalOperator = distributedRelationalOperator;
 				if (context.relationalOperator() != null)
 				{
 					relationalOperator = CreateRelationalOperator(context.relationalOperator());
@@ -815,81 +816,87 @@ namespace TypeCobol.Compiler.Parser
 			return conditionOperand;
 		}
 
-		internal SyntaxProperty<RelationalOperator> CreateRelationalOperator(CodeElementsParser.RelationalOperatorContext context)
-		{
-			if(context.strictRelation() != null)
-			{
-				bool invertStrictRelation = false;
-				if (context.NOT() != null)
-				{
-					invertStrictRelation = true;
-				}
+		internal RelationalOperator CreateRelationalOperator(CodeElementsParser.RelationalOperatorContext context)
+        {
+            var notToken = context.NOT() == null ? null : ParseTreeUtils.GetFirstToken(context.NOT());
 
-				CodeElementsParser.StrictRelationContext strictContext = context.strictRelation();
+            if (context.strictRelation() != null)
+			{
+                CodeElementsParser.StrictRelationContext strictContext = context.strictRelation();
 				if(strictContext.GREATER() != null)
 				{
-					return new SyntaxProperty<RelationalOperator>(
-						!invertStrictRelation ? RelationalOperator.GreaterThan : RelationalOperator.LessThanOrEqualTo,
-						ParseTreeUtils.GetFirstToken(strictContext.GREATER()));
+					return new RelationalOperator(
+                        new SyntaxProperty<RelationalOperatorSymbol>(RelationalOperatorSymbol.GreaterThan, ParseTreeUtils.GetFirstToken(strictContext.GREATER())),
+                        notToken
+                        );
 				}
 				else if (strictContext.GreaterThanOperator() != null)
 				{
-					return new SyntaxProperty<RelationalOperator>(
-						!invertStrictRelation ? RelationalOperator.GreaterThan : RelationalOperator.LessThanOrEqualTo,
-						ParseTreeUtils.GetFirstToken(strictContext.GreaterThanOperator()));
-				}
+                    return new RelationalOperator(
+                        new SyntaxProperty<RelationalOperatorSymbol>(RelationalOperatorSymbol.GreaterThan, ParseTreeUtils.GetFirstToken(strictContext.GreaterThanOperator())),
+                        notToken
+                    );
+                }
 				else if (strictContext.LESS() != null)
 				{
-					return new SyntaxProperty<RelationalOperator>(
-						!invertStrictRelation ? RelationalOperator.LessThan : RelationalOperator.GreaterThanOrEqualTo,
-						ParseTreeUtils.GetFirstToken(strictContext.LESS()));
-				}
+                    return new RelationalOperator(
+                        new SyntaxProperty<RelationalOperatorSymbol>(RelationalOperatorSymbol.LessThan, ParseTreeUtils.GetFirstToken(strictContext.LESS())),
+                        notToken
+                    );
+                }
 				else if (strictContext.LessThanOperator() != null)
 				{
-					return new SyntaxProperty<RelationalOperator>(
-						!invertStrictRelation ? RelationalOperator.LessThan : RelationalOperator.GreaterThanOrEqualTo,
-						ParseTreeUtils.GetFirstToken(strictContext.LessThanOperator()));
-				}
+                    return new RelationalOperator(
+                        new SyntaxProperty<RelationalOperatorSymbol>(RelationalOperatorSymbol.LessThan, ParseTreeUtils.GetFirstToken(strictContext.LessThanOperator())),
+                        notToken
+                    );
+                }
 				else if (strictContext.EQUAL() != null)
 				{
-					return new SyntaxProperty<RelationalOperator>(
-						!invertStrictRelation ? RelationalOperator.EqualTo : RelationalOperator.NotEqualTo,
-						ParseTreeUtils.GetFirstToken(strictContext.EQUAL()));
-				}
+                    return new RelationalOperator(
+                        new SyntaxProperty<RelationalOperatorSymbol>(RelationalOperatorSymbol.EqualTo, ParseTreeUtils.GetFirstToken(strictContext.EQUAL())),
+                        notToken
+                    );
+                }
 				else // if (strictContext.EqualOperator() != null)
 				{
-					return new SyntaxProperty<RelationalOperator>(
-						!invertStrictRelation ? RelationalOperator.EqualTo : RelationalOperator.NotEqualTo,
-						ParseTreeUtils.GetFirstToken(strictContext.EqualOperator()));
-				}
+                    return new RelationalOperator(
+                        new SyntaxProperty<RelationalOperatorSymbol>(RelationalOperatorSymbol.EqualTo, ParseTreeUtils.GetFirstToken(strictContext.EqualOperator())),
+                        notToken
+                    );
+                }
 			}
 			else
 			{
 				CodeElementsParser.SimpleRelationContext simpleContext = context.simpleRelation();
 				if (simpleContext.GREATER() != null)
 				{
-					return new SyntaxProperty<RelationalOperator>(
-						RelationalOperator.GreaterThanOrEqualTo,
-						ParseTreeUtils.GetFirstToken(simpleContext.GREATER()));
-				}
+                    return new RelationalOperator(
+                        new SyntaxProperty<RelationalOperatorSymbol>(RelationalOperatorSymbol.GreaterThanOrEqualTo, ParseTreeUtils.GetFirstToken(simpleContext.GREATER())),
+                        notToken
+                    );
+                }
 				else if (simpleContext.GreaterThanOrEqualOperator() != null)
 				{
-					return new SyntaxProperty<RelationalOperator>(
-						RelationalOperator.GreaterThanOrEqualTo,
-						ParseTreeUtils.GetFirstToken(simpleContext.GreaterThanOrEqualOperator()));
-				}
+                    return new RelationalOperator(
+                        new SyntaxProperty<RelationalOperatorSymbol>(RelationalOperatorSymbol.GreaterThanOrEqualTo, ParseTreeUtils.GetFirstToken(simpleContext.GreaterThanOrEqualOperator())),
+                        notToken
+                    );
+                }
 				if (simpleContext.LESS() != null)
 				{
-					return new SyntaxProperty<RelationalOperator>(
-						RelationalOperator.LessThanOrEqualTo,
-						ParseTreeUtils.GetFirstToken(simpleContext.LESS()));
-				}
+                    return new RelationalOperator(
+                        new SyntaxProperty<RelationalOperatorSymbol>(RelationalOperatorSymbol.LessThanOrEqualTo, ParseTreeUtils.GetFirstToken(simpleContext.LESS())),
+                        notToken
+                    );
+                }
 				else // if (simpleContext.LessThanOrEqualOperator() != null)
 				{
-					return new SyntaxProperty<RelationalOperator>(
-						RelationalOperator.LessThanOrEqualTo,
-						ParseTreeUtils.GetFirstToken(simpleContext.LessThanOrEqualOperator()));
-				}
+                    return new RelationalOperator(
+                        new SyntaxProperty<RelationalOperatorSymbol>(RelationalOperatorSymbol.LessThanOrEqualTo, ParseTreeUtils.GetFirstToken(simpleContext.LessThanOrEqualOperator())),
+                        notToken
+                    );
+                }
 			}
 		}
 

--- a/TypeCobol/Compiler/Parser/InspectedProgramClassDocument.cs
+++ b/TypeCobol/Compiler/Parser/InspectedProgramClassDocument.cs
@@ -10,9 +10,10 @@ namespace TypeCobol.Compiler.Parser
     /// </summary>
     public class InspectedProgramClassDocument
     {
-        public InspectedProgramClassDocument(ProgramClassDocument programClassDocument, List<Diagnostic> diagnostics, Dictionary<string, object> analyzerResults)
+        public InspectedProgramClassDocument(ProgramClassDocument programClassDocument, int version, List<Diagnostic> diagnostics, Dictionary<string, object> analyzerResults)
         {
             PreviousStepSnapshot = programClassDocument;
+            CurrentVersion = version;
             Diagnostics = diagnostics;
             AnalyzerResults = new AnalyzerResults(analyzerResults);
         }
@@ -21,6 +22,11 @@ namespace TypeCobol.Compiler.Parser
         /// Snapshot of the fully parsed program that was quality checked
         /// </summary>
         public ProgramClassDocument PreviousStepSnapshot { get; }
+
+        /// <summary>
+        /// Version number of the current document
+        /// </summary>
+        public int CurrentVersion { get; }
 
         /// <summary>
         /// List of rules violations returned by code analysis

--- a/TypeCobol/Compiler/Parser/ProgramClassParserStep.cs
+++ b/TypeCobol/Compiler/Parser/ProgramClassParserStep.cs
@@ -50,7 +50,6 @@ namespace TypeCobol.Compiler.Parser
             SymbolTable customSymbols,
             PerfStatsForParserInvocation perfStatsForParserInvocation,
             ISyntaxDrivenAnalyzer[] customAnalyzers,
-            bool wrapCopyIntoProgram,
             out SourceFile root,
             out List<Diagnostic> diagnostics, 
             out Dictionary<CodeElement, Node> nodeCodeElementLinkers,
@@ -63,7 +62,7 @@ namespace TypeCobol.Compiler.Parser
 #endif
             IEnumerable<CodeElement> before = null;
             IEnumerable<CodeElement> after = null;
-            if (wrapCopyIntoProgram)
+            if (textSourceInfo.IsCopy)
             {
                 var programSkeleton = new CopyParsing.ProgramSkeleton(textSourceInfo);
                 before = programSkeleton.Before();

--- a/TypeCobol/Compiler/Scanner/MultilineScanState.cs
+++ b/TypeCobol/Compiler/Scanner/MultilineScanState.cs
@@ -69,7 +69,11 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// True if we are scanning inside a Copy.
         /// </summary>
-        public bool InsideCopy { get; set; }
+        public bool InsideCopy
+        {
+            get;
+            internal set; //Setter is used only at import time when we jump from including document to included copy.
+        }
 
         /// <summary>
         /// Encoding of the text file : used to decode the value of an hexadecimal alphanumeric literal
@@ -114,8 +118,8 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// Initialize scanner state for the first line
         /// </summary>
-        public MultilineScanState(Encoding encodingForAlphanumericLiterals, bool insideDataDivision = false, bool decimalPointIsComma = false, bool withDebuggingMode = false) :
-            this(insideDataDivision, false, false, false, false, false, false, decimalPointIsComma, withDebuggingMode, encodingForAlphanumericLiterals)
+        public MultilineScanState(Encoding encodingForAlphanumericLiterals, bool insideDataDivision = false, bool decimalPointIsComma = false, bool withDebuggingMode = false, bool insideCopy = false) :
+            this(insideDataDivision, false, false, false, false, false, false, decimalPointIsComma, withDebuggingMode, insideCopy, encodingForAlphanumericLiterals)
         { }
 
         /// <summary>
@@ -123,7 +127,7 @@ namespace TypeCobol.Compiler.Scanner
         /// </summary>
         private MultilineScanState(bool insideDataDivision, bool insideProcedureDivision, bool insidePseudoText, bool insideSymbolicCharacterDefinitions, 
                 bool insideFormalizedComment, bool insideMultilineComments, bool insideParamsField,
-                bool decimalPointIsComma, bool withDebuggingMode, Encoding encodingForAlphanumericLiterals)
+                bool decimalPointIsComma, bool withDebuggingMode, bool insideCopy, Encoding encodingForAlphanumericLiterals)
         {
             InsideDataDivision = insideDataDivision;
             InsideProcedureDivision = insideProcedureDivision;
@@ -134,6 +138,7 @@ namespace TypeCobol.Compiler.Scanner
             InsideSymbolicCharacterDefinitions = insideSymbolicCharacterDefinitions;
             DecimalPointIsComma = decimalPointIsComma;
             WithDebuggingMode = withDebuggingMode;
+            InsideCopy = insideCopy;
             EncodingForAlphanumericLiterals = encodingForAlphanumericLiterals;
         }
 
@@ -144,8 +149,7 @@ namespace TypeCobol.Compiler.Scanner
         {
             MultilineScanState clone = new MultilineScanState(InsideDataDivision, InsideProcedureDivision, InsidePseudoText, InsideSymbolicCharacterDefinitions,
                 InsideFormalizedComment, InsideMultilineComments, InsideParamsField, 
-                DecimalPointIsComma, WithDebuggingMode, EncodingForAlphanumericLiterals);
-            clone.InsideCopy = this.InsideCopy;
+                DecimalPointIsComma, WithDebuggingMode, InsideCopy, EncodingForAlphanumericLiterals);
             if (LastSignificantToken != null) clone.LastSignificantToken = LastSignificantToken;
             if (BeforeLastSignificantToken != null) clone.BeforeLastSignificantToken = BeforeLastSignificantToken;
             if (SymbolicCharacters != null)

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -2148,7 +2148,7 @@ namespace TypeCobol.Compiler.Scanner
                 //   as a system-name.
 
                 // Try to match keyword text
-                tokenType = TokenUtils.GetTokenTypeFromTokenString(tokenText);
+                tokenType = TokenUtils.GetTokenTypeFromTokenString(tokenText, compilerOptions.IsCobolLanguage);
 
                 // Special cases of user defined words : 
                 // - symbolic characters

--- a/TypeCobol/Compiler/Scanner/TokenUtils.cs
+++ b/TypeCobol/Compiler/Scanner/TokenUtils.cs
@@ -72,17 +72,26 @@ namespace TypeCobol.Compiler.Scanner
 
         private static IDictionary<string, TokenType> tokenTypeFromTokenString;
 
-        internal static TokenType GetTokenTypeFromTokenString(string tokenString)
+        internal static TokenType GetTokenTypeFromTokenString(string tokenString, bool pureCobol)
         {
-            TokenType tokenType;
-            if (tokenTypeFromTokenString.TryGetValue(tokenString, out tokenType))
+            if (tokenTypeFromTokenString.TryGetValue(tokenString, out var tokenType))
             {
-                return tokenType;
+                //In TypeCobol context, return found type
+                if (!pureCobol) return tokenType;
+
+                //In pure Cobol context, check token family
+                switch (GetTokenFamilyFromTokenType(tokenType))
+                {
+                    case TokenFamily.Cobol2002Keyword:
+                    case TokenFamily.TypeCobolKeyword:
+                        //Special case for TC-specific keywords
+                        return TokenType.UserDefinedWord;
+                    default:
+                        return tokenType;
+                }
             }
-            else
-            {
-                return TokenType.UserDefinedWord;
-            }
+
+            return TokenType.UserDefinedWord;
         }
         
         // Formalized Comments only to avoid Formalized Comments tokens detection in Cobol and Cobol tokens in Formalized Comments

--- a/TypeCobol/Compiler/Text/CobolTextLine.cs
+++ b/TypeCobol/Compiler/Text/CobolTextLine.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using TypeCobol.Compiler.Concurrency;
+using TypeCobol.Compiler.Directives;
 using TypeCobol.Compiler.File;
 using TypeCobol.Compiler.Scanner;
 
@@ -115,6 +116,7 @@ namespace TypeCobol.Compiler.Text
         public static ICollection<ITextLine> CreateCobolLines(ColumnsLayout layout, int index, char indicator, string indent, string text, int pmax, int pmin, bool bConvertFirstLine)
         {
             var result = new List<ITextLine>();
+            var scannerOptions = new TypeCobolOptions();
             foreach (var part in text.Split(new[] { Environment.NewLine, "\n", "\r" }, StringSplitOptions.None))
             {
                 int max = pmax;
@@ -133,7 +135,7 @@ namespace TypeCobol.Compiler.Text
                         indicator = '-';
                     }
 
-                    IList<Tuple<string, bool>> lines = Split(part, max, min);
+                    IList<Tuple<string, bool>> lines = Split(part, max, min, scannerOptions);
 
                     for (int i = 0; i < lines.Count; i++)
                     {
@@ -176,7 +178,7 @@ namespace TypeCobol.Compiler.Text
             return result;
         }
 
-        private static IList<Tuple<string, bool> > Split(string line, int max, int min)
+        private static IList<Tuple<string, bool> > Split(string line, int max, int min, TypeCobolOptions scannerOptions)
         {
             var lines = new List<Tuple<string, bool>>();
             int nLine = (line.Length / max) + ((line.Length % max) != 0 ? 1 : 0);
@@ -195,7 +197,7 @@ namespace TypeCobol.Compiler.Text
             TokensLine tempTokensLine = TokensLine.CreateVirtualLineForInsertedToken(0, line);
             tempTokensLine.InitializeScanState(new MultilineScanState(IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147)));
 
-            Scanner.Scanner scanner = new Scanner.Scanner(line, 0, line.Length - 1, tempTokensLine, null, false);
+            Scanner.Scanner scanner = new Scanner.Scanner(line, 0, line.Length - 1, tempTokensLine, scannerOptions, false);
             Token t = null;
             int nCurLength = 0;
             int nSpan = max;

--- a/TypeCobol/Compiler/Text/ReadOnlyTextDocument.cs
+++ b/TypeCobol/Compiler/Text/ReadOnlyTextDocument.cs
@@ -20,11 +20,14 @@ namespace TypeCobol.Compiler.Text
         /// Initialize a cobol document from any source of characters
         /// </summary> 
         /// <param name="fileName">Name of the file the document is stored in</param>
+        /// <param name="encodingForAlphanumericLiterals">Document encoding</param>
+        /// <param name="columnsLayout">Document layout</param>
+        /// <param name="isCopy">Document nature</param>
         /// <param name="textSource">Sequence of unicode characters with line delimiters (Cr? Lf)</param>
-        public ReadOnlyTextDocument(string fileName, Encoding encodingForAlphanumericLiterals, ColumnsLayout columnsLayout, IEnumerable<char> textSource)
+        public ReadOnlyTextDocument(string fileName, Encoding encodingForAlphanumericLiterals, ColumnsLayout columnsLayout, bool isCopy, IEnumerable<char> textSource)
         {
             // Document source name and text format
-            Source = new TextSourceInfo(fileName, encodingForAlphanumericLiterals, columnsLayout);
+            Source = new TextSourceInfo(fileName, encodingForAlphanumericLiterals, columnsLayout, isCopy);
 
             // Initialize document text lines
             LoadChars(textSource);

--- a/TypeCobol/Compiler/Text/TextSourceInfo.cs
+++ b/TypeCobol/Compiler/Text/TextSourceInfo.cs
@@ -1,34 +1,39 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 
 namespace TypeCobol.Compiler.Text
 {
     /// <summary>
-    /// Informations on the source file on disk, or the buffer in memory, from which a text document was loaded
+    /// Information on the source file on disk, or the buffer in memory, from which a text document was loaded
     /// </summary>
     public class TextSourceInfo
     {
-        public TextSourceInfo(string name, Encoding encodingForAlphanumericLiterals, ColumnsLayout columnsLayout)
+        public TextSourceInfo(string name, Encoding encodingForAlphanumericLiterals, ColumnsLayout columnsLayout, bool isCopy)
         {
             Name = name;
             EncodingForAlphanumericLiterals = encodingForAlphanumericLiterals;
             ColumnsLayout = columnsLayout;
+            IsCopy = isCopy;
         }
 
         /// <summary>
         /// Name of the source file on disk (or the buffer in memory) from which a text document was loaded.
         /// Could be null if no name has been set for an in-memory buffer.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Character set used to encode the hexadecimal alphanumeric literals in the text document
         /// </summary>
-        public Encoding EncodingForAlphanumericLiterals { get; private set; }
+        public Encoding EncodingForAlphanumericLiterals { get; }
 
         /// <summary>
         /// Format of the text document lines : Cobol reference format on 72 columns, or free text format
         /// </summary>
-        public ColumnsLayout ColumnsLayout { get; private set; }
+        public ColumnsLayout ColumnsLayout { get; }
+
+        /// <summary>
+        /// Nature of expected file content: True for copybook, False for program.
+        /// </summary>
+        public bool IsCopy { get; }
     }
 }

--- a/TypeCobol/LanguageServices/CodeAnalysis/Statistics/StatsGenerator.cs
+++ b/TypeCobol/LanguageServices/CodeAnalysis/Statistics/StatsGenerator.cs
@@ -91,7 +91,7 @@ namespace TypeCobol.LanguageServices.CodeAnalysis.Statistics
                     try
                     {
                         // Compile program
-                        FileCompiler fileCompiler = new FileCompiler(null, textName, project.SourceFileProvider, project, project.ColumnsLayout, project.CompilationOptions.Clone(), null, false, project);
+                        FileCompiler fileCompiler = new FileCompiler(null, textName, project.ColumnsLayout, false, project.SourceFileProvider, project, project.CompilationOptions.Clone(), null, project);
                         fileCompiler.CompileOnce();
                         CompilationUnit compilationResult = fileCompiler.CompilationResultsForProgram;
                         programCopiesNotFound = 0;

--- a/TypeCobol/Parser.cs
+++ b/TypeCobol/Parser.cs
@@ -54,7 +54,7 @@ namespace TypeCobol
 			foreach (var folder in copies) {
 				sourceFileProvider.AddLocalDirectoryLibrary(folder, false, Helpers.DEFAULT_COPY_EXTENSIONS, format.Encoding, format.EndOfLineDelimiter, format.FixedLineLength);
 			}
-			compiler = new FileCompiler(null, filename, project.SourceFileProvider, project, format.ColumnsLayout, options, CustomSymbols, isCopy, project);
+			compiler = new FileCompiler(null, filename, format.ColumnsLayout, isCopy, project.SourceFileProvider, project, options, CustomSymbols, project);
             
 			Compilers.Add(path, compiler);
 			Inits.Add(path, false);

--- a/TypeCobol/Tools/CommandLine/TypeCobolCompiler.cs
+++ b/TypeCobol/Tools/CommandLine/TypeCobolCompiler.cs
@@ -41,7 +41,7 @@ namespace TypeCobol.Tools.CommandLine
                     Console.Write(textName + " ... ");
                     try
                     {
-                        FileCompiler fileCompiler = new FileCompiler(null, textName, project.SourceFileProvider, project, ColumnsLayout.CobolReferenceFormat, compilerOptions.Clone(), null, false, project);
+                        FileCompiler fileCompiler = new FileCompiler(null, textName, ColumnsLayout.CobolReferenceFormat, false, project.SourceFileProvider, project, compilerOptions.Clone(), null, project);
                         fileCompiler.CompileOnce();
                         Console.WriteLine(" OK");
                     }


### PR DESCRIPTION
### Changelog

WI #1941 Avoid using :: in completion results for pure Cobol (#1957)

WI #1939 Improve Expression trees (#1962)

WI #1946 Improve error message for unsupported EXHIBIT statement (#1959)

WI #1958 Publish LSP diagnostics on code analysis completion (#1960)

WI #1961 Add IsCopy property into TextSourceInfo object (#1963)

WI #1964 Discard TypeCobol keywords when using -cob option (#1968) 