### PR TITLE
WI #1907 Disable REMARKS directive parsing

### DIFF
--- a/CLI/test/ressources/CopyInsideTypeDefInsideDependency_EI/output_expected/CopyInsideTypeDefInsideDependency.rdz.tcbl
+++ b/CLI/test/ressources/CopyInsideTypeDefInsideDependency_EI/output_expected/CopyInsideTypeDefInsideDependency.rdz.tcbl
@@ -91,11 +91,6 @@
       
        IDENTIFICATION DIVISION.
        PROGRAM-ID. PGMSTK1.
-      *REMARKS. COPY=(
-      *        YPRTD20
-      *        YCONVEA
-      *        ).
-                                                            
       
        DATA DIVISION.
        Working-STORAGE SECTION.

--- a/CLI/test/ressources/typedefCopy/output_expected/Client.rdz.tcbl
+++ b/CLI/test/ressources/typedefCopy/output_expected/Client.rdz.tcbl
@@ -1,6 +1,10 @@
-      *TypeCobol_Version:[[ParserVersion]]
+      *TypeCobol_Version:v0.0.0-local
        IDENTIFICATION DIVISION.
        PROGRAM-ID. Client.
+      *REMARKS. COPY=(
+      *        TESTCPY
+      *        ).
+                                                           
        data division.
        working-storage section.
       *01 MyType typedef strict public.

--- a/Codegen/src/Actions/Remarks.cs
+++ b/Codegen/src/Actions/Remarks.cs
@@ -43,8 +43,8 @@ namespace TypeCobol.Codegen.Actions
         public IList<Action> Execute()
         {
 #if EUROINFO_RULES
-            if (((Program) Source).IsNested)
-                return null; //We dont have to care about nested program. It prevents from generating REMARKS directive multiple times
+            if (!((Program) Source).IsMainProgram)
+                return null; //We don't have to care about nested/stacked programs. It prevents from generating REMARKS directive multiple times
 
             //Get tokensLine
             var tokensLines = (CompilationDocument.CobolTextLines as IReadOnlyList<Compiler.Scanner.TokensLine>);

--- a/Codegen/test/CodegenTestUtils.cs
+++ b/Codegen/test/CodegenTestUtils.cs
@@ -22,10 +22,9 @@ namespace TypeCobol.Codegen {
         /// for now and we don't have specifications for FreeFormat.
         /// </summary>
         /// <param name="path"></param>
-        /// <param name="autoRemarks"></param>
         /// <param name="typeCobolVersion"></param>
         /// <param name="copies"></param>
-        public static void ParseGenerateCompare(string path, bool autoRemarks = false, string typeCobolVersion = null, IList<string> copies = null
+        public static void ParseGenerateCompare(string path, string typeCobolVersion = null, IList<string> copies = null
 #if EUROINFO_RULES
             , string cpyCopyNamesMapFilePath = null
 #endif
@@ -33,7 +32,6 @@ namespace TypeCobol.Codegen {
         {
             var options = new TypeCobolOptions();
 #if EUROINFO_RULES
-            options.AutoRemarksEnable = autoRemarks;
             if (cpyCopyNamesMapFilePath != null) options.CpyCopyNameMap = new CopyNameMapFile(cpyCopyNamesMapFilePath);
 #endif
             ParseGenerateCompare(path, options, DocumentFormat.RDZReferenceFormat, typeCobolVersion, copies, null);
@@ -87,16 +85,12 @@ namespace TypeCobol.Codegen {
         /// for now and we don't have specifications for FreeFormat.
         /// </summary>
         /// <param name="path"></param>
-        /// <param name="autoRemarks"></param>
         /// <param name="typeCobolVersion"></param>
-        /// <param name="copies"></param>        
-        public static void ParseGenerateCompareWithLineMapping(string path, bool autoRemarks = false, string typeCobolVersion = null, IList<string> copies = null)
+        /// <param name="copies"></param>
+        /// <remarks>CpyCopyNameMap option is not supported yet in this method</remarks>
+        public static void ParseGenerateCompareWithLineMapping(string path, string typeCobolVersion = null, IList<string> copies = null)
         {
             var options = new TypeCobolOptions();
-#if EUROINFO_RULES
-            options.AutoRemarksEnable = autoRemarks;
-            //No CPY copy list support yet
-#endif
             ParseGenerateCompare(path, options, DocumentFormat.RDZReferenceFormat, typeCobolVersion, copies, new MemoryStream());
         }
 

--- a/Codegen/test/TestTypeCobolCodegen.cs
+++ b/Codegen/test/TestTypeCobolCodegen.cs
@@ -215,7 +215,7 @@ namespace TypeCobol.Codegen {
         {
             string dir = System.IO.Directory.GetCurrentDirectory();
             string copies = Path.Combine(dir, "resources", "input", "TypeCobol", "CopyReplace4Colon");
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CopyReplace4Colon", "CopyReplace4Colon") + ".rdz.cbl", false,
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CopyReplace4Colon", "CopyReplace4Colon") + ".rdz.cbl",
                 null, new List<string>() { copies });
         }
 
@@ -555,7 +555,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void TypeCobolVersionTest()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "TCOBVersion") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "TCOBVersion") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
 	    [TestMethod]
@@ -563,7 +563,7 @@ namespace TypeCobol.Codegen {
 	    [TestProperty("Time", "fast")]
 	    public void ProcedureSubscriptTest()
 	    {
-	        CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "ProcedureSubscript") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+	        CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "ProcedureSubscript") + ".rdz.tcbl", "TestTypeCobolVersion");
 	    }
 
 	    [TestMethod]
@@ -571,7 +571,7 @@ namespace TypeCobol.Codegen {
 	    [TestProperty("Time", "fast")]
 	    public void PointersTest()
 	    {
-	        CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Pointers") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+	        CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Pointers") + ".rdz.tcbl", "TestTypeCobolVersion");
 	    }
 
         [TestMethod]
@@ -579,7 +579,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void ProgramParameterCompUsageTypesTest()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "ProgramParameterCompUsageTypes") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "ProgramParameterCompUsageTypes") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -587,9 +587,9 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void CobolLineSplit_IN_VarTest()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CobolLineSplit_IN_Var") + ".rdz.tcbl", false, "TestTypeCobolVersion");
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CobolLineSplit_IN_Var1") + ".rdz.tcbl", false, "TestTypeCobolVersion");
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CobolLineSplit_IN_Var2") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CobolLineSplit_IN_Var") + ".rdz.tcbl", "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CobolLineSplit_IN_Var1") + ".rdz.tcbl", "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CobolLineSplit_IN_Var2") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -597,7 +597,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void GenQualifiedBoolVarTest()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenQualifiedBoolVar") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenQualifiedBoolVar") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -605,7 +605,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void GenMoveCorrTest()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenMoveCorr") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenMoveCorr") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -613,7 +613,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void GenCorrStatementsTest()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenCorrStatements") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenCorrStatements") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -621,7 +621,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void GenContinueInsideTypdefTest()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenContinueInsideTypdef") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenContinueInsideTypdef") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
 
@@ -630,7 +630,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void Gen_73_80_RemoveTextTest()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Gen_73_80_RemoveText") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Gen_73_80_RemoveText") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -638,7 +638,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void GenGlobalKeywordTest()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenGlobalKeyword") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenGlobalKeyword") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -646,7 +646,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void SetUnsafeTest()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "SetUnsafe") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "SetUnsafe") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -654,7 +654,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void GenTCobVersionAfterOptionsTest()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenTCobVersionAfterOptions") + ".rdz.cbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "GenTCobVersionAfterOptions") + ".rdz.cbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -662,7 +662,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void CopyReplaceInProcLinkage()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CopyReplaceInProcLinkage") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "CopyReplaceInProcLinkage") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
 	    [TestMethod]
@@ -670,8 +670,8 @@ namespace TypeCobol.Codegen {
 	    [TestProperty("Time", "fast")]
 	    public void MisPlaceCopyInstrWithProcMetaDataTest()
 	    {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "MisPlaceCopyInstrWithProcMetaData") + ".rdz.tcbl", false, "TestTypeCobolVersion");
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "MisPlaceCopyInstrWithProcMetaData2") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "MisPlaceCopyInstrWithProcMetaData") + ".rdz.tcbl", "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "MisPlaceCopyInstrWithProcMetaData2") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
 
@@ -680,7 +680,7 @@ namespace TypeCobol.Codegen {
 	    [TestProperty("Time", "fast")]
 	    public void DeclarativesWithProcedures()
 	    {
-	        CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "DeclarativesWithProcedures") + ".tcbl", false, "TestTypeCobolVersion");
+	        CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "DeclarativesWithProcedures") + ".tcbl", "TestTypeCobolVersion");
 	    }
 
 	    [TestMethod]
@@ -688,7 +688,7 @@ namespace TypeCobol.Codegen {
 	    [TestProperty("Time", "fast")]
 	    public void DeclarativesWithProcedures2()
 	    {
-	        CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "DeclarativesWithProcedures2") + ".tcbl", false, "TestTypeCobolVersion");
+	        CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "DeclarativesWithProcedures2") + ".tcbl", "TestTypeCobolVersion");
 	    }
 
         [TestMethod]
@@ -696,7 +696,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void DeclarativesWithInstructionsWithinTest()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "DeclarativesWithInstructionsWithin") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "DeclarativesWithInstructionsWithin") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -704,7 +704,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void DeclarativesInsideProcedure()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "DeclarativesInsideProcedure") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "DeclarativesInsideProcedure") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
 	    [TestMethod]
@@ -712,7 +712,7 @@ namespace TypeCobol.Codegen {
 	    [TestProperty("Time", "fast")]
 	    public void FormalizedCommentsTest()
 	    {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "FormalizedComments") + ".tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "FormalizedComments") + ".tcbl", "TestTypeCobolVersion");
 	    }
 
 	    [TestMethod]
@@ -720,7 +720,7 @@ namespace TypeCobol.Codegen {
 	    [TestProperty("Time", "fast")]
 	    public void MultilinesCommentsTest()
 	    {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "MultilinesComments") + ".tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "MultilinesComments") + ".tcbl", "TestTypeCobolVersion");
 	    }
 
 	    [TestMethod]
@@ -728,7 +728,7 @@ namespace TypeCobol.Codegen {
 	    [TestProperty("Time", "fast")]
 	    public void MoveUnsafeToQualifiedInsideFunction()
 	    {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "MoveUnsafeToQualifiedInsideFunction") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "MoveUnsafeToQualifiedInsideFunction") + ".rdz.tcbl", "TestTypeCobolVersion");
 	    }
 	    
         [TestMethod]
@@ -738,7 +738,7 @@ namespace TypeCobol.Codegen {
 	    {    
 	        string dir = System.IO.Directory.GetCurrentDirectory();
 	        string copies = Path.Combine(dir, "resources", "input", "TypeCobol", "TypedefCopys");
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "TypedefCopys", "TypedefBodyInsideCopy") + ".rdz.tcbl", false,
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "TypedefCopys", "TypedefBodyInsideCopy") + ".rdz.tcbl",
 	            null, new List<string>() {copies});
 	    }
 
@@ -750,7 +750,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void EvaluateWhenGroupInProc()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "EvaluateWhenGroupInProc") + ".tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "EvaluateWhenGroupInProc") + ".tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -758,7 +758,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void GlobalStorageLineMapping()
         {
-            CodegenTestUtils.ParseGenerateCompareWithLineMapping(Path.Combine("TypeCobol", "Global_Storage", "GlobalStorage") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompareWithLineMapping(Path.Combine("TypeCobol", "Global_Storage", "GlobalStorage") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -766,9 +766,9 @@ namespace TypeCobol.Codegen {
 	    [TestProperty("Time", "fast")]
 	    public void GlobalStorage()
 	    {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Global_Storage", "GlobalStorage") + ".rdz.tcbl", false, "TestTypeCobolVersion");
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Global_Storage", "GlobalStorageWithUsingTypeDef") + ".rdz.tcbl", false, "TestTypeCobolVersion");
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Global_Storage", "CopyConfigSectionOnly") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Global_Storage", "GlobalStorage") + ".rdz.tcbl", "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Global_Storage", "GlobalStorageWithUsingTypeDef") + ".rdz.tcbl", "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Global_Storage", "CopyConfigSectionOnly") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -776,7 +776,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void GlobalStorage_TypedefWithIndexedArray()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Global_Storage", "GlobalStorageWithTypedefAndIndex") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Global_Storage", "GlobalStorageWithTypedefAndIndex") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -784,7 +784,7 @@ namespace TypeCobol.Codegen {
         [TestProperty("Time", "fast")]
         public void GlobalStorageWith_6_73_80()
         {
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Global_Storage", "GlobalStorage2") + ".rdz.tcbl", false, "TestTypeCobolVersion");
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Global_Storage", "GlobalStorage2") + ".rdz.tcbl", "TestTypeCobolVersion");
         }
 
         [TestMethod]
@@ -818,10 +818,10 @@ namespace TypeCobol.Codegen {
         public void RemarksGeneration()
         {
             string cpyCopiesPath = Path.Combine("resources", "input", "TypeCobol", "Remarks", "CpyCopies.lst");
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Remarks", "RemarksLess") + ".rdz.cbl", true, cpyCopyNamesMapFilePath: cpyCopiesPath);
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Remarks", "RemarksPartial") + ".rdz.cbl", true, cpyCopyNamesMapFilePath: cpyCopiesPath);
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Remarks", "RemarksNonUsed") + ".rdz.cbl", true, cpyCopyNamesMapFilePath: cpyCopiesPath);
-            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Remarks", "NestedProgram") + ".rdz.cbl", true, cpyCopyNamesMapFilePath: cpyCopiesPath);
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Remarks", "RemarksLess") + ".rdz.cbl", cpyCopyNamesMapFilePath: cpyCopiesPath);
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Remarks", "RemarksPartial") + ".rdz.cbl", cpyCopyNamesMapFilePath: cpyCopiesPath);
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Remarks", "RemarksNonUsed") + ".rdz.cbl", cpyCopyNamesMapFilePath: cpyCopiesPath);
+            CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "Remarks", "NestedProgram") + ".rdz.cbl", cpyCopyNamesMapFilePath: cpyCopiesPath);
         }
 #endif
     }

--- a/Codegen/test/resources/output/Cobol85/CopyNotExpanded.rdz.cbl
+++ b/Codegen/test/resources/output/Cobol85/CopyNotExpanded.rdz.cbl
@@ -1,6 +1,11 @@
 ﻿000000 IDENTIFICATION DIVISION.
 000000* Test to check if COPY are not expanded when code is generated
 000000 PROGRAM-ID.   CopyNotExpanded.
+      *REMARKS. COPY=(
+      *        CopyData
+      *        CopyProcedure
+      *        ).
+                                                                                                                                             
 000000
 000000 DATA DIVISION.
 000000 WORKING-STORAGE SECTION.

--- a/Codegen/test/resources/output/TypeCobol/Codegen.rdz.cbl
+++ b/Codegen/test/resources/output/TypeCobol/Codegen.rdz.cbl
@@ -1,7 +1,12 @@
       * 1 errors
       * Line 19[43,50] <37, Warning, General> - Warning: "COPY SUPPRESS" should not be used
 000010 IDENTIFICATION DIVISION.                                         000010
-000020 PROGRAM-ID. Codegen.    
+000020 PROGRAM-ID. Codegen. 
+      *REMARKS. COPY=(
+      *        Codegen-FirstCopy
+      *        Codegen-SECONDCOPY
+      *        ).
+                                                                                                               
 000031* If you want to write                                            000031
 000032* a block-commented Haiku                            
       * you'll need three star signs                                    000033

--- a/Codegen/test/resources/output/TypeCobol/CopyReplace4Colon/CopyReplace4Colon.rdz.cbl
+++ b/Codegen/test/resources/output/TypeCobol/CopyReplace4Colon/CopyReplace4Colon.rdz.cbl
@@ -1,5 +1,9 @@
 ﻿       IDENTIFICATION DIVISION.
        PROGRAM-ID. CPYRPL4C.
+      *REMARKS. COPY=(
+      *        YxxxENT
+      *        ).
+                                                             
       
        ENVIRONMENT DIVISION.
        DATA DIVISION.

--- a/Codegen/test/resources/output/TypeCobol/CopyReplaceInProcLinkage.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/CopyReplaceInProcLinkage.rdz.tcbl
@@ -1,6 +1,10 @@
       *TypeCobol_Version:TestTypeCobolVersion
        IDENTIFICATION DIVISION.
        PROGRAM-ID. DVZF0OSM.
+      *REMARKS. COPY=(
+      *        MSVCOUT
+      *        ).
+                                                             
        PROCEDURE DIVISION.
            .
 

--- a/Codegen/test/resources/output/TypeCobol/FunDeclare.rdz.cbl
+++ b/Codegen/test/resources/output/TypeCobol/FunDeclare.rdz.cbl
@@ -1,5 +1,10 @@
        IDENTIFICATION DIVISION.
        PROGRAM-ID. FunDeclare.
+      *REMARKS. COPY=(
+      *        MyDataCopy
+      *        MyProcedureCopy
+      *        ).
+                                                               
        PROCEDURE DIVISION.
 
       *DECLARE FUNCTION DoesNothing PRIVATE.

--- a/Codegen/test/resources/output/TypeCobol/MisPlaceCopyInstrWithProcMetaData.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/MisPlaceCopyInstrWithProcMetaData.rdz.tcbl
@@ -1,6 +1,10 @@
       *TypeCobol_Version:TestTypeCobolVersion
        IDENTIFICATION DIVISION.
        PROGRAM-ID. DVZF0OSM.
+      *REMARKS. COPY=(
+      *        Codegen-SecondCopy
+      *        ).
+                                                             
        data division.
        WORKING-STORAGE SECTION.
        01 TC-DVZF0OS2 pic X(08) value 'DVZF0OS2'.
@@ -80,8 +84,11 @@
 
        ID DIVISION.
        PROGRAM-ID. DVZF0OS2.
-       DATA DIVISION.
+      *REMARKS. COPY=(
+      *        Codegen-SecondCopy
+      *        ).
                                                  
+       DATA DIVISION.
        WORKING-STORAGE SECTION.
        01  TC-DVZF0OS2-FctList-Loaded PIC X(02).
            88 TC-DVZF0OS2-FctList-IsLoaded      VALUE 'OK'.
@@ -94,7 +101,6 @@
            05 TC-DVZF0OS2-bdb3e928-Idt   PIC X(08) VALUE 'bdb3e928'.
            05 TC-DVZF0OS2-bdb3e928 PROCEDURE-POINTER.
 
-       
        LINKAGE SECTION.
        01 PntTab-Pnt POINTER.
 

--- a/Codegen/test/resources/output/TypeCobol/MisPlaceCopyInstrWithProcMetaData.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/MisPlaceCopyInstrWithProcMetaData.rdz.tcbl
@@ -84,11 +84,8 @@
 
        ID DIVISION.
        PROGRAM-ID. DVZF0OS2.
-      *REMARKS. COPY=(
-      *        Codegen-SecondCopy
-      *        ).
-                                                 
        DATA DIVISION.
+                                                 
        WORKING-STORAGE SECTION.
        01  TC-DVZF0OS2-FctList-Loaded PIC X(02).
            88 TC-DVZF0OS2-FctList-IsLoaded      VALUE 'OK'.
@@ -101,6 +98,7 @@
            05 TC-DVZF0OS2-bdb3e928-Idt   PIC X(08) VALUE 'bdb3e928'.
            05 TC-DVZF0OS2-bdb3e928 PROCEDURE-POINTER.
 
+       
        LINKAGE SECTION.
        01 PntTab-Pnt POINTER.
 

--- a/Codegen/test/resources/output/TypeCobol/MisPlaceCopyInstrWithProcMetaData2.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/MisPlaceCopyInstrWithProcMetaData2.rdz.tcbl
@@ -1,6 +1,10 @@
       *TypeCobol_Version:TestTypeCobolVersion
        IDENTIFICATION DIVISION.
        PROGRAM-ID. DVZF0OSM.
+      *REMARKS. COPY=(
+      *        Codegen-SecondCopy
+      *        ).
+                                                             
        data division.
        WORKING-STORAGE SECTION.
        01 TC-DVZF0OS2 pic X(08) value 'DVZF0OS2'.
@@ -80,6 +84,10 @@
 
        ID DIVISION.
        PROGRAM-ID. DVZF0OS2.
+      *REMARKS. COPY=(
+      *        Codegen-SecondCopy
+      *        ).
+                                                 
        data division.
        working-storage section.
        01 var1 .

--- a/Codegen/test/resources/output/TypeCobol/MisPlaceCopyInstrWithProcMetaData2.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/MisPlaceCopyInstrWithProcMetaData2.rdz.tcbl
@@ -84,10 +84,6 @@
 
        ID DIVISION.
        PROGRAM-ID. DVZF0OS2.
-      *REMARKS. COPY=(
-      *        Codegen-SecondCopy
-      *        ).
-                                                 
        data division.
        working-storage section.
        01 var1 .

--- a/Codegen/test/resources/output/TypeCobol/TypedefCopys/TypedefBodyInsideCopy.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/TypedefCopys/TypedefBodyInsideCopy.rdz.tcbl
@@ -1,5 +1,10 @@
 ﻿       identification division.
        program-id. MyPGM.
+      *REMARKS. COPY=(
+      *        MyCopyA
+      *        MyCopyB
+      *        ).
+                                                          
        environment division.
        configuration section.
        source-computer. ibm-370

--- a/Codegen/test/resources/output/TypeCobol/VariableTypeExternal.rdz.tcbl
+++ b/Codegen/test/resources/output/TypeCobol/VariableTypeExternal.rdz.tcbl
@@ -2,6 +2,10 @@
       * Line 13[43,50] <37, Warning, General> - Warning: "COPY SUPPRESS" should not be used
        IDENTIFICATION DIVISION.
        PROGRAM-ID. VARTYPEXT.
+      *REMARKS. COPY=(
+      *        MyDataCopy
+      *        ).
+                                                              
        DATA DIVISION.
        WORKING-STORAGE SECTION.
       *Données immuables et stable pendant toute

--- a/TypeCobol.Test/HighLevelAPI/TestLTNV.cs
+++ b/TypeCobol.Test/HighLevelAPI/TestLTNV.cs
@@ -29,7 +29,7 @@ namespace TypeCobol.Test.HighLevelAPI {
 
             string cpyCopyNamesFile = Path.Combine(Root, "LTNV", "FO200001.copylist");
 
-            ParseAndTestGetLTNVCopys(rootPath, "FO200001.rdz.cbl", true, cpyCopyNamesFile, errors, new List<string> {"FO200001"},
+            ParseAndTestGetLTNVCopys(rootPath, "FO200001.rdz.cbl", cpyCopyNamesFile, errors, new List<string> {"FO200001"},
                 new Dictionary<string, string>()
                 {
                     {"YFO2FAW", "YFO2FAL"},
@@ -40,7 +40,7 @@ namespace TypeCobol.Test.HighLevelAPI {
 
             cpyCopyNamesFile = Path.Combine(Root, "LTNV", "FOOABCDE.copylist");
 
-            ParseAndTestGetLTNVCopys(rootPath, "FOOABCDE.rdz.cbl", true, cpyCopyNamesFile, errors, new List<string> { "FOOABCDE" },
+            ParseAndTestGetLTNVCopys(rootPath, "FOOABCDE.rdz.cbl", cpyCopyNamesFile, errors, new List<string> { "FOOABCDE" },
                 new Dictionary<string, string>()
                 {
                     { "YFOOFAW", "FOOFAW" },
@@ -62,12 +62,12 @@ namespace TypeCobol.Test.HighLevelAPI {
             }
         }
 
-        private static void ParseAndTestGetLTNVCopys(string rootPath, string path, bool autoRemarks, string cpyCopyNamesFile, List < Exception> errors, IList<string> programsName ,params IDictionary<string, string>[] expected)
+        private static void ParseAndTestGetLTNVCopys(string rootPath, string path, string cpyCopyNamesFile, List < Exception> errors, IList<string> programsName ,params IDictionary<string, string>[] expected)
         {
             Assert.IsTrue(programsName.Count == expected.Length);//check if parameter of this method are coherent
             try
             {
-                var result = ParseAndGetLTNVCopys(rootPath, path, autoRemarks, cpyCopyNamesFile);
+                var result = ParseAndGetLTNVCopys(rootPath, path, cpyCopyNamesFile);
                 Assert.IsTrue(result.Count == expected.Length);
 
                 var actualPgmNames = result.Keys.ToList();
@@ -90,9 +90,9 @@ namespace TypeCobol.Test.HighLevelAPI {
             }
         }
 
-        private static IDictionary<Program, IDictionary<string, string>> ParseAndGetLTNVCopys(string rootPath, string path, bool autoRemarks = false, string cpyCopyNamesFile = null)
+        private static IDictionary<Program, IDictionary<string, string>> ParseAndGetLTNVCopys(string rootPath, string path, string cpyCopyNamesFile = null)
         {
-            var options = new TypeCobolOptions() { AutoRemarksEnable = autoRemarks };
+            var options = new TypeCobolOptions();
             if (cpyCopyNamesFile != null)
             {
                 options.CpyCopyNameMap = new CopyNameMapFile(cpyCopyNamesFile);

--- a/TypeCobol.Test/Parser/Performance/Performance.cs
+++ b/TypeCobol.Test/Parser/Performance/Performance.cs
@@ -400,14 +400,7 @@ namespace TypeCobol.Test.Parser.Performance
             stats.IterationNumber = 20;
             //Warmup before measurement
             var documentWarmup = new TypeCobol.Parser();
-            var options = new TypeCobolOptions
-            {
-                ExecToStep = ExecutionStep.CrossCheck,
-#if EUROINFO_RULES
-                AutoRemarksEnable = true
-#endif
-            };
-
+            var options = new TypeCobolOptions { ExecToStep = ExecutionStep.CrossCheck };
 
             //Warmup
             documentWarmup = ParseDocument(fullPath, options, format, copiesFolder);

--- a/TypeCobol.Test/Report/ReportTestHelper.cs
+++ b/TypeCobol.Test/Report/ReportTestHelper.cs
@@ -49,9 +49,7 @@ namespace TypeCobol.Test.Report
             DocumentFormat format = DocumentFormat.RDZReferenceFormat;
             var parser = new TypeCobol.Parser();
             var typeCobolOption = new TypeCobolOptions { ExecToStep = ExecutionStep.CrossCheck };
-#if EUROINFO_RULES
-                typeCobolOption.AutoRemarksEnable = false;
-#endif
+            
             string copyFolder = Path.Combine(Directory.GetCurrentDirectory(), ROOT_COPY);
             parser.Init(input, isCopy, typeCobolOption, format, new List<string>() { copyFolder }, analyzerProvider);
             parser.Parse(input);

--- a/TypeCobol.Test/TestCollection.cs
+++ b/TypeCobol.Test/TestCollection.cs
@@ -246,7 +246,7 @@ namespace TypeCobol.Test {
 
             var folderTester = new FolderTester(tempRoot, tempRoot, tempRoot, extensions);
 
-            folderTester.Test(false, false, true);
+            folderTester.Test();
 
             nbOfTests += folderTester.GetTestCount();
             Console.Write("\n");

--- a/TypeCobol.Test/Utils/Comparator.cs
+++ b/TypeCobol.Test/Utils/Comparator.cs
@@ -191,7 +191,7 @@ namespace TypeCobol.Test.Utils
             return _nbOfTests;
         }
 
-		public void Test(bool debug = false, bool json = false, bool autoRemarks = false, bool isCobolLanguage = false) {
+		public void Test(bool debug = false, bool json = false, bool isCobolLanguage = false) {
 			var errors = new StringBuilder();
 			foreach (var samplePath in samples) {
 				IList<FilesComparator> comparators = GetComparators(_sampleRoot, _resultsRoot, samplePath, debug);
@@ -203,9 +203,6 @@ namespace TypeCobol.Test.Utils
                 foreach (var comparator in comparators) {
                     Console.WriteLine(comparator.paths.Result + " checked with " + comparator.GetType().Name);
                     var unit = new TestUnit(comparator, _copyExtensions);
-#if EUROINFO_RULES
-                    unit.Compiler.CompilerOptions.AutoRemarksEnable = autoRemarks;
-#endif
                     unit.Compiler.CompilerOptions.IsCobolLanguage = isCobolLanguage;
                     unit.Parse();
 				    if (unit.Observer.HasErrors)

--- a/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
+++ b/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
@@ -12,7 +12,6 @@ namespace TypeCobol.Compiler.Directives
     {
         // insert options specific to TypeCobol here ...
 #if EUROINFO_RULES
-        public bool AutoRemarksEnable { get; set; }
         /// <summary>
         /// Path to generate collected used copy names
         /// </summary>
@@ -94,7 +93,6 @@ namespace TypeCobol.Compiler.Directives
             UseEuroInformationLegacyReplacingSyntax = config.UseEuroInformationLegacyReplacingSyntax;
 
 #if EUROINFO_RULES
-            AutoRemarksEnable = config.AutoRemarks;
             CpyCopyNameMap = config.CpyCopyNameMap;
             ReportUsedCopyNamesPath = config.ReportUsedCopyNamesPath;
 #endif

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -8,7 +8,6 @@ using JetBrains.Annotations;
 using TypeCobol.Compiler.Concurrency;
 using TypeCobol.Compiler.Diagnostics;
 using TypeCobol.Compiler.Directives;
-using TypeCobol.Compiler.File;
 using TypeCobol.Compiler.Text;
 
 namespace TypeCobol.Compiler.Scanner
@@ -55,7 +54,7 @@ namespace TypeCobol.Compiler.Scanner
             int lastIndex = textLine.Source.EndIndex;
 
 #if EUROINFO_RULES
-            if (compilerOptions.UseEuroInformationLegacyReplacingSyntax)
+            if (compilerOptions.UseEuroInformationLegacyReplacingSyntax && !compilerOptions.IsCobolLanguage)
             {
                 if (tokensLine.ScanState.LeavingRemarksDirective) //If last scanned line was the end of a remarksDirective then mark scanstate as outside of remarksDirective for this new line
                     tokensLine.ScanState.InsideRemarksDirective = tokensLine.ScanState.LeavingRemarksDirective = false;

--- a/TypeCobol/Tools/Options-Config/TypeCobolConfiguration.cs
+++ b/TypeCobol/Tools/Options-Config/TypeCobolConfiguration.cs
@@ -18,7 +18,6 @@ namespace TypeCobol.Tools.Options_Config
     public class TypeCobolConfiguration : ITypeCobolCheckOptions
     {
         public DocumentFormat Format;
-        public bool AutoRemarks;
         public string HaltOnMissingCopyFilePath;
         public string ExpandingCopyFilePath;
         public string ExtractedCopiesFilePath;
@@ -269,7 +268,7 @@ namespace TypeCobol.Tools.Options_Config
                 { "o|output=","{PATH} to an output file where to generate code. This option can be specified more than once.", v => typeCobolConfig.OutputFiles.Add(v) },
                 { "d|diagnostics=", "{PATH} to the error diagnostics file.", v => typeCobolConfig.ErrorFile = v },
                 { "s|skeletons=", "{PATH} to the skeletons file. DEPRECATED : generation using dynamic skeleton is no longer supported.", v => {}},
-                { "a|autoremarks", "Enable automatic remarks creation while parsing and generating Cobol.", v => typeCobolConfig.AutoRemarks = true },
+                { "a|autoremarks", "Enable automatic remarks creation while parsing and generating Cobol. DEPRECATED, this option is always activated.", v => {}},
                 { "hc|haltonmissingcopy=", "HaltOnMissingCopy will generate a file to list all the absent copies.", v => typeCobolConfig.HaltOnMissingCopyFilePath = v },
                 { "ets|exectostep=", "ExecToStep will execute TypeCobol Compiler until the included given step (Scanner/0, Preprocessor/1, SyntaxCheck/2, SemanticCheck/3, CrossCheck/4, QualityCheck/5, Generate/6).", v => typeCobolConfig.RawExecToStep = v},
                 { "e|encoding=", "{ENCODING} of the file(s) to parse. It can be one of \"rdz\"(this is the default), \"zos\", or \"utf8\". "+"If this option is not present, the parser will attempt to guess the {ENCODING} automatically.",


### PR DESCRIPTION
This PR addresses:
- #2127
- #2126
- #2124
- #1639
- #1103

It is also an answer to #1907 however parsing of `REMARKS` directive could not be fully removed because it is required for Codegen when generating the clause into target Cobol85 source file.

**Changes:**
- `REMARKS` comments are parsed only in TypeCobol mode (meaning `IsCobolLanguage == false`)
- `AutoRemarks` option has been removed. When using Codegen, `REMARKS` clause is always generated using data from actual `COPY` clauses found in source
- `REMARKS` are not generated anymore for stacked programs
