### PR TITLE
WI #2347 Check for null LevelNumbers in completion operations

### DIFF
--- a/TypeCobol.LanguageServer/TypeCobolServer.cs
+++ b/TypeCobol.LanguageServer/TypeCobolServer.cs
@@ -734,14 +734,15 @@ namespace TypeCobol.LanguageServer
                             }
                         case TokenType.DISPLAY:
                             {
-                                System.Linq.Expressions.Expression<Func<DataDefinition, bool>> predicate = dataDefinition =>
+                                Func<DataDefinition, bool> predicate = dataDefinition =>
                                     dataDefinition.Name.StartsWith(userFilterText, StringComparison.OrdinalIgnoreCase) // keep only variables with matching name
                                     && dataDefinition.Usage != DataUsage.ProcedurePointer // invalid usages in DISPLAY statement
                                     && dataDefinition.Usage != DataUsage.FunctionPointer
                                     && dataDefinition.Usage != DataUsage.ObjectReference
                                     && dataDefinition.Usage != DataUsage.Index
-                                    && (dataDefinition.CodeElement != null && dataDefinition.CodeElement.LevelNumber.Value < 88);
+                                    && (dataDefinition.CodeElement?.LevelNumber != null && dataDefinition.CodeElement.LevelNumber.Value < 88);
                                 // Ignore level 88. Note that dataDefinition.CodeElement != null condition also filters out IndexDefinition which is invalid in the context of DISPLAY
+                                // Filtering dataDefinition without LevelNumber also excludes FileDescription which are invalid for a DISPLAY
                                 items.AddRange(CompletionFactory.GetCompletionForVariable(docContext.FileCompiler, matchingCodeElement, predicate));
                                 break;
                             }
@@ -750,8 +751,7 @@ namespace TypeCobol.LanguageServer
                                 items.AddRange(CompletionFactory.GetCompletionForVariable(docContext.FileCompiler, matchingCodeElement,
                                     da =>
                                         da.Name.StartsWith(userFilterText, StringComparison.OrdinalIgnoreCase) &&
-                                        ((da.CodeElement != null &&
-                                          da.CodeElement.LevelNumber.Value < 88)
+                                        ((da.CodeElement?.LevelNumber != null && da.CodeElement.LevelNumber.Value < 88)
                                          || (da.CodeElement == null && da is IndexDefinition))));
                                 //Ignore 88 level variable
                                 break;
@@ -778,8 +778,7 @@ namespace TypeCobol.LanguageServer
                                 items.AddRange(CompletionFactory.GetCompletionForVariable(docContext.FileCompiler, matchingCodeElement,
                                     v => v.Name.StartsWith(userFilterText, StringComparison.OrdinalIgnoreCase)
                                          &&
-                                         ((v.CodeElement != null &&
-                                           v.CodeElement.LevelNumber.Value == 88)
+                                         ((v.CodeElement?.LevelNumber != null && v.CodeElement.LevelNumber.Value == 88)
                                           //Level 88 Variable
                                           || v.DataType == DataType.Numeric //Numeric Integer Variable
                                           || v.Usage == DataUsage.Pointer) //Or usage is pointer 

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.CodeElements.Expressions;
 using TypeCobol.Compiler.Nodes;
-using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using TypeCobol.Compiler.Concurrency;
 
@@ -189,7 +188,7 @@ namespace TypeCobol.Compiler.CodeModel
         /// <param name="predicate">Predicate to search variable(s)</param>
         /// <param name="maximalScope">The maximal symboltable scope to search in</param>
         /// <returns></returns>
-        public IEnumerable<DataDefinition> GetVariables(Expression<Func<DataDefinition, bool>> predicate, Scope maximalScope)
+        public IEnumerable<DataDefinition> GetVariables(Func<DataDefinition, bool> predicate, Scope maximalScope)
         {
             var foundedVariables = new List<DataDefinition>();
 
@@ -200,7 +199,7 @@ namespace TypeCobol.Compiler.CodeModel
                     throw new NotSupportedException(); //There is no variable stored in those scopes
              
                 var dataToSeek = currentTable.DataEntries.Values.SelectMany(t => t);
-                var results = dataToSeek.AsQueryable().Where(predicate);
+                var results = dataToSeek.Where(predicate);
                 foundedVariables.AddRange(results);
 
                 currentTable = currentTable.EnclosingScope;
@@ -786,9 +785,9 @@ namespace TypeCobol.Compiler.CodeModel
         /// Get all paragraphs in the current scope.
         /// </summary>
         /// <returns>The collection of paragraph names</returns>
-        public IEnumerable<Paragraph> GetParagraphs(Expression<Func<Paragraph, bool>> predicate)
+        public IEnumerable<Paragraph> GetParagraphs(Func<Paragraph, bool> predicate)
         {
-            return Paragraphs.Values.SelectMany(p => p).AsQueryable().Where(predicate).Distinct();
+            return Paragraphs.Values.SelectMany(p => p).Where(predicate).Distinct();
         }
 
         /// <summary>
@@ -943,7 +942,7 @@ namespace TypeCobol.Compiler.CodeModel
             return found;
         }
 
-        public IEnumerable<TypeDefinition> GetTypes(Expression<Func<TypeDefinition, bool>> predicate, Scope maximalScope)
+        public IEnumerable<TypeDefinition> GetTypes(Func<TypeDefinition, bool> predicate, Scope maximalScope)
         {
             var foundedTypes = new List<TypeDefinition>();
 
@@ -966,7 +965,7 @@ namespace TypeCobol.Compiler.CodeModel
                     dataToSeek = dataToSeek.Where(typeDefinition => typeDefinition.CodeElement.Visibility == AccessModifier.Public);
                 }
 
-                var results = dataToSeek.AsQueryable().Where(predicate);
+                var results = dataToSeek.Where(predicate);
 
                 foundedTypes.AddRange(results);
 
@@ -1042,7 +1041,7 @@ namespace TypeCobol.Compiler.CodeModel
             return GetFunction(uri, profile);
         }
 
-        public IEnumerable<FunctionDeclaration> GetFunctions(Expression<Func<FunctionDeclaration, bool>> predicate, Scope maximalScope)
+        public IEnumerable<FunctionDeclaration> GetFunctions(Func<FunctionDeclaration, bool> predicate, Scope maximalScope)
         {
             var foundedFunctions = new List<FunctionDeclaration>();
 
@@ -1058,7 +1057,7 @@ namespace TypeCobol.Compiler.CodeModel
                             .Functions.Values.SelectMany(t => t));
                 }
 
-                var results = dataToSeek.AsQueryable().Where(predicate);
+                var results = dataToSeek.Where(predicate);
 
                 if (currentTable.CurrentScope == Scope.Intrinsic || currentTable.CurrentScope == Scope.Namespace)
                     results = results.Where(tp =>

--- a/TypeCobol/Compiler/Nodes/Data.cs
+++ b/TypeCobol/Compiler/Nodes/Data.cs
@@ -209,6 +209,7 @@ namespace TypeCobol.Compiler.Nodes {
     ///   DataRedefines                 ->          DataRedefinesEntry
     ///   DataCondition   88            ->      DataConditionEntry
     ///   DataRenames     66            ->      DataRenamesEntry
+    ///   FileDescriptionEntryNode      ->      FileDescriptionEntry
     ///     
     /// 
     /// Implementation note:


### PR DESCRIPTION
Fixes #2347.
Also removes unwanted usages of `System.Linq.Expressions` as described in #2170.