### PR TITLE
2235 Optimize code element parser step in incremental

### DIFF
--- a/TypeCobol/Compiler/Parser/CodeElementsParserStep.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementsParserStep.cs
@@ -110,10 +110,11 @@ namespace TypeCobol.Compiler.Parser
             //Start line to seek token in the stream of token (stream of token=tokenIterator) 
             int startLineToSeekToken = 0;
 
+            //For incremental mode, calculate best value for startLineToSeekToken
             if (largestRefreshParseSection != null)
             {
                 //No need to check for ReplacedToken or ImportedToken here, as we directly interact with documentLines
-                //which are the lines of the original document
+                //which are the lines of the original document.
 
                 //TODO find all ReplaceDirective that can target the current line.
                 //Count the largest number of tokens that a Replace directive can target
@@ -147,8 +148,8 @@ namespace TypeCobol.Compiler.Parser
             CodeElementsParser cobolParser = new CodeElementsParser(tokenStream);
             // REVERT TO STD PARSER ==> TracingCobolParser cobolParser = new TracingCobolParser(tokenStream);
 
-            // Optionnaly activate Antlr Parser performance profiling
-            // WARNING : use this in a single-treaded context only (uses static field)     
+            // Optionally activate Antlr Parser performance profiling
+            // WARNING : use this in a single-threaded context only (uses static field)     
             if (perfStatsForParserInvocation.ActivateDetailedAntlrPofiling)
                 AntlrPerformanceProfiler = new AntlrPerformanceProfiler(cobolParser);
             else

--- a/TypeCobol/Compiler/Preprocessor/AutoReplacePartialWordsTokensDocument.cs
+++ b/TypeCobol/Compiler/Preprocessor/AutoReplacePartialWordsTokensDocument.cs
@@ -88,6 +88,6 @@ namespace TypeCobol.Compiler.Preprocessor
             _compilerOptions = compilerOptions;
         }
 
-        public override ITokensLinesIterator GetProcessedTokensIterator() => new TokensLinesIterator(base.GetProcessedTokensIterator(), _compilerOptions);
+        public override ITokensLinesIterator GetProcessedTokensIterator(int startLine = 0) => new TokensLinesIterator(base.GetProcessedTokensIterator(startLine), _compilerOptions);
     }
 }

--- a/TypeCobol/Compiler/Preprocessor/CopyTokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Preprocessor/CopyTokensLinesIterator.cs
@@ -65,7 +65,9 @@ namespace TypeCobol.Compiler.Preprocessor
         }
 
         /// <summary>
-        /// Resets the iterator position : before the first token of the document
+        /// Resets the iterator position :
+        /// - Before the first token of the document if startLine = 0
+        /// - To the specified startLine otherwise
         /// </summary>
         public void Reset(int startLine = 0)
         {

--- a/TypeCobol/Compiler/Preprocessor/CopyTokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Preprocessor/CopyTokensLinesIterator.cs
@@ -54,26 +54,33 @@ namespace TypeCobol.Compiler.Preprocessor
         /// <summary>
         /// Set the initial position of the iterator with startToken.
         /// </summary>
-        public CopyTokensLinesIterator(string sourceFileName, IReadOnlyList<IProcessedTokensLine> tokensLines, int channelFilter)
+        public CopyTokensLinesIterator(string sourceFileName, IReadOnlyList<IProcessedTokensLine> tokensLines, int channelFilter, int startLine = 0)
         {
             this.sourceFileName = sourceFileName;
             this.tokensLines = tokensLines;
             this.channelFilter = channelFilter;
 
             // Start just before the first token in the document
-            Reset();
+            Reset(startLine);
         }
 
         /// <summary>
         /// Resets the iterator position : before the first token of the document
         /// </summary>
-        public void Reset()
+        public void Reset(int startLine = 0)
         {
-            currentPosition.LineIndex = 0;
+            if (startLine < 0) {
+                startLine = 0;
+            }
+            if(startLine >= tokensLines.Count)
+            {
+                startLine = tokensLines.Count - 1; //Start on last line
+            }
+            currentPosition.LineIndex = startLine;
             currentPosition.TokenIndexInLine = -1;
             if (tokensLines.Count > 0)
             {
-                currentLine = tokensLines[0];
+                currentLine = tokensLines[startLine];
             }
             else
             {

--- a/TypeCobol/Compiler/Preprocessor/ProcessedTokensDocument.cs
+++ b/TypeCobol/Compiler/Preprocessor/ProcessedTokensDocument.cs
@@ -48,9 +48,9 @@ namespace TypeCobol.Compiler.Preprocessor
         /// - COPY directives text imports
         /// - REPLACE directive token replacements
         /// </summary>
-        public virtual ITokensLinesIterator GetProcessedTokensIterator()
+        public virtual ITokensLinesIterator GetProcessedTokensIterator(int startLine = 0)
         {
-            ITokensLinesIterator copyIterator = new CopyTokensLinesIterator(TextSourceInfo.Name, Lines, Token.CHANNEL_SourceTokens);
+            ITokensLinesIterator copyIterator = new CopyTokensLinesIterator(TextSourceInfo.Name, Lines, Token.CHANNEL_SourceTokens, startLine);
             ITokensLinesIterator replaceIterator = new ReplaceTokensLinesIterator(copyIterator, _compilerOptions);
             return replaceIterator;
         }


### PR DESCRIPTION
WI #2235 Optimize code element parser step in incremental mode only.
In incremental mode, tokenIterator will now start at a more appropriate line to avoid iteration over all tokens of the document.

What's left to do:
- Specific incremental tests. We already have some incremental tests. I need to be sure that they cover the case of this implementation.
I've tested in our private IDE and it works fine so far.
- Create a performance test with a lot of COPY to reflect our real use case. 
   - One test with a modification in the data division
   - One test with a modification in the procedure division

Performance gain:
[Gain-2235.xlsx](https://github.com/TypeCobolTeam/TypeCobol/files/9899396/Gain-2235.xlsx)
As always with performance gain, if you run the same test twice, you won't gain exactly the same results. You can still see that CodeElementParserStep is close to 0ms.
