### PR TITLE
WI #2339 Do not create invalid IntegerValue for MaxBlockSize of a file description

### DIFF
--- a/TypeCobol/Compiler/CodeElements/Expressions/SyntaxValue.cs
+++ b/TypeCobol/Compiler/CodeElements/Expressions/SyntaxValue.cs
@@ -65,7 +65,10 @@ namespace TypeCobol.Compiler.CodeElements
     /// </summary>
     public class IntegerValue : SyntaxValue<long>
     {
-        public IntegerValue(Token t) : base(t) { }
+        public IntegerValue(Token t) : base(t)
+        {
+            System.Diagnostics.Debug.Assert(t != null || this is GeneratedIntegerValue);
+        }
 
         public override long Value
         {

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
@@ -953,7 +953,9 @@ namespace TypeCobol.Compiler.Parser
 			}
 			if (context.blockContainsClause() != null && context.blockContainsClause().Length > 0) {
 				var blockContainsClauseContext = context.blockContainsClause()[0];
-				entry.MaxBlockSize = CobolWordsBuilder.CreateIntegerValue(blockContainsClauseContext.maxNumberOfBytes);
+				if (blockContainsClauseContext.maxNumberOfBytes != null) {
+					entry.MaxBlockSize = CobolWordsBuilder.CreateIntegerValue(blockContainsClauseContext.maxNumberOfBytes);
+				}
 				if (blockContainsClauseContext.minNumberOfBytes != null) {
 					entry.MinBlockSize = CobolWordsBuilder.CreateIntegerValue(blockContainsClauseContext.minNumberOfBytes);
 				}


### PR DESCRIPTION
Insta fix for #2339.