### PR TITLE
1874 new diag conf section in nested program

### DIFF
--- a/TypeCobol.Test/Parser/Programs/Cobol85/NoConfSectionInNestedPrg.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/NoConfSectionInNestedPrg.rdz.cbl
@@ -1,0 +1,29 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Main.
+       ENVIRONMENT DIVISION.
+      *Ok
+       CONFIGURATION SECTION.
+       DATA DIVISION.
+       PROCEDURE DIVISION.
+
+           goback.
+
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Nested.
+       ENVIRONMENT DIVISION.
+      *Ko CONFIGURATION SECTION is not allowed in nested programs
+       CONFIGURATION SECTION.
+       PROCEDURE DIVISION.
+           goback.
+       END PROGRAM Nested.
+
+       END PROGRAM Main.
+       
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Stacked.
+       ENVIRONMENT DIVISION.
+      *Ok for stacked
+       CONFIGURATION SECTION.
+       PROCEDURE DIVISION.
+           goback.
+       END PROGRAM Stacked.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/NoConfSectionInNestedPrg.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/NoConfSectionInNestedPrg.rdzMix.txt
@@ -1,0 +1,30 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Main.
+       ENVIRONMENT DIVISION.
+      *Ok
+       CONFIGURATION SECTION.
+       DATA DIVISION.
+       PROCEDURE DIVISION.
+
+           goback.
+
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Nested.
+       ENVIRONMENT DIVISION.
+      *Ko CONFIGURATION SECTION is not allowed in nested programs
+Line 15[8,29] <27, Error, Syntax> - Syntax error : A Nested Program cannot have a CONFIGURATION SECTION.
+       CONFIGURATION SECTION.
+       PROCEDURE DIVISION.
+           goback.
+       END PROGRAM Nested.
+
+       END PROGRAM Main.
+       
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Stacked.
+       ENVIRONMENT DIVISION.
+      *Ok for stacked
+       CONFIGURATION SECTION.
+       PROCEDURE DIVISION.
+           goback.
+       END PROGRAM Stacked.

--- a/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
@@ -532,20 +532,20 @@ namespace TypeCobol.Compiler.Diagnostics
             CheckEndProgram(program);
             
             FormalizedCommentsChecker.CheckProgramComments(program);
-            if (program.IsNested)
-            {  // Check that a Nested Program cannot have a CONFIGURATION SECTION
-                IList<EnvironmentDivision> envDiv = program.GetChildren<EnvironmentDivision>();
-                if (envDiv.Count > 0)
-                {
-                    IList<ConfigurationSection> confSection = envDiv[0].GetChildren<ConfigurationSection>();
-                    if (confSection.Count > 0)
-                    {
-                        DiagnosticUtils.AddError(confSection[0], "A Nested Program cannot have a CONFIGURATION SECTION.");
-                    }
-                }
+          
+            return true;
+        }
+
+        public override bool Visit(ConfigurationSection configurationSection)
+        {
+            Program program = configurationSection.GetProgramNode();
+            if (program != null && program.IsNested)
+            {
+                DiagnosticUtils.AddError(configurationSection, "A Nested Program cannot have a CONFIGURATION SECTION.");
             }
             return true;
         }
+
 
         public override bool VisitVariableWriter(VariableWriter variableWriter)
         {

--- a/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
@@ -532,6 +532,18 @@ namespace TypeCobol.Compiler.Diagnostics
             CheckEndProgram(program);
             
             FormalizedCommentsChecker.CheckProgramComments(program);
+            if (program.IsNested)
+            {  // Check that a Nested Program cannot have a CONFIGURATION SECTION
+                IList<EnvironmentDivision> envDiv = program.GetChildren<EnvironmentDivision>();
+                if (envDiv.Count > 0)
+                {
+                    IList<ConfigurationSection> confSection = envDiv[0].GetChildren<ConfigurationSection>();
+                    if (confSection.Count > 0)
+                    {
+                        DiagnosticUtils.AddError(confSection[0], "A Nested Program cannot have a CONFIGURATION SECTION.");
+                    }
+                }
+            }
             return true;
         }
 


### PR DESCRIPTION
**What have been done**

A diagnostic is added to report an error in case presence of a CONFIGURATION SECTION in a nested program.
A test case is also adedd.
