### PR TITLE
WI #2381 Handle REPLACE OFF syntax correctly in scanner's scan state

### DIFF
--- a/TypeCobol.Test/Parser/Programs/Cobol85/DebugLinesVsReplaceOff.rdz-Nodes.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/DebugLinesVsReplaceOff.rdz-Nodes.txt
@@ -1,0 +1,24 @@
+Line 14[38,46] <37, Warning, General> - Warning: Debugging mode is active
+Line 18[17,17] <30, Error, Semantics> - Semantic error: Symbol a is not referenced
+Line 18[22,22] <30, Error, Semantics> - Semantic error: Symbol b is not referenced
+--- Nodes ---
+?
+  MyPGM1
+    procedure-division
+      sentence-0
+        [[GobackStatement]] [12,17:GOBACK]<GOBACK> --> [12,17:GOBACK]<GOBACK>
+
+        end
+    end
+  MyPGM2
+    environment-division
+      configuration
+        source-computer
+    procedure-division
+      sentence-0
+        [[MoveStatement]] [12,15:MOVE]<MOVE> --> [22,22:b]<UserDefinedWord>
+
+        [[GobackStatement]] [12,17:GOBACK]<GOBACK> --> [12,17:GOBACK]<GOBACK>
+
+        end
+    end

--- a/TypeCobol.Test/Parser/Programs/Cobol85/DebugLinesVsReplaceOff.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/DebugLinesVsReplaceOff.rdz.cbl
@@ -1,0 +1,21 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. MyPGM1.
+       REPLACE OFF.
+       PROCEDURE DIVISION.
+      *Ok debugging mode is off
+      D    MOVE a TO b
+           GOBACK
+           .
+       END PROGRAM MyPGM1.
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. MyPGM2.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER. IBM-370 WITH DEBUGGING MODE.
+       REPLACE OFF.
+       PROCEDURE DIVISION.
+      *Ko debugging mode is active and a and b are not defined
+      D    MOVE a TO b
+           GOBACK
+           .
+       END PROGRAM MyPGM2.

--- a/TypeCobol/Compiler/Scanner/MultilineScanState.cs
+++ b/TypeCobol/Compiler/Scanner/MultilineScanState.cs
@@ -265,7 +265,7 @@ namespace TypeCobol.Compiler.Scanner
                     InsideMultilineComments = false;
                     return;
                 case TokenType.CURRENCY:
-                    // CURRENCY token is used either to satrt a CURRENCY SIGN clause or as an intrinsic type name in tC
+                    // CURRENCY token is used either to start a CURRENCY SIGN clause or as an intrinsic type name in TC
                     if (LastSignificantToken?.TokenType != TokenType.TYPE)
                     {
                         SpecialNames.BeginCurrencySignClause();
@@ -290,6 +290,12 @@ namespace TypeCobol.Compiler.Scanner
                     if (_afterReplacementPseudoText)
                     {
                         _afterReplacementPseudoText = false;
+                        InsideReplaceDirective = false;
+                    }
+                    break;
+                case TokenType.OFF:
+                    if (LastSignificantToken?.TokenType == TokenType.REPLACE)
+                    {
                         InsideReplaceDirective = false;
                     }
                     break;


### PR DESCRIPTION
Fixes #2381