### PR TITLE
WI #1774 Protect against null values coming from StorageArea[Reads/Writes]Symbol dictionaries

### DIFF
--- a/TypeCobol.Analysis/Dfa/DefaultDataFlowGraphBuilder.cs
+++ b/TypeCobol.Analysis/Dfa/DefaultDataFlowGraphBuilder.cs
@@ -3,7 +3,6 @@ using TypeCobol.Analysis.Graph;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.Nodes;
 using TypeCobol.Compiler.Symbols;
-using TypeCobol.Compiler.Types;
 using System.Linq;
 
 namespace TypeCobol.Analysis.Dfa
@@ -20,7 +19,7 @@ namespace TypeCobol.Analysis.Dfa
             {
                 foreach (var p in symbolDictionary)
                 {
-                    result.Add(p.Value);
+                    if (p.Value != null) result.Add(p.Value);
                 }
             }
 

--- a/TypeCobol.Analysis/Dfa/ValueOrigin.cs
+++ b/TypeCobol.Analysis/Dfa/ValueOrigin.cs
@@ -95,7 +95,7 @@ namespace TypeCobol.Analysis.Dfa
                             {
                                 //(2.1.1.1.2) MOVE anotherVar TO var
                                 //Find the corresponding UsePoint and recurse
-                                var sendingVariable = defPoint.Instruction.StorageAreaReadsSymbol[simpleMove.SendingVariable.StorageArea];
+                                var sendingVariable = defPoint.Instruction.StorageAreaReadsSymbol[simpleMove.SendingVariable.StorageArea];//May be null
                                 var defBlockData = dfaBuilder.Cfg.AllBlocks[defPoint.BlockIndex].Data;
                                 for (int i = defBlockData.UseListFirstIndex; i < defBlockData.UseListFirstIndex + defBlockData.UseCount; i++)
                                 {

--- a/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
@@ -968,7 +968,7 @@ namespace TypeCobol.Compiler.Diagnostics
                 //Add DataDefinition found and corresponding VariableSymbol into caches
                 dataDefinitionStorage.Add(storageArea, dataDefinitionFound);
                 var variableSymbol = dataDefinitionFound.SemanticData as VariableSymbol;
-                symbolStorage.Add(storageArea, variableSymbol);//Beware, variableSymbol my be null !
+                symbolStorage.Add(storageArea, variableSymbol); //Beware, as long as SemanticDomain is not complete, variableSymbol may be null !
 
                 //SemanticDomain validation : check that the symbol has been built.
                 if (dataDefinitionFound.ParentTypeDefinition == null)


### PR DESCRIPTION
This is not a fix for #1774 but a safety. The real bug is located in our private analyzer which did not check properly for null values coming from the 2 dictionaries.