### PR TITLE
WI #2039 Remove PERFORM recursivity check from CFG

### DIFF
--- a/TypeCobol.Analysis.Test/BasicCfgInstrs/ExtendedPerformProc3Recursive0.diag
+++ b/TypeCobol.Analysis.Test/BasicCfgInstrs/ExtendedPerformProc3Recursive0.diag
@@ -1,3 +1,2 @@
 ﻿--- Diagnostics ---
-Line 28[15,29] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec', recursive instruction is '       perform pararec2'.
 Line 29[15,57] <37, Warning, General> - Warning: Unreachable code detected

--- a/TypeCobol.Analysis.Test/BasicCfgInstrs/ExtendedPerformProc4Recursive0.diag
+++ b/TypeCobol.Analysis.Test/BasicCfgInstrs/ExtendedPerformProc4Recursive0.diag
@@ -1,5 +1,2 @@
 ﻿--- Diagnostics ---
-Line 31[15,29] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec', recursive instruction is '       perform pararec2'.
 Line 32[15,57] <37, Warning, General> - Warning: Unreachable code detected
-Line 57[15,64] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec4', recursive instruction is '       perform pararec4 varying n from 1 by 1 until n > 5'.
-Line 57[15,64] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec4', recursive instruction is '       perform pararec3 test after varying n from 1 by 1 until n'.

--- a/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformIdentity.diag
+++ b/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformIdentity.diag
@@ -1,2 +1,0 @@
---- Diagnostics ---
-Line 6[12,23] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM main', recursive instruction is '    PERFORM main'.

--- a/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProc1Recursive0.diag
+++ b/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProc1Recursive0.diag
@@ -1,2 +1,0 @@
---- Diagnostics ---
-Line 16[15,29] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec', recursive instruction is '       perform pararec'.

--- a/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProc2Recursive0.diag
+++ b/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProc2Recursive0.diag
@@ -1,2 +1,0 @@
---- Diagnostics ---
-Line 27[15,29] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec', recursive instruction is '       perform pararec2'.

--- a/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProc3Recursive0.diag
+++ b/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProc3Recursive0.diag
@@ -1,2 +1,0 @@
---- Diagnostics ---
-Line 28[15,29] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec', recursive instruction is '       perform pararec2'.

--- a/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProc4Recursive0.diag
+++ b/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProc4Recursive0.diag
@@ -1,4 +1,0 @@
---- Diagnostics ---
-Line 31[15,29] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec', recursive instruction is '       perform pararec2'.
-Line 57[15,64] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec4', recursive instruction is '       perform pararec4 varying n from 1 by 1 until n > 5'.
-Line 57[15,64] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec4', recursive instruction is '       perform pararec3 test after varying n from 1 by 1 until n'.

--- a/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProcIterativeAfterRecursive0.diag
+++ b/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProcIterativeAfterRecursive0.diag
@@ -1,2 +1,0 @@
---- Diagnostics ---
-Line 16[15,64] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec', recursive instruction is '       perform pararec  varying n from 1 by 1 until n > 5'.

--- a/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProcIterativeAfterRecursive1.diag
+++ b/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProcIterativeAfterRecursive1.diag
@@ -1,2 +1,0 @@
---- Diagnostics ---
-Line 16[15,72] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec', recursive instruction is '       perform pararec test after varying n from 1 by 1 until n>5'.

--- a/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProcIterativeAfterRecursive2.diag
+++ b/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProcIterativeAfterRecursive2.diag
@@ -1,2 +1,0 @@
---- Diagnostics ---
-Line 16[15,72] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec', recursive instruction is '       perform pararec test after varying n from 1 by 1 until n>5'.

--- a/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProcIterativeRecursive0.diag
+++ b/TypeCobol.Analysis.Test/BasicCfgInstrs/PerformProcIterativeRecursive0.diag
@@ -1,2 +1,0 @@
---- Diagnostics ---
-Line 16[15,64] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM pararec', recursive instruction is '       perform pararec  varying n from 1 by 1 until n > 5'.

--- a/TypeCobol.Analysis.Test/BasicCfgInstrs/SG102A.diag
+++ b/TypeCobol.Analysis.Test/BasicCfgInstrs/SG102A.diag
@@ -15,10 +15,6 @@ Line 242[13,46] <37, Warning, General> - Warning: "end-if" is missing
 Line 250[12,37] <37, Warning, General> - Warning: "end-if" is missing
 Line 266[12,43] <37, Warning, General> - Warning: "end-if" is missing
 Line 267[12,42] <37, Warning, General> - Warning: "end-if" is missing
-Line 269[41,66] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM WRITE-LINE', recursive instruction is '                                      PERFORM WRT-LN'.
-Line 269[41,66] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM WRITE-LINE', recursive instruction is '                                      PERFORM WRT-LN 2 TIMES'.
-Line 269[41,66] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM WRITE-LINE', recursive instruction is '                                         PERFORM WRT-LN'.
-Line 269[41,66] <37, Warning, General> - Warning: A recursive loop has been encountered while analyzing 'PERFORM WRITE-LINE', recursive instruction is '    PERFORM WRT-LN'.
 Line 276[12,43] <37, Warning, General> - Warning: "end-if" is missing
 Line 277[12,38] <37, Warning, General> - Warning: "end-if" is missing
 Line 293[12,16] <37, Warning, General> - Warning: ALTER should not be used

--- a/TypeCobol.Analysis/Cfg/ControlFlowGraphBuilder.BasicBlockForNodeGroup.cs
+++ b/TypeCobol.Analysis/Cfg/ControlFlowGraphBuilder.BasicBlockForNodeGroup.cs
@@ -64,17 +64,6 @@ namespace TypeCobol.Analysis.Cfg
             }
 
             /// <summary>
-            /// To detect recursivity on PERFORM Procedure calls.
-            /// This is a bit array of GroupIndex encountered during the workflow
-            /// call of other PERFORM.
-            /// </summary>
-            internal BitArray RecursivityGroupSet
-            {
-                get;
-                set;
-            }
-
-            /// <summary>
             /// Constructor.
             /// </summary>
             public BasicBlockForNodeGroup()

--- a/TypeCobol.Analysis/Graph/BasicBlock.cs
+++ b/TypeCobol.Analysis/Graph/BasicBlock.cs
@@ -81,8 +81,7 @@ namespace TypeCobol.Analysis.Graph
             Declaratives = 0x01 << 2,   //Flag if this basic block is inside a declaratives section.
             Start = 0x01 << 3,          //Flag for a start node.
             End = 0x01 << 4,            //Flag for a end node.
-            GroupGrafted = 0x01 << 5,   //Flag a Grafted Group.
-            Recursive = 0x01 << 6       //Flag a recursive block
+            GroupGrafted = 0x01 << 5   //Flag a Grafted Group.
         }
 
         /// <summary>

--- a/TypeCobol.Analysis/Graph/ControlFlowGraph.cs
+++ b/TypeCobol.Analysis/Graph/ControlFlowGraph.cs
@@ -135,12 +135,6 @@ namespace TypeCobol.Analysis.Graph
         public Dictionary<PerformProcedure, Tuple<N, N>> WrongOrderPerformThrus { get; private set; }
 
         /// <summary>
-        /// All recursive PERFORMs found in the program. Null if no such perform found.
-        /// Key is the recursive PERFORM statement, value is the list of all detected instructions that lead to recursion.
-        /// </summary>
-        public Dictionary<PerformProcedure, List<N>> RecursivePerforms { get; private set; }
-
-        /// <summary>
         /// All unreachable blocks of this graph. The property may be null but not empty.
         /// </summary>
         public List<BasicBlock<N, D>> UnreachableBlocks { get; private set; }
@@ -241,28 +235,6 @@ namespace TypeCobol.Analysis.Graph
 
             System.Diagnostics.Debug.Assert(!WrongOrderPerformThrus.ContainsKey(performThru));
             WrongOrderPerformThrus.Add(performThru, new Tuple<N, N>(procedure, throughProcedure));
-        }
-
-        /// <summary>
-        /// Register a recursive jump for a perform statement.
-        /// </summary>
-        /// <param name="perform">Perform node</param>
-        /// <param name="recursiveJump">Recursive jump node</param>
-        internal void AddRecursivePerform(PerformProcedure perform, N recursiveJump)
-        {
-            if (RecursivePerforms == null)
-            {
-                RecursivePerforms = new Dictionary<PerformProcedure, List<N>>();
-            }
-
-            if (RecursivePerforms.TryGetValue(perform, out var nodes))
-            {
-                nodes.Add(recursiveJump);
-            }
-            else
-            {
-                RecursivePerforms.Add(perform, new List<N>() { recursiveJump });
-            }
         }
 
         /// <summary>

--- a/TypeCobol.Analysis/Resource.Designer.cs
+++ b/TypeCobol.Analysis/Resource.Designer.cs
@@ -19,7 +19,7 @@ namespace TypeCobol.Analysis {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resource {
@@ -84,15 +84,6 @@ namespace TypeCobol.Analysis {
         internal static string BasicBlockGroupGoesBeyondTheLimit {
             get {
                 return ResourceManager.GetString("BasicBlockGroupGoesBeyondTheLimit", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A recursive loop has been encountered while analyzing &apos;PERFORM {0}&apos;, recursive instruction is &apos;{1}&apos;..
-        /// </summary>
-        internal static string RecursiveBlockOnPerformProcedure {
-            get {
-                return ResourceManager.GetString("RecursiveBlockOnPerformProcedure", resourceCulture);
             }
         }
     }

--- a/TypeCobol.Analysis/Resource.resx
+++ b/TypeCobol.Analysis/Resource.resx
@@ -126,7 +126,4 @@
   <data name="BasicBlockGroupGoesBeyondTheLimit" xml:space="preserve">
     <value>Statement '{0}' located at line {1}, column {2} prevents this PERFORM statement to reach its exit.</value>
   </data>
-  <data name="RecursiveBlockOnPerformProcedure" xml:space="preserve">
-    <value>A recursive loop has been encountered while analyzing 'PERFORM {0}', recursive instruction is '{1}'.</value>
-  </data>
 </root>

--- a/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
+++ b/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
@@ -81,11 +81,6 @@ namespace TypeCobol.Compiler.Directives
         /// </summary>
         public TypeCobolCheckOption CheckPerformThruOrder { get; set; }
 
-        /// <summary>
-        /// Check that perform statement are not recursive, requires CFG.
-        /// </summary>
-        public TypeCobolCheckOption CheckRecursivePerforms { get; set; }
-
         public TypeCobolOptions(TypeCobolConfiguration config)
         {
             HaltOnMissingCopy = config.HaltOnMissingCopyFilePath != null;
@@ -104,7 +99,6 @@ namespace TypeCobol.Compiler.Directives
             CheckEndProgram = config.CheckEndProgram;
             CheckPerformPrematureExits = config.CheckPerformPrematureExits;
             CheckPerformThruOrder = config.CheckPerformThruOrder;
-            CheckRecursivePerforms = config.CheckRecursivePerforms;
         }
 
         public TypeCobolOptions()

--- a/TypeCobol/Tools/Options-Config/TypeCobolConfiguration.cs
+++ b/TypeCobol/Tools/Options-Config/TypeCobolConfiguration.cs
@@ -48,7 +48,6 @@ namespace TypeCobol.Tools.Options_Config
         public TypeCobolCheckOption CheckEndProgram { get; set; }
         public TypeCobolCheckOption CheckPerformPrematureExits { get; set; }
         public TypeCobolCheckOption CheckPerformThruOrder { get; set; }
-        public TypeCobolCheckOption CheckRecursivePerforms { get; set; }
 
         public List<string> Copies = new List<string>();
         public List<string> Dependencies = new List<string>();
@@ -246,7 +245,6 @@ namespace TypeCobol.Tools.Options_Config
         TypeCobolCheckOption CheckEndProgram { get; set; }
         TypeCobolCheckOption CheckPerformPrematureExits { get; set; }
         TypeCobolCheckOption CheckPerformThruOrder { get; set; }
-        TypeCobolCheckOption CheckRecursivePerforms { get; set; }
     }
 
     public static class TypeCobolCheckOptionsInitializer
@@ -257,7 +255,6 @@ namespace TypeCobol.Tools.Options_Config
             checkOptions.CheckEndProgram = new TypeCobolCheckOption(Severity.Error);
             checkOptions.CheckPerformPrematureExits = new TypeCobolCheckOption(Severity.Warning);
             checkOptions.CheckPerformThruOrder = new TypeCobolCheckOption(Severity.Warning);
-            checkOptions.CheckRecursivePerforms = new TypeCobolCheckOption(Severity.Warning);
         }
     }
 
@@ -293,7 +290,6 @@ namespace TypeCobol.Tools.Options_Config
                 { "diag.cep|diagnostic.checkEndProgram=", "Indicate level of check end program: warning, error, info, ignore.", v => typeCobolConfig.CheckEndProgram = TypeCobolCheckOption.Parse(v) },
                 { "diag.cppe|diagnostic.checkPerformPrematureExits=", "Indicate level of check perform premature exits: warning, error, info, ignore.", v => typeCobolConfig.CheckPerformPrematureExits = TypeCobolCheckOption.Parse(v) },
                 { "diag.cpto|diagnostic.checkPerformThruOrder=", "Indicate level of check perform thru procedure order: warning, error, info, ignore.", v => typeCobolConfig.CheckPerformThruOrder = TypeCobolCheckOption.Parse(v) },
-                { "diag.crp|diagnostic.checkRecursivePerforms=", "Indicate level of check recursive performs: warning, error, info, ignore.", v => typeCobolConfig.CheckRecursivePerforms = TypeCobolCheckOption.Parse(v) },
                 { "log|logfilepath=", "{PATH} to TypeCobol.CLI.log log file", v => typeCobolConfig.LogFile = Path.Combine(v, TypeCobolConfiguration.DefaultLogFileName)},
                 { "cfg|cfgbuild=", "CFG build option, recognized values are: None/0, Standard/1, Extended/2, WithDfa/3.", v => typeCobolConfig.RawCfgBuildingMode = v },
                 { "cob|cobol", "Indicate that it's a pure Cobol85 input file.", v => typeCobolConfig.IsCobolLanguage = true },


### PR DESCRIPTION
This is a complement to #2099.

As the PERFORM recursivity check will be moved to our private code-quality analyzer, this PR removes the previous implementation from the parser.
