### PR TITLE
WI #2163 Fix NullReferenceException on invalid condition expressions

### DIFF
--- a/TypeCobol.Test/Parser/CodeElements/IFInvalidConditions.cbl
+++ b/TypeCobol.Test/Parser/CodeElements/IFInvalidConditions.cbl
@@ -1,0 +1,3 @@
+*Issue #2163, would previously throw NullReferenceException
+IF (Var1 NOT SPACE) DISPLAY 'hello' END-IF.
+IF (Var1 NOT SPACE OR LOW-VALUE) DISPLAY 'hello' END-IF.

--- a/TypeCobol.Test/Parser/CodeElements/IFInvalidConditions.txt
+++ b/TypeCobol.Test/Parser/CodeElements/IFInvalidConditions.txt
@@ -1,0 +1,22 @@
+﻿--- Diagnostics ---
+Line 2[10,12] <27, Error, Syntax> - Syntax error : no viable alternative at input 'Var1 ... NOT' RuleStack=codeElement>ifStatement>conditionalExpression>conditionalExpression>conditionNameConditionOrSwitchStatusCondition>conditionReference>qualifiedConditionName,  OffendingSymbol=[10,12:NOT]<NOT>
+Line 3[10,12] <27, Error, Syntax> - Syntax error : no viable alternative at input 'Var1 ... NOT' RuleStack=codeElement>ifStatement>conditionalExpression>conditionalExpression>conditionNameConditionOrSwitchStatusCondition>conditionReference>qualifiedConditionName,  OffendingSymbol=[10,12:NOT]<NOT>
+--- Code Elements ---
+[[IfStatement]] [1,2:IF]<IF> --> [11,10:<missing RightParenthesisSeparator>]<RightParenthesisSeparator>
+
+[[DisplayStatement]] [21,27:DISPLAY]<DISPLAY> --> [29,35:'hello']<AlphanumericLiteral>(',Y,Y){hello}
+- variables = 'hello'
+
+[[IfStatementEnd]] [37,42:END-IF]<END_IF> --> [37,42:END-IF]<END_IF>
+
+[[SentenceEnd]] [43,43+:.]<PeriodSeparator> --> [43,43+:.]<PeriodSeparator>
+
+[[IfStatement]] [1,2:IF]<IF> --> [11,10:<missing RightParenthesisSeparator>]<RightParenthesisSeparator>
+
+[[DisplayStatement]] [34,40:DISPLAY]<DISPLAY> --> [42,48:'hello']<AlphanumericLiteral>(',Y,Y){hello}
+- variables = 'hello'
+
+[[IfStatementEnd]] [50,55:END-IF]<END_IF> --> [50,55:END-IF]<END_IF>
+
+[[SentenceEnd]] [56,56+:.]<PeriodSeparator> --> [56,56+:.]<PeriodSeparator>
+

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolWordsBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolWordsBuilder.cs
@@ -925,6 +925,7 @@ namespace TypeCobol.Compiler.Parser
             var c = context.cobolQualifiedConditionName();
             if (c != null) return CreateQualifiedConditionName(c.conditionNameReferenceOrConditionForUPSISwitchNameReference(), c.dataNameReferenceOrFileNameReferenceOrMnemonicForUPSISwitchNameReference());
             var tc = context.tcQualifiedConditionName();
+            if (tc == null) return null;
             var tail = tc.dataNameReferenceOrFileNameReferenceOrMnemonicForUPSISwitchNameReference();
             Array.Reverse(tail);
             return CreateQualifiedConditionName(tc.conditionNameReferenceOrConditionForUPSISwitchNameReference(), tail, false);


### PR DESCRIPTION
Fixes #2163.

Both syntax are invalid according to the IBM compiler, so our parser should reject them as well.
The exception has been fixed by checking for null and returning a null `SymbolReference`. Although not checked in every usages the property storing the SymbolReference is already marked as `[CanBeNull]`.
