### PR TITLE
WI #2026 Remove static END_OF_FILE token

### DIFF
--- a/TypeCobol.Test/Parser/Preprocessor/PreprocessorUtils.cs
+++ b/TypeCobol.Test/Parser/Preprocessor/PreprocessorUtils.cs
@@ -73,7 +73,7 @@ namespace TypeCobol.Test.Parser.Preprocessor
             StringBuilder sbTokens = new StringBuilder();
             ITokensLinesIterator tokens = processedDoc.GetProcessedTokensIterator();
             Token token = tokens.NextToken();
-            if (token != Token.END_OF_FILE)
+            if (token.TokenType != TokenType.EndOfFile)
             {
                 string documentPath = null;
                 int lineIndex = -1;
@@ -91,7 +91,7 @@ namespace TypeCobol.Test.Parser.Preprocessor
                     }
                     sbTokens.AppendLine(token.ToString());
                 }
-                while ((token = tokens.NextToken()) != Token.END_OF_FILE);
+                while ((token = tokens.NextToken()).TokenType != TokenType.EndOfFile);
             }
 
             // Errors

--- a/TypeCobol/Compiler/AntlrUtils/AntlrPerformanceProfiler.cs
+++ b/TypeCobol/Compiler/AntlrUtils/AntlrPerformanceProfiler.cs
@@ -101,8 +101,8 @@ namespace TypeCobol.Compiler.AntlrUtils
             if (tokensCountIterator != null)
             {
                 ITokensLine lastLine = null;
-                Token token = null;
-                while ((token = tokensCountIterator.NextToken()) != Token.END_OF_FILE)
+                Token token;
+                while ((token = tokensCountIterator.NextToken()).TokenType != TokenType.EndOfFile)
                 {
                     CurrentFileInfo.TokensCount++;
                     if (token.TokensLine != lastLine)

--- a/TypeCobol/Compiler/AntlrUtils/TokensLinesTokenStream.cs
+++ b/TypeCobol/Compiler/AntlrUtils/TokensLinesTokenStream.cs
@@ -61,7 +61,7 @@ namespace TypeCobol.Compiler.AntlrUtils
         }
 
         /// <summary>
-        /// Start monitoring if the token stream reached a specific token which marks the end of an instersting section
+        /// Start monitoring if the token stream reached a specific token which marks the end of an interesting section
         /// </summary>
         public void StartLookingForStopToken(Token stopToken)
         {
@@ -69,7 +69,7 @@ namespace TypeCobol.Compiler.AntlrUtils
             if (stopToken != null)
             {
                 StopToken = stopToken;
-                stopTokenReplacedByEOF = new ReplacedToken(Token.END_OF_FILE, stopToken);
+                stopTokenReplacedByEOF = new ReplacedToken(Token.EndOfFile(), stopToken);
                 StreamReachedStopToken = false;
             }
         }

--- a/TypeCobol/Compiler/CupCommon/CobolWordsTokenizer.cs
+++ b/TypeCobol/Compiler/CupCommon/CobolWordsTokenizer.cs
@@ -233,7 +233,7 @@ namespace TypeCobol.Compiler.CupCommon
         public void ConsumeNextTokenOnTheSameLine(TokenType nextTokenType)
         {
             Token currentToken = base.CurrentToken;
-            if (currentToken == Token.END_OF_FILE)
+            if (currentToken != null && currentToken.TokenType == TokenType.EndOfFile)
                 return;//Ignore if end of file
             Token nextToken = base.NextToken();
             if (nextToken != null && currentToken != null &&
@@ -259,21 +259,6 @@ namespace TypeCobol.Compiler.CupCommon
         }
 
         /// <summary>
-        /// Enter in the Stop Scanning Mode if the current is not of the given type
-        /// </summary>
-        /// <param name="tokenType">The Token type to check</param>
-        public void EnterStopScanningModeIfNotToken(TokenType tokenType)
-        {
-            Token currentToken = base.CurrentToken;
-            if (currentToken == null)
-                return;
-            if (currentToken == Token.END_OF_FILE)
-                return;//Ignore if end of file
-            if (currentToken.TokenType != tokenType)
-                EnterStopScanningMode();
-        }
-
-        /// <summary>
         /// Enter in the Stop Scanning Mode if the next is not of the given type
         /// </summary>
         /// <param name="nextTokenType"></param>
@@ -282,7 +267,7 @@ namespace TypeCobol.Compiler.CupCommon
             Token currentToken = base.CurrentToken;
             if (currentToken == null)
                 return;
-            if (currentToken == Token.END_OF_FILE)
+            if (currentToken.TokenType == TokenType.EndOfFile)
                 return;//Ignore if end of file
             Token nextToken = base.NextToken();
             base.PreviousToken();
@@ -326,11 +311,12 @@ namespace TypeCobol.Compiler.CupCommon
         /// </summary>
         /// <param name="expected">The expected next token</param>
         /// <param name="resulting">The resulting token if matching</param>
-        /// <param name="defaultToken">The defualt token if no matching</param>
+        /// <param name="defaultToken">The default token if no matching</param>
         /// <returns></returns>
         private int TryMatchNextToken(TokenType expected, int resulting, int defaultToken)
         {
-            if (base.CurrentToken == Token.END_OF_FILE)
+            var currentToken = base.CurrentToken;
+            if (currentToken != null && currentToken.TokenType == TokenType.EndOfFile)
                 return defaultToken;
             Token nextToken = base.NextToken();
             if (nextToken != null)
@@ -350,11 +336,11 @@ namespace TypeCobol.Compiler.CupCommon
         /// </summary>
         /// <param name="expected">The expected next token</param>
         /// <param name="resulting">The resulting token if matching</param>
-        /// <param name="defaultToken">The defualt token if no matching</param>
+        /// <param name="defaultToken">The default token if no matching</param>
         /// <returns></returns>
         private int TryMatchPrevToken(TokenType expected, int resulting, int defaultToken)
         {
-            if (base.CurrentToken == Token.END_OF_FILE)
+            if (base.CurrentToken == null)
                 return defaultToken;
             Token prevToken = base.PreviousToken();
             if (prevToken != null)
@@ -436,7 +422,7 @@ namespace TypeCobol.Compiler.CupCommon
             FirstToken = null;
             LastToken = null;            
             Token token = null;
-            while ((token = base.NextToken()) != Token.END_OF_FILE)
+            while ((token = base.NextToken()).TokenType != TokenType.EndOfFile)
             {
                 if (FirstToken == null)
                 {

--- a/TypeCobol/Compiler/Parser/CodeElementsLinesTokenSource.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementsLinesTokenSource.cs
@@ -103,7 +103,7 @@ namespace TypeCobol.Compiler.Parser
                 }
             }
 
-            return Token.END_OF_FILE;
+            return Token.EndOfFile();
         }
 
         public string SourceName

--- a/TypeCobol/Compiler/Preprocessor/CopyTokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Preprocessor/CopyTokensLinesIterator.cs
@@ -254,15 +254,16 @@ namespace TypeCobol.Compiler.Preprocessor
             // If the document is empty or after end of file, immediately return EndOfFile
             if (currentLine == null)
             {
-                currentPosition.CurrentToken = Token.END_OF_FILE;
-                return Token.END_OF_FILE;
+                var eof = Token.EndOfFile();
+                currentPosition.CurrentToken = eof;
+                return eof;
             }
 
             // If the iterator is positioned in an imported document, return the next imported token
             if(currentPosition.ImportedDocumentIterator != null)
             {
                 Token nextImportedToken = currentPosition.ImportedDocumentIterator.NextToken();
-                if(nextImportedToken == Token.END_OF_FILE)
+                if(nextImportedToken.TokenType == TokenType.EndOfFile)
                 {
                     currentPosition.ImportedDocumentIterator = null;
                     currentPosition.ImportedDocumentIteratorPosition = null;
@@ -297,8 +298,9 @@ namespace TypeCobol.Compiler.Preprocessor
                     {
                         // return EndOfFile
                         currentLine = null;
-                        currentPosition.CurrentToken = Token.END_OF_FILE;
-                        return Token.END_OF_FILE;
+                        var eof = Token.EndOfFile();
+                        currentPosition.CurrentToken = eof;
+                        return eof;
                     }
                 }
                 // Check if the next token found matches the filter criteria or is a COPY compiler directive or is a REPLACE directive
@@ -322,7 +324,7 @@ namespace TypeCobol.Compiler.Preprocessor
 
                     // No suitable next token found in the imported document
                     // -> get next token in the main document
-                    if (nextTokenCandidate == Token.END_OF_FILE)
+                    if (nextTokenCandidate.TokenType == TokenType.EndOfFile)
                     {
                         return NextToken();
                     }

--- a/TypeCobol/Compiler/Scanner/ITokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Scanner/ITokensLinesIterator.cs
@@ -51,7 +51,7 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// Get next token or EndOfFile
         /// </summary>
-            Token NextToken();
+        Token NextToken();
 
         /// <summary>
         /// Get null (before the first call to NextToken()), current token, or EndOfFile

--- a/TypeCobol/Compiler/Scanner/Token.cs
+++ b/TypeCobol/Compiler/Scanner/Token.cs
@@ -413,8 +413,14 @@ namespace TypeCobol.Compiler.Scanner
             get { return -1; }
         }
 
-        // Common token for End of file
-        public static Token END_OF_FILE = new Token(TokenType.EndOfFile, 0, -1, TypeCobol.Compiler.Scanner.TokensLine.CreateVirtualLineForInsertedToken(-1, String.Empty));
+        /// <summary>
+        /// Creates a new instance of special end-of-file Token.
+        /// </summary>
+        /// <returns>New Token instance with EndOfFile TokenType</returns>
+        public static Token EndOfFile()
+        {
+            return new Token(TokenType.EndOfFile, 0, -1, Compiler.Scanner.TokensLine.CreateVirtualLineForInsertedToken(-1, string.Empty));
+        }
 
         // --- Token comparison for REPLACE directive ---
 

--- a/TypeCobol/Compiler/Scanner/TokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Scanner/TokensLinesIterator.cs
@@ -199,7 +199,7 @@ namespace TypeCobol.Compiler.Scanner
             // If document is empty, immediately return EndOfFile
             if (currentLine == null)
             {
-                return Token.END_OF_FILE;
+                return Token.EndOfFile();
             }
 
             // While we can find a next token
@@ -224,7 +224,7 @@ namespace TypeCobol.Compiler.Scanner
                     {
                         // return EndOfFile
                         currentLine = null;
-                        return Token.END_OF_FILE;
+                        return Token.EndOfFile();
                     }
                 }
                 // Check if the next token found matches the filter criteria

--- a/TypeCobol/LanguageServices/CodeAnalysis/Statistics/StatsGenerator.cs
+++ b/TypeCobol/LanguageServices/CodeAnalysis/Statistics/StatsGenerator.cs
@@ -296,7 +296,7 @@ namespace TypeCobol.LanguageServices.CodeAnalysis.Statistics
                         // Iterate over tokens AFTER preprocessing
                         ITokensLinesIterator processedTokensIterator = compilationResult.ProcessedTokensDocumentSnapshot.GetProcessedTokensIterator();
                         Token processedToken = null;
-                        while ((processedToken = processedTokensIterator.NextToken()) != Token.END_OF_FILE)
+                        while ((processedToken = processedTokensIterator.NextToken()).TokenType != TokenType.EndOfFile)
                         {
                             tokensCounter.OnElement((int)processedToken.TokenType);
                             ReplacedToken replacedToken = processedToken as ReplacedToken;


### PR DESCRIPTION
Fix #2026.
Following #2030, this PR removes the data retention caused by static `Token` instance 'END_OF_FILE'.
