### PR TITLE
WI #2165 Allow parentheses around identifers in conditions

### DIFF
--- a/TypeCobol.Test/Parser/CodeElements/IF.cbl
+++ b/TypeCobol.Test/Parser/CodeElements/IF.cbl
@@ -202,3 +202,13 @@ IF ( a OF b ( x OF y ) = 'OK'  ) THEN CONTINUE END-IF.
 SPECIAL-NAMES. DECIMAL-POINT IS COMMA.
 IF x > 100,00 CONTINUE END-IF.
 IF mytable(1, x) > 42 CONTINUE END-IF.
+
+* With optional parentheses around identifiers
+* class condition
+if (Var1) is numeric display "numeric" end-if.
+* condition-name or switch status condition
+if (test1) display "test1" end-if.
+* relation condition
+if (var1) is greater than 1 display "> 1" end-if.
+* sign condition
+if (Var1) is positive display "positive" end-if.

--- a/TypeCobol.Test/Parser/CodeElements/IF.txt
+++ b/TypeCobol.Test/Parser/CodeElements/IF.txt
@@ -645,3 +645,39 @@
 
 [[SentenceEnd]] [38,38+:.]<PeriodSeparator> --> [38,38+:.]<PeriodSeparator>
 
+[[IfStatement]] [1,2:if]<IF> --> [14,20:numeric]<NUMERIC>
+
+[[DisplayStatement]] [22,28:display]<DISPLAY> --> [30,38:"numeric"]<AlphanumericLiteral>(",Y,Y){numeric}
+- variables = "numeric"
+
+[[IfStatementEnd]] [40,45:end-if]<END_IF> --> [40,45:end-if]<END_IF>
+
+[[SentenceEnd]] [46,46+:.]<PeriodSeparator> --> [46,46+:.]<PeriodSeparator>
+
+[[IfStatement]] [1,2:if]<IF> --> [10,10:)]<RightParenthesisSeparator>
+
+[[DisplayStatement]] [12,18:display]<DISPLAY> --> [20,26:"test1"]<AlphanumericLiteral>(",Y,Y){test1}
+- variables = "test1"
+
+[[IfStatementEnd]] [28,33:end-if]<END_IF> --> [28,33:end-if]<END_IF>
+
+[[SentenceEnd]] [34,34+:.]<PeriodSeparator> --> [34,34+:.]<PeriodSeparator>
+
+[[IfStatement]] [1,2:if]<IF> --> [27,27:1]<IntegerLiteral>{1}
+
+[[DisplayStatement]] [29,35:display]<DISPLAY> --> [37,41:"> 1"]<AlphanumericLiteral>(",Y,Y){> 1}
+- variables = "> 1"
+
+[[IfStatementEnd]] [43,48:end-if]<END_IF> --> [43,48:end-if]<END_IF>
+
+[[SentenceEnd]] [49,49+:.]<PeriodSeparator> --> [49,49+:.]<PeriodSeparator>
+
+[[IfStatement]] [1,2:if]<IF> --> [14,21:positive]<POSITIVE>
+
+[[DisplayStatement]] [23,29:display]<DISPLAY> --> [31,40:"positive"]<AlphanumericLiteral>(",Y,Y){positive}
+- variables = "positive"
+
+[[IfStatementEnd]] [42,47:end-if]<END_IF> --> [42,47:end-if]<END_IF>
+
+[[SentenceEnd]] [48,48+:.]<PeriodSeparator> --> [48,48+:.]<PeriodSeparator>
+

--- a/TypeCobol/AntlrGrammar/CobolExpressions.g4
+++ b/TypeCobol/AntlrGrammar/CobolExpressions.g4
@@ -686,8 +686,11 @@ conditionalExpression:
 
 // ... more details on the evaluation of classCondition p257/258 ...
 
+parenthesedIdentifier:
+	identifier | (LeftParenthesisSeparator identifier RightParenthesisSeparator);
+
 classCondition:
-	identifier IS? NOT? (characterClassNameReference | dataItemContentType);
+	parenthesedIdentifier IS? NOT? (characterClassNameReference | dataItemContentType);
 
 dataItemContentType: 
 	(NUMERIC | ALPHABETIC | ALPHABETIC_LOWER | ALPHABETIC_UPPER | DBCS | KANJI);

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolExpressionsBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolExpressionsBuilder.cs
@@ -675,7 +675,7 @@ namespace TypeCobol.Compiler.Parser
 					ParseTreeUtils.GetFirstToken(context.NOT()));
 			}
 
-			var dataItemStorageArea = CreateIdentifier(context.identifier());
+			var dataItemStorageArea = CreateIdentifier(context.parenthesedIdentifier().identifier());
 
 			ClassCondition classCondition = null;
 			if(context.characterClassNameReference() != null)


### PR DESCRIPTION
Fixes #2165.

IBM compiler allows parentheses around identifiers in all condition types, our parser lacked this feature only in class conditions.