### PR TITLE
WI #2289 Add optional SQL parsing

### DIFF
--- a/Codegen/test/TestTypeCobolCodegen.cs
+++ b/Codegen/test/TestTypeCobolCodegen.cs
@@ -111,14 +111,9 @@ namespace TypeCobol.Codegen {
 		[TestProperty("Time","fast")]
 		public void ParseFunctionsDeclaration() {
             CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "FunDeclare") + ".rdz.cbl");
-#if !SQL_PARSING
             CodegenTestUtils.ParseGenerateCompare(Path.Combine("TypeCobol", "FunDeclareWithExec") + ".rdz.cbl");
-#endif
         }
 
-#if SQL_PARSING
-        [Ignore]
-#endif
         [TestMethod]
         [TestCategory("Codegen")]
         [TestProperty("Time", "fast")]

--- a/TypeCobol.Analysis.Test/CfgDfaBuildingTests.cs
+++ b/TypeCobol.Analysis.Test/CfgDfaBuildingTests.cs
@@ -49,9 +49,6 @@ namespace TypeCobol.Analysis.Test
         /// </summary>
         [TestMethod]
         [TestCategory("CfgDfaBuildTest")]
-#if SQL_PARSING
-        [Ignore]
-#endif
         public void ExecSqlOutsideProc()
         {
             ExecNodeListener listener = null;

--- a/TypeCobol.Test/Parser/CodeElements/EXEC.txt
+++ b/TypeCobol.Test/Parser/CodeElements/EXEC.txt
@@ -1,51 +1,17 @@
 ﻿--- Code Elements ---
 [[ExecStatement]] [1,4:EXEC]<EXEC> --> [6,8:SQL]<ExecTranslatorName>
 
-[[ExecStatementText]] [3,8:UPDATE]<ExecStatementText> --> [3,8:UPDATE]<ExecStatementText>
+[[ExecStatementText]] [3,16:UPDATE TIDCA01]<ExecStatementText> --> [3,16:UPDATE TIDCA01]<ExecStatementText>
 
-[[ExecStatementText]] [10,14:TIDCA]<ExecStatementText> --> [10,14:TIDCA]<ExecStatementText>
+[[ExecStatementText]] [1,12:  SET x = :y]<ExecStatementText> --> [1,12:  SET x = :y]<ExecStatementText>
 
-[[ExecStatementText]] [15,16:01]<ExecStatementText> --> [15,16:01]<ExecStatementText>
+[[ExecStatementText]] [1,16:    WHERE a = :b]<ExecStatementText> --> [1,16:    WHERE a = :b]<ExecStatementText>
 
-[[ExecStatementText]] [3,5:SET]<ExecStatementText> --> [3,5:SET]<ExecStatementText>
+[[ExecStatementText]] [1,16:      AND c = :d]<ExecStatementText> --> [1,16:      AND c = :d]<ExecStatementText>
 
-[[ExecStatementText]] [7,7:x]<ExecStatementText> --> [7,7:x]<ExecStatementText>
+[[ExecStatementText]] [1,16:      AND e = :f]<ExecStatementText> --> [1,16:      AND e = :f]<ExecStatementText>
 
-[[ExecStatementText]] [9,11:= :]<ExecStatementText> --> [9,11:= :]<ExecStatementText>
-
-[[ExecStatementText]] [12,12:y]<ExecStatementText> --> [12,12:y]<ExecStatementText>
-
-[[ExecStatementText]] [5,9:WHERE]<ExecStatementText> --> [5,9:WHERE]<ExecStatementText>
-
-[[ExecStatementText]] [11,11:a]<ExecStatementText> --> [11,11:a]<ExecStatementText>
-
-[[ExecStatementText]] [13,15:= :]<ExecStatementText> --> [13,15:= :]<ExecStatementText>
-
-[[ExecStatementText]] [16,16:b]<ExecStatementText> --> [16,16:b]<ExecStatementText>
-
-[[ExecStatementText]] [7,9:AND]<ExecStatementText> --> [7,9:AND]<ExecStatementText>
-
-[[ExecStatementText]] [11,11:c]<ExecStatementText> --> [11,11:c]<ExecStatementText>
-
-[[ExecStatementText]] [13,15:= :]<ExecStatementText> --> [13,15:= :]<ExecStatementText>
-
-[[ExecStatementText]] [16,16:d]<ExecStatementText> --> [16,16:d]<ExecStatementText>
-
-[[ExecStatementText]] [7,9:AND]<ExecStatementText> --> [7,9:AND]<ExecStatementText>
-
-[[ExecStatementText]] [11,11:e]<ExecStatementText> --> [11,11:e]<ExecStatementText>
-
-[[ExecStatementText]] [13,15:= :]<ExecStatementText> --> [13,15:= :]<ExecStatementText>
-
-[[ExecStatementText]] [16,16:f]<ExecStatementText> --> [16,16:f]<ExecStatementText>
-
-[[ExecStatementText]] [7,9:AND]<ExecStatementText> --> [7,9:AND]<ExecStatementText>
-
-[[ExecStatementText]] [11,11:g]<ExecStatementText> --> [11,11:g]<ExecStatementText>
-
-[[ExecStatementText]] [13,15:= :]<ExecStatementText> --> [13,15:= :]<ExecStatementText>
-
-[[ExecStatementText]] [16,16:h]<ExecStatementText> --> [16,16:h]<ExecStatementText>
+[[ExecStatementText]] [1,16:      AND g = :h]<ExecStatementText> --> [1,16:      AND g = :h]<ExecStatementText>
 
 [[ExecStatementEnd]] [1,8:END-EXEC]<END_EXEC> --> [1,8:END-EXEC]<END_EXEC>
 

--- a/TypeCobol.Test/Parser/Preprocessor/TestCompilerDirectiveBuilder.cs
+++ b/TypeCobol.Test/Parser/Preprocessor/TestCompilerDirectiveBuilder.cs
@@ -66,7 +66,9 @@ namespace TypeCobol.Test.Parser.Preprocessor
         public static void CheckEXEC_SQL_INCLUDE()
         {
             string testName = "ExecSqlInclude";
+            _DirectiveProject.CompilationOptions.EnableSqlParsing = true;
             string result = PreprocessorUtils.ProcessCompilerDirectives(_DirectiveProject, testName);
+            _DirectiveProject.CompilationOptions.EnableSqlParsing = false;
             PreprocessorUtils.CheckWithDirectiveResultFile(result, testName);
         }
 

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/CopyWithExecSqlAndData1.cpy
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/CopyWithExecSqlAndData1.cpy
@@ -1,4 +1,4 @@
-          EXEC SQL DECLARE Table2 TABLE
-          ( Table2_Field2 CHAR(1) NOT NULL,
-          ) END-EXEC.
+          EXEC SQL
+            SELECT * FROM Table2 
+          END-EXEC.
           01 table2-field2 PIC X.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/CopyWithExecSqlAndData2.cpy
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/CopyWithExecSqlAndData2.cpy
@@ -1,4 +1,4 @@
-          EXEC SQL DECLARE Table2 TABLE
-          ( Table2_Field2 CHAR(1) NOT NULL,
-          ) END-EXEC.
+          EXEC SQL
+            SELECT * FROM Table2 
+          END-EXEC.
           05 table2-field2 PIC X.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/CopyWithExecSqlOnly.cpy
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/CopyWithExecSqlOnly.cpy
@@ -1,3 +1,3 @@
-          EXEC SQL DECLARE Table2 TABLE
-          ( Table2_Field2 CHAR(1) NOT NULL,
-          ) END-EXEC.
+          EXEC SQL
+            SELECT * FROM Table2 
+          END-EXEC.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/ExecSqlInDataDivision.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/ExecSqlInDataDivision.rdz.cbl
@@ -4,9 +4,9 @@
        WORKING-STORAGE SECTION.
       *KO empty group item
        01 group1.
-          EXEC SQL DECLARE Table1 TABLE
-          ( Table1_Field1 CHAR(1) NOT NULL,
-          ) END-EXEC.
+          EXEC SQL
+            SELECT * FROM Table2 
+          END-EXEC.
       *KO same thing but with a copy
        01 group2.
        COPY CopyWithExecSqlOnly.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/ExecSqlInDataDivision.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/ExecSqlInDataDivision.rdzMix.txt
@@ -5,10 +5,9 @@
       *KO empty group item
 Line 6[11,16] <27, Error, Syntax> - Syntax error : A group item cannot be empty.
        01 group1.
-          EXEC SQL DECLARE Table1 TABLE
-          ( Table1_Field1 CHAR(1) NOT NULL,
-Line 9[13,20] <37, Warning, General> - Warning: a End statement is not aligned with the matching opening statement
-          ) END-EXEC.
+          EXEC SQL
+            SELECT * FROM Table2 
+          END-EXEC.
       *KO same thing but with a copy
 Line 11[11,16] <27, Error, Syntax> - Syntax error : A group item cannot be empty.
        01 group2.

--- a/TypeCobol.Test/Parser/Programs/TypeCobol/NodeBuilder-UnexpectedChild.rdz-Nodes.txt
+++ b/TypeCobol.Test/Parser/Programs/TypeCobol/NodeBuilder-UnexpectedChild.rdz-Nodes.txt
@@ -15,37 +15,15 @@
         sqlcode
         [[ExecStatement]] [10,13:EXEC]<EXEC> --> [15,17:SQL]<ExecTranslatorName>
 
-          [[ExecStatementText]] [19,25:DECLARE]<ExecStatementText> --> [19,25:DECLARE]<ExecStatementText>
+          [[ExecStatementText]] [19,41:DECLARE tablename TABLE]<ExecStatementText> --> [19,41:DECLARE tablename TABLE]<ExecStatementText>
 
-          [[ExecStatementText]] [27,35:tablename]<ExecStatementText> --> [27,35:tablename]<ExecStatementText>
+          [[ExecStatementText]] [8,10:  (]<ExecStatementText> --> [8,10:  (]<ExecStatementText>
 
-          [[ExecStatementText]] [37,41:TABLE]<ExecStatementText> --> [37,41:TABLE]<ExecStatementText>
+          [[ExecStatementText]] [8,37:    num  DECIMAL(45) NOT NULL,]<ExecStatementText> --> [8,37:    num  DECIMAL(45) NOT NULL,]<ExecStatementText>
 
-          [[ExecStatementText]] [10,10:(]<ExecStatementText> --> [10,10:(]<ExecStatementText>
+          [[ExecStatementText]] [8,37:    str  VARCHAR(256) NOT NULL]<ExecStatementText> --> [8,37:    str  VARCHAR(256) NOT NULL]<ExecStatementText>
 
-          [[ExecStatementText]] [12,14:num]<ExecStatementText> --> [12,14:num]<ExecStatementText>
-
-          [[ExecStatementText]] [17,23:DECIMAL]<ExecStatementText> --> [17,23:DECIMAL]<ExecStatementText>
-
-          [[ExecStatementText]] [24,28:(45) ]<ExecStatementText> --> [24,28:(45) ]<ExecStatementText>
-
-          [[ExecStatementText]] [29,31:NOT]<ExecStatementText> --> [29,31:NOT]<ExecStatementText>
-
-          [[ExecStatementText]] [33,36:NULL]<ExecStatementText> --> [33,36:NULL]<ExecStatementText>
-
-          [[ExecStatementText]] [37,37:,]<ExecStatementText> --> [37,37:,]<ExecStatementText>
-
-          [[ExecStatementText]] [12,14:str]<ExecStatementText> --> [12,14:str]<ExecStatementText>
-
-          [[ExecStatementText]] [17,23:VARCHAR]<ExecStatementText> --> [17,23:VARCHAR]<ExecStatementText>
-
-          [[ExecStatementText]] [24,29:(256) ]<ExecStatementText> --> [24,29:(256) ]<ExecStatementText>
-
-          [[ExecStatementText]] [30,32:NOT]<ExecStatementText> --> [30,32:NOT]<ExecStatementText>
-
-          [[ExecStatementText]] [34,37:NULL]<ExecStatementText> --> [34,37:NULL]<ExecStatementText>
-
-          [[ExecStatementText]] [10,11:) ]<ExecStatementText> --> [10,11:) ]<ExecStatementText>
+          [[ExecStatementText]] [8,10:  )]<ExecStatementText> --> [8,10:  )]<ExecStatementText>
 
           end
     end

--- a/TypeCobol.Test/Parser/Scanner/ResultFiles/ExecStatement.txt
+++ b/TypeCobol.Test/Parser/Scanner/ResultFiles/ExecStatement.txt
@@ -1,8 +1,7 @@
 -- Line 1 --
 [1,4:EXEC]<EXEC>
 [6,8:SQL]<ExecTranslatorName>
-[10,15:DELETE]<SQL_DELETE>
-[17,21:Table]<SQL_TABLE>
+[10,21:DELETE Table]<ExecStatementText>
 [23,30:END-EXEC]<END_EXEC>
 [31,31+:.]<PeriodSeparator>
 
@@ -28,21 +27,13 @@
 [4,6:SQL]<ExecTranslatorName>
 
 -- Line 6 --
-[3,6:tout]<UserDefinedWord>
-[8,9:un]<UserDefinedWord>
-[11,13:tas]<UserDefinedWord>
-[15,16:de]<UserDefinedWord>
-[18,23:blabla]<UserDefinedWord>
+[3,23:tout un tas de blabla]<ExecStatementText>
 
 -- Line 7 --
-[6,14:bliblibli]<UserDefinedWord>
+[1,14:     bliblibli]<ExecStatementText>
 
 -- Line 8 --
-[4,4:c]<UserDefinedWord>
-[6,8:est]<UserDefinedWord>
-[10,11:la]<UserDefinedWord>
-[13,15:fin]<UserDefinedWord>
-[16,16:.]<PeriodSeparator>
+[1,16:   c est la fin.]<ExecStatementText>
 [17,24:END-EXEC]<END_EXEC>
 [26,28:ici]<UserDefinedWord>
 [29,29+:.]<PeriodSeparator>

--- a/TypeCobol.Test/Parser/Scanner/TestRealPrograms.cs
+++ b/TypeCobol.Test/Parser/Scanner/TestRealPrograms.cs
@@ -26,12 +26,7 @@ namespace TypeCobol.Test.Parser.Scanner
             foreach (string fileName in PlatformUtils.ListFilesInSubdirectory(ParserScannerSamples))
             {
                 string textName = Path.GetFileNameWithoutExtension(fileName);
-#if SQL_PARSING
-                if (textName == "RealPGM2")
-                {
-                    continue;
-                }
-#endif
+
                 // Initialize a CompilationDocument
                 FileCompiler compiler = new FileCompiler(null, textName, ColumnsLayout.CobolReferenceFormat, false, project.SourceFileProvider, project, new TypeCobolOptions(), null, project);
 

--- a/TypeCobol.Test/Utils/Comparator.cs
+++ b/TypeCobol.Test/Utils/Comparator.cs
@@ -210,6 +210,14 @@ namespace TypeCobol.Test.Utils
                         continue;
                 }
 #endif
+                string containingDirectory = Path.GetDirectoryName(samplePath);
+                bool enableSqlParsing = containingDirectory != null && containingDirectory.IndexOf("SQL", StringComparison.InvariantCultureIgnoreCase) >= 0;
+                if (enableSqlParsing)
+                {
+                    //Temporary
+                    continue;
+                }
+
                 IList<FilesComparator> comparators = GetComparators(_sampleRoot, _resultsRoot, samplePath, debug);
 				if (comparators.Count < 1) {
 					Console.WriteLine(" /!\\ ERROR: Missing result file \"" + samplePath + "\"");

--- a/TypeCobol.Test/Utils/Comparator.cs
+++ b/TypeCobol.Test/Utils/Comparator.cs
@@ -198,18 +198,6 @@ namespace TypeCobol.Test.Utils
 		public void Test(bool debug = false, bool json = false, bool isCobolLanguage = false) {
 			var errors = new StringBuilder();
 			foreach (var samplePath in samples) {
-#if SQL_PARSING
-                var fileName = Path.GetFileName(samplePath);
-                switch (fileName)
-                {
-                    case "ExecSqlInDataDivision.rdz.cbl":
-                    case "Program.pgm":        
-                    case "ParagraphSection.rdz.cbl":
-                    case "EXEC.cbl":
-                    case "NodeBuilder-UnexpectedChild.rdz.tcbl":
-                        continue;
-                }
-#endif
                 string containingDirectory = Path.GetDirectoryName(samplePath);
                 bool enableSqlParsing = containingDirectory != null && containingDirectory.IndexOf("SQL", StringComparison.InvariantCultureIgnoreCase) >= 0;
                 if (enableSqlParsing)

--- a/TypeCobol.Test/Utils/Comparator.cs
+++ b/TypeCobol.Test/Utils/Comparator.cs
@@ -198,14 +198,9 @@ namespace TypeCobol.Test.Utils
 		public void Test(bool debug = false, bool json = false, bool isCobolLanguage = false) {
 			var errors = new StringBuilder();
 			foreach (var samplePath in samples) {
+                // Automatically enable SQL parsing for samples located in a directory containing "SQL" within its path
                 string containingDirectory = Path.GetDirectoryName(samplePath);
                 bool enableSqlParsing = containingDirectory != null && containingDirectory.IndexOf("SQL", StringComparison.InvariantCultureIgnoreCase) >= 0;
-                if (enableSqlParsing)
-                {
-                    //Temporary
-                    continue;
-                }
-
                 IList<FilesComparator> comparators = GetComparators(_sampleRoot, _resultsRoot, samplePath, debug);
 				if (comparators.Count < 1) {
 					Console.WriteLine(" /!\\ ERROR: Missing result file \"" + samplePath + "\"");
@@ -216,6 +211,7 @@ namespace TypeCobol.Test.Utils
                     Console.WriteLine(comparator.paths.Result + " checked with " + comparator.GetType().Name);
                     var unit = new TestUnit(comparator, _copyExtensions);
                     unit.Compiler.CompilerOptions.IsCobolLanguage = isCobolLanguage;
+                    unit.Compiler.CompilerOptions.EnableSqlParsing = enableSqlParsing;
                     unit.Parse();
 				    if (unit.Observer.HasErrors)
 				    {

--- a/TypeCobol/Common.props
+++ b/TypeCobol/Common.props
@@ -37,7 +37,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE;SQL_PARSING</DefineConstants>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>$(SolutionDir)\TypeCobol\TypeCobol.ruleset</CodeAnalysisRuleSet>
@@ -47,7 +47,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;SQL_PARSING</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>$(SolutionDir)\TypeCobol\TypeCobol.ruleset</CodeAnalysisRuleSet>
@@ -58,7 +58,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE;EUROINFO_RULES;SQL_PARSING</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;EUROINFO_RULES</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>$(SolutionDir)\TypeCobol\TypeCobol.ruleset</CodeAnalysisRuleSet>
@@ -68,7 +68,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;EUROINFO_RULES;SQL_PARSING</DefineConstants>
+    <DefineConstants>TRACE;EUROINFO_RULES</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>$(SolutionDir)\TypeCobol\TypeCobol.ruleset</CodeAnalysisRuleSet>

--- a/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
+++ b/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
@@ -65,6 +65,11 @@ namespace TypeCobol.Compiler.Directives
         public bool OptimizeWhitespaceScanning { get; set; } = true;
 
         /// <summary>
+        /// Enable parsing of SQL code embedded into EXEC SQL [...] END-EXEC blocks.
+        /// </summary>
+        public bool EnableSqlParsing { get; set; } = false;
+
+        /// <summary>
         /// Check if a End statement is aligned with the matching opening statement.
         /// </summary>
         public TypeCobolCheckOption CheckEndAlignment { get; set; }

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -1951,7 +1951,7 @@ namespace TypeCobol.Compiler.Scanner
                 tokensLine.ScanState.InsideSql = true;
             }
 
-            if (tokensLine.ScanState.InsideSql)
+            if (tokensLine.ScanState.InsideSql && compilerOptions.EnableSqlParsing)
             {
                 // Use dedicated SQL scanner
                 if (_sqlScanner == null)


### PR DESCRIPTION
Fixes #2289.
- new option `EnableSqlParsing`, default to `false`
- removal of `SQl_PARSING` compilation constant which is not required anymore

When using `FolderTester`, tests located in a directory containing the string "SQL" are automatically parsed using sql parsing.
