### PR TITLE
WI #2332 Add Debug code for exception in CodeElement.SourceText

### DIFF
--- a/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
@@ -33,16 +33,7 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
                 foreach (var codeElement in codeElementsLine.CodeElements)
                 {
                     codeElements.AppendLine($"{codeElement.Line}: {codeElement.Type}");
-                    string sourceText;
-                    try
-                    {
-                        sourceText = codeElement.SourceText;
-                    }
-                    catch (Exception e)
-                    {
-                        sourceText = $"Could not dump CodeElement: {e.Message}";
-                    }
-                    sourceCode.AppendLine(sourceText);
+                    sourceCode.AppendLine(codeElement.SafeGetSourceText());
                 }
             }
 

--- a/TypeCobol/Logging/LoggingSystemExtensions.cs
+++ b/TypeCobol/Logging/LoggingSystemExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.Nodes;
 
 namespace TypeCobol.Logging
@@ -104,14 +105,7 @@ namespace TypeCobol.Logging
                 string text;
                 if (node.CodeElement != null)
                 {
-                    try
-                    {
-                        text = node.CodeElement.SourceText;
-                    }
-                    catch (Exception e)
-                    {
-                        text = $"Could not dump CodeElement: {e.Message}";
-                    }
+                    text = node.CodeElement.SafeGetSourceText();
                 }
                 else
                 {
@@ -141,5 +135,42 @@ namespace TypeCobol.Logging
                 return index < node.Parent.ChildrenCount - 1 ? node.Parent.Children[index + 1] : null;
             }
         }
+
+        #region Temporary debug code for #2332
+
+        internal static string SafeGetSourceText(this CodeElement codeElement)
+        {
+            if (codeElement == null) return NULL; // Should not happen
+
+            string result;
+            try
+            {
+                result = codeElement.SourceText;
+            }
+            catch (Exception exception)
+            {
+                // Trace exception and attempt to read tokens directly
+                var builder = new StringBuilder();
+                builder.Append($"Could not dump CodeElement: {exception.GetType().FullName} - {exception.Message}");
+                if (exception is ArgumentOutOfRangeException argumentOutOfRangeException)
+                {
+                    builder.Append($" - {argumentOutOfRangeException.ActualValue}");
+                }
+
+                builder.AppendLine();
+                foreach (var token in codeElement.ConsumedTokens)
+                {
+                    builder.Append('<');
+                    builder.Append(token.Text);
+                    builder.Append("> ");
+                }
+
+                result = builder.ToString();
+            }
+
+            return result;
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Temporary code for #2332.

As `SourceText` is used only in debug code itself (CreateDebugData / ProgramClassBuilder), this will also allow to get complete traces.
