### PR TITLE
WI #2185 Relocate only statements when new Sentence is created

### DIFF
--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -771,7 +771,7 @@ namespace TypeCobol.Compiler.CodeModel
                 else
                 {
                     //Match paragraphs located directly in the PROCEDURE DIVISION
-                    matchParentSection = MatchRootParagraph;
+                    matchParentSection = p => p.Parent.CodeElement.Type == CodeElementType.ProcedureDivisionHeader;
                 }
 
                 //If we get results in the same section, we return them. Otherwise, just return candidates with correct name.
@@ -780,29 +780,6 @@ namespace TypeCobol.Compiler.CodeModel
             }
 
             return EmptyParagraphList;
-        }
-
-        private static bool MatchRootParagraph(Paragraph paragraph)
-        {
-            #region Temporary debug code to help fix #2185
-
-            if (paragraph.Parent == null)
-            {
-                var debugData = Logging.LoggingSystemExtensions.CreateDebugData(paragraph);
-                Logging.LoggingSystem.LogMessage(Logging.LogLevel.Error, "SymbolTable.GetParagraph, paragraph parent is null", debugData);
-                return false;
-            }
-
-            if (paragraph.Parent.CodeElement == null)
-            {
-                var debugData = Logging.LoggingSystemExtensions.CreateDebugData(paragraph);
-                Logging.LoggingSystem.LogMessage(Logging.LogLevel.Error, "SymbolTable.GetParagraph, paragraph parent code element is null", debugData);
-                return false;
-            }
-
-            #endregion
-
-            return paragraph.Parent.CodeElement.Type == CodeElementType.ProcedureDivisionHeader;
         }
 
         /// <summary>

--- a/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
@@ -18,6 +18,44 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
     /// </summary>
     public class ProgramClassBuilder : IProgramClassBuilder
     {
+        private static bool _SourceCodeDumped;
+
+        private void LogErrorIncludingFullSourceCode(string message)
+        {
+            if (_SourceCodeDumped) return; //Dump only once to avoid huge logs
+
+            var codeElements = new StringBuilder();
+            var sourceCode = new StringBuilder();
+            foreach (var codeElementsLine in _codeElementsLines)
+            {
+                if (!codeElementsLine.HasCodeElements) continue;
+
+                foreach (var codeElement in codeElementsLine.CodeElements)
+                {
+                    codeElements.AppendLine($"{codeElement.Line}: {codeElement.Type}");
+                    string sourceText;
+                    try
+                    {
+                        sourceText = codeElement.SourceText;
+                    }
+                    catch (Exception e)
+                    {
+                        sourceText = $"Could not dump CodeElement: {e.Message}";
+                    }
+                    sourceCode.AppendLine(sourceText);
+                }
+            }
+
+            var contextData = new Dictionary<string, object>()
+                              {
+                                  { "codeElements", codeElements.ToString() },
+                                  { "sourceCode", sourceCode.ToString() }
+                              };
+            LoggingSystem.LogMessage(LogLevel.Error, message, contextData);
+
+            _SourceCodeDumped = true;
+        }
+
         public SyntaxTree SyntaxTree { get; set; }
 
         private TypeDefinition _CurrentTypeDefinition
@@ -230,6 +268,8 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
             }
             else
             {
+                #region Temporary debug code for #2319
+
                 if (CurrentNode != CurrentProgram)
                 {
                     // This is abnormal, re-synchronize builder with CUP parser
@@ -238,26 +278,10 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
                         Exit();
                     }
 
-                    var codeElements = new StringBuilder();
-                    var sourceCode = new StringBuilder();
-                    foreach (var codeElementsLine in _codeElementsLines)
-                    {
-                        if (!codeElementsLine.HasCodeElements) continue;
-
-                        foreach (var codeElement in codeElementsLine.CodeElements)
-                        {
-                            codeElements.AppendLine($"{codeElement.Line}: {codeElement.Type}");
-                            sourceCode.AppendLine(codeElement.SourceText);
-                        }
-                    }
-
-                    var contextData = new Dictionary<string, object>()
-                                      {
-                                          { "codeElements", codeElements.ToString() },
-                                          { "sourceCode", sourceCode.ToString() }
-                                      };
-                    LoggingSystem.LogMessage(LogLevel.Error, $"Syntax tree fixed for nested pgm '{programIdentification.ProgramName?.Name}'.", contextData);
+                    LogErrorIncludingFullSourceCode($"Syntax tree fixed for nested pgm '{programIdentification.ProgramName?.Name}'.");
                 }
+
+                #endregion
 
                 // Nested
                 CurrentProgram = new NestedProgram(CurrentProgram, programIdentification);
@@ -877,6 +901,17 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
 
         public virtual void StartParagraph(ParagraphHeader header)
         {
+            #region Temporary debug code for #2185
+
+            if (CurrentNode is Sentence)
+            {
+                // Invalid AST
+                Exit();
+                LogErrorIncludingFullSourceCode($"Invalid parent for paragraph '{header.Name}'.");
+            }
+
+            #endregion
+
             var paragraph = new Paragraph(header);
             Enter(paragraph, header);
             paragraph.SymbolTable.AddParagraph(paragraph);

--- a/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
@@ -914,7 +914,7 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
         /// </summary>
         public virtual void CheckStartSentenceLastStatement()
         {
-            if (LastEnteredNode != null)
+            if (LastEnteredNode is Statement)
             {
                 Node parent = LastEnteredNode.Parent;
                 if (parent is Paragraph || parent is ProcedureDivision)

--- a/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
@@ -270,14 +270,10 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
             {
                 #region Temporary debug code for #2319
 
-                if (CurrentNode != CurrentProgram)
+                while (CurrentNode != CurrentProgram)
                 {
                     // This is abnormal, re-synchronize builder with CUP parser
-                    while (CurrentNode != CurrentProgram)
-                    {
-                        Exit();
-                    }
-
+                    Exit();
                     LogErrorIncludingFullSourceCode($"Syntax tree fixed for nested pgm '{programIdentification.ProgramName?.Name}'.");
                 }
 
@@ -903,11 +899,17 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
         {
             #region Temporary debug code for #2185
 
-            if (CurrentNode is Sentence)
+            while (!IsValidParagraphParent())
             {
                 // Invalid AST
                 Exit();
                 LogErrorIncludingFullSourceCode($"Invalid parent for paragraph '{header.Name}'.");
+            }
+
+            bool IsValidParagraphParent()
+            {
+                var parentType = CurrentNode.CodeElement?.Type;
+                return parentType == CodeElementType.ProcedureDivisionHeader || parentType == CodeElementType.SectionHeader;
             }
 
             #endregion

--- a/TypeCobol/Logging/LoggingSystemExtensions.cs
+++ b/TypeCobol/Logging/LoggingSystemExtensions.cs
@@ -104,7 +104,14 @@ namespace TypeCobol.Logging
                 string text;
                 if (node.CodeElement != null)
                 {
-                    text = node.CodeElement.SourceText;
+                    try
+                    {
+                        text = node.CodeElement.SourceText;
+                    }
+                    catch (Exception e)
+                    {
+                        text = $"Could not dump CodeElement: {e.Message}";
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Instead of changing the `ProgramClassBuilder` workflow, I'd like to try this solution which ensure a `Paragraph` won't be relocated as a child of a `Sentence`.