### PR TITLE
WI #2294 Avoid exception when parsing a copy containing statements

### DIFF
--- a/TypeCobol.Test/Parser/Copies/ContainingCode.rdz-Nodes.txt
+++ b/TypeCobol.Test/Parser/Copies/ContainingCode.rdz-Nodes.txt
@@ -1,0 +1,7 @@
+Line 1[12,53] <27, Error, Syntax> - Syntax error : extraneous input 'DISPLAY"This statement comes from a copy"' expecting {ProgramIdentification, ProgramEnd, ClassIdentification, ClassEnd, FactoryEnd, ObjectIdentification, ObjectEnd, MethodEnd, ProcedureDivisionHeader, WorkingStorageSectionHeader, LocalStorageSectionHeader, LinkageSectionHeader, FileDescriptionEntry, DataDescriptionEntry, DataRedefinesEntry, DataRenamesEntry, DataConditionEntry, ExecStatement, FunctionDeclarationEnd, GlobalStorageSectionHeader}
+Line 0[0,0] <37, Warning, General> - Warning: This parser does not support COPYs containing COBOL statements.
+--- Nodes ---
+?
+  ContainingCode.rdz
+    data-division
+      working-storage

--- a/TypeCobol.Test/Parser/Copies/ContainingCode.rdz.cpy
+++ b/TypeCobol.Test/Parser/Copies/ContainingCode.rdz.cpy
@@ -1,0 +1,1 @@
+﻿           DISPLAY "This statement comes from a copy"

--- a/TypeCobol/Compiler/CompilationUnit.cs
+++ b/TypeCobol/Compiler/CompilationUnit.cs
@@ -292,13 +292,22 @@ namespace TypeCobol.Compiler
                     //Direct copy parsing : remove redundant root 01 level if any.
                     if (UseDirectCopyParsing)
                     {
-                        var firstDataDefinition = root.MainProgram
+                        var workingStorageSection = root.MainProgram
                             .Children[0]  //Data Division
-                            .Children[0]  //Working-Storage Section
-                            .Children[0]; //First data def
-                        if (firstDataDefinition.ChildrenCount == 0)
+                            .Children[0]; //Working-Storage Section
+                        if (workingStorageSection.ChildrenCount > 0)
                         {
-                            firstDataDefinition.Remove();
+                            var firstDataDefinition = workingStorageSection.Children[0];
+                            if (firstDataDefinition.ChildrenCount == 0)
+                            {
+                                firstDataDefinition.Remove();
+                            }
+                        }
+                        else
+                        {
+                            //Copy contains instructions that could not be parsed as a DataDefinition
+                            var diagnostic = new Diagnostic(MessageCode.Warning, Diagnostic.Position.Default, "This parser does not support COPYs containing COBOL statements.");
+                            newDiagnostics.Add(diagnostic);
                         }
                     }
 

--- a/TypeCobol/Compiler/Parser/CopyParsing/ProgramSkeleton.cs
+++ b/TypeCobol/Compiler/Parser/CopyParsing/ProgramSkeleton.cs
@@ -16,7 +16,7 @@ namespace TypeCobol.Compiler.Parser.CopyParsing
     /// WORKING-STORAGE SECTION.
     /// 01.
     /// --copy content--
-    /// END PROGRAM.
+    /// END PROGRAM copyName.
     ///
     /// The anonymous 01 level allow to include copies without knowing their own starting level,
     /// it is removed at the end of the node phase if it comes out without any child data.


### PR DESCRIPTION
Fixes #2294.