### PR TITLE
v1.5.22

### DIFF
--- a/TypeCobol.Test/Parser/Programs/Cobol85/CharOutsideEditableRange.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/CharOutsideEditableRange.rdzMix.txt
@@ -6,17 +6,17 @@
        PROCEDURE DIVISION.
            display "max-ok_max-ok_max-ok_max-ok_max-ok_max-ok_max-ok_ma"
 
-Line 9[6,6] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 9[20,72] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display "3333333333333333333333333333222222222222222222222222
 
            move var1 to var1
 
-Line 13[6,6] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 13[20,59] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display "endxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1234
-Line 14[6,6] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 14[20,72] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display "3333333333333333333333333333222222222222222222222222
 
-Line 16[6,6] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 16[17,72] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            move "gggggggggggggggggggggggggggggggggggggggggggggssssssssss
                     to var1
            GOBACK.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine.rdzMix.txt
@@ -30,9 +30,11 @@ Line 10[19,21] <30, Error, Semantics> - Semantic error: Symbol foo is not refere
 
       
       *    KO
+Line 32[13,75] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 33[19,20] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -            ' er zer '
+Line 34[13,74] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 35[19,20] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -            " er zer '
@@ -40,9 +42,11 @@ Line 35[19,20] <21, Error, Tokens> - The delimiter character of this continuatio
 Line 37[19,20] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -            ' er zer "
       
+Line 39[13,75] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 40[19,20] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -            " er zer "
+Line 41[13,74] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 42[19,20] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -            ' er zer "
@@ -66,6 +70,7 @@ Line 52[19,20] <21, Error, Tokens> - The delimiter character of this continuatio
            display "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 57[21,22] <27, Error, Syntax> - Syntax error : Starting delimiter of the continuation line is missing.
       -              er zer "
+Line 58[13,72] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 59[20,21] <27, Error, Syntax> - Syntax error : Closing delimiter of the continuation line is missing.
       -             " er zer

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine2.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine2.rdzMix.txt
@@ -2,6 +2,7 @@
        PROGRAM-ID. MyPGM2.
        procedure division.
       * KO
+Line 5[13,75] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 6[17,18] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -          ' er zer '

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine4.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine4.rdzMix.txt
@@ -2,6 +2,7 @@
        PROGRAM-ID. MyPGM4.
        procedure division.
       * KO
+Line 5[14,75] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
             display 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 6[17,18] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -          " er zer "

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine6.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine6.rdzMix.txt
@@ -2,6 +2,7 @@
        PROGRAM-ID. MyPGM6.
        procedure division.
       * KO
+Line 5[18,73] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
                 display "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 6[18,19] <27, Error, Syntax> - Syntax error : Starting delimiter of the continuation line is missing.
       -           er zer '

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine8.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine8.rdzMix.txt
@@ -2,6 +2,7 @@
        PROGRAM-ID. MyPGM8.
        procedure division.
       * KO
+Line 5[18,73] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
                 display 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 6[18,19] <27, Error, Syntax> - Syntax error : Starting delimiter of the continuation line is missing.
       -           er zer "

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationMultiStrings.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationMultiStrings.rdzMix.txt
@@ -37,6 +37,7 @@ Line 32[12,35] <27, Error, Syntax> - Syntax error : extraneous input ''TAXONOMY:
            'WYYYYYY PROV RANGE 01: YYYYYYY THRU YYYYYYY'
 Line 36[14,21] <27, Error, Syntax> - Syntax error : extraneous input 'TAXONOMY' expecting {separator, statement starting keyword, keyword}
 Line 36[11,12] <22, Error, Tokens> - The alphanumeric literal was not properly continued. This continuation line can start with two delimiters '' only if the alphanumeric literal on the previous line ended with a delimiter ' in column 72
+Line 36[36,37] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
       -    ''TAXONOMY: YYYYYYYYYYYY'.
       * accepted by US and IBM because ' is colum 72
        01 CONSTPARM3             PIC X(78) VALUE

--- a/TypeCobol.Test/Parser/Programs/Cobol85/InvalidReplace2.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/InvalidReplace2.rdz.cbl
@@ -1,0 +1,71 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      *Ok
+       REPLACE ==:item-a:== BY ==A==, ==:item-b:== BY ==B==.
+       01 DATA-:item-a: PIC X.
+       01 DATA-:item-b: PIC X.
+      
+      *Warning
+      *A blank was missing before character"="in column 39.
+      *A blank was assumed.
+       REPLACE ==:item-c:== BY ==C== ,==:item-d:== BY ==D==.
+       01 DATA-:item-c: PIC X.
+       01 DATA-:item-d: PIC X.
+      
+      *Ok
+       REPLACE ==:item-e:== BY ==E==; ==:item-f:== BY ==F==.
+       01 DATA-:item-e: PIC X.
+       01 DATA-:item-f: PIC X.
+      
+      *Warning - accepted by IBM compiler but currently not supported
+      *A blank was missing before character"="in column 39.
+      *A blank was assumed.
+       REPLACE ==:item-g:== BY ==G== ;==:item-h:== BY ==H==.
+       01 DATA-:item-g: PIC X.
+       01 DATA-:item-h: PIC X.
+      
+      *Ok
+       REPLACE ==:item-i:== BY ==I== , ==:item-j:== BY ==J==.
+       01 DATA-:item-i: PIC X.
+       01 DATA-:item-j: PIC X.
+      
+      *Warning
+      *A blank was missing before character"="in column 39.
+      *A blank was assumed.
+       REPLACE ==:item-k:== BY ==K==,==:item-l:== BY ==L==.
+       01 DATA-:item-k: PIC X.
+       01 DATA-:item-l: PIC X.
+      
+      *Ok
+       REPLACE ==:item-m:== BY ==M== ; ==:item-n:== BY ==N==.
+       01 DATA-:item-m: PIC X.
+       01 DATA-:item-n: PIC X.
+      
+      *Warning - accepted by IBM compiler but currently not supported
+      *A blank was missing before character"="in column 39.
+      *A blank was assumed.
+       REPLACE ==:item-o:== BY ==O==;==:item-p:== BY ==P==.
+       01 DATA-:item-o: PIC X.
+       01 DATA-:item-p: PIC X.
+       PROCEDURE DIVISION.
+           DISPLAY DATA-A
+                   DATA-B
+                   DATA-C
+                   DATA-D
+                   DATA-E
+                   DATA-F
+                   DATA-G
+                   DATA-H
+                   DATA-I
+                   DATA-J
+                   DATA-K
+                   DATA-L
+                   DATA-M
+                   DATA-N
+                   DATA-O
+                   DATA-P
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/InvalidReplace2.rdzMix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/InvalidReplace2.rdzMix.txt
@@ -1,0 +1,77 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      *Ok
+       REPLACE ==:item-a:== BY ==A==, ==:item-b:== BY ==B==.
+       01 DATA-:item-a: PIC X.
+       01 DATA-:item-b: PIC X.
+      
+      *Warning
+      *A blank was missing before character"="in column 39.
+      *A blank was assumed.
+Line 13[39,40] <53, Warning, Tokens> - Invalid character found before pseudo-text delimiter "==": ","
+       REPLACE ==:item-c:== BY ==C== ,==:item-d:== BY ==D==.
+       01 DATA-:item-c: PIC X.
+       01 DATA-:item-d: PIC X.
+      
+      *Ok
+       REPLACE ==:item-e:== BY ==E==; ==:item-f:== BY ==F==.
+       01 DATA-:item-e: PIC X.
+       01 DATA-:item-f: PIC X.
+      
+      *Warning - accepted by IBM compiler but currently not supported
+      *A blank was missing before character"="in column 39.
+      *A blank was assumed.
+Line 25[38,38] <3, Error, Tokens> - Semicolon separator should be followed by a space
+Line 25[39,40] <53, Warning, Tokens> - Invalid character found before pseudo-text delimiter "==": ";"
+       REPLACE ==:item-g:== BY ==G== ;==:item-h:== BY ==H==.
+       01 DATA-:item-g: PIC X.
+       01 DATA-:item-h: PIC X.
+      
+      *Ok
+       REPLACE ==:item-i:== BY ==I== , ==:item-j:== BY ==J==.
+       01 DATA-:item-i: PIC X.
+       01 DATA-:item-j: PIC X.
+      
+      *Warning
+      *A blank was missing before character"="in column 39.
+      *A blank was assumed.
+Line 37[38,39] <53, Warning, Tokens> - Invalid character found before pseudo-text delimiter "==": ","
+       REPLACE ==:item-k:== BY ==K==,==:item-l:== BY ==L==.
+       01 DATA-:item-k: PIC X.
+       01 DATA-:item-l: PIC X.
+      
+      *Ok
+       REPLACE ==:item-m:== BY ==M== ; ==:item-n:== BY ==N==.
+       01 DATA-:item-m: PIC X.
+       01 DATA-:item-n: PIC X.
+      
+      *Warning - accepted by IBM compiler but currently not supported
+      *A blank was missing before character"="in column 39.
+      *A blank was assumed.
+Line 49[37,37] <3, Error, Tokens> - Semicolon separator should be followed by a space
+Line 49[38,39] <53, Warning, Tokens> - Invalid character found before pseudo-text delimiter "==": ";"
+       REPLACE ==:item-o:== BY ==O==;==:item-p:== BY ==P==.
+       01 DATA-:item-o: PIC X.
+       01 DATA-:item-p: PIC X.
+       PROCEDURE DIVISION.
+           DISPLAY DATA-A
+                   DATA-B
+                   DATA-C
+                   DATA-D
+                   DATA-E
+                   DATA-F
+                   DATA-G
+                   DATA-H
+                   DATA-I
+                   DATA-J
+                   DATA-K
+                   DATA-L
+                   DATA-M
+                   DATA-N
+                   DATA-O
+                   DATA-P
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment.rdz.cbl
@@ -1,0 +1,182 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID.     TCOFM117.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER. IBM-370.
+       OBJECT-COMPUTER. IBM-370.
+       SPECIAL-NAMES.
+      * Syntax is:
+      *  Environment-name IS Mnemonic-name
+      *  - Valid values of Environment-name are listed in IBM
+      *    specifications
+      *  - Mnemonic-name is an user defined word
+      
+      
+      *    can only be used in ACCEPT
+           SYSIN  is SYSIN-M
+      *Ko define same environment-name twice
+      *A duplicate"SYSIN"clause was found.  Scanning was resumed at the
+      *next area"A"item or the start of the next clause.
+           SYSIN  is SYSIN-M2
+           SYSIPT    SYSIPT-M
+      
+      *    can only be used in DISPLAY
+           SYSOUT   is SYSOUT-M
+           SYSLIST     SYSLIST-M
+           SYSLST   is SYSLST-M
+           SYSPUNCH is SYSPUNCH-M
+           SYSPCH   is SYSPCH-M
+      
+      *    Ok in ACCEPT and DISPLAY
+           CONSOLE is CONSOLE-M
+      
+      *    Ok in WRITE ADVANCING
+           C01 is C01-M
+           C02    C02-M
+           C03 is C03-M
+      
+      *    KO syntax only for UPSI switch
+      *    Will be picked up by ANTLR but stops the whole SPECIAL-NAMES
+      *    CodeElement parsing.
+      *    C04 is C04-M
+      *      ON STATUS IS C04-M-ON
+      *      OFF STATUS IS C04-M-OFF
+      
+      *    KO syntax only for UPSI switch
+      *    Will be picked up by ANTLR but stops the whole SPECIAL-NAMES
+      *    CodeElement parsing.
+      *    C05
+      *      ON STATUS IS C05-ON
+      *      OFF STATUS IS C05-OFF
+      
+      
+           CSP    IS CSP-M
+           S01    IS S01-M
+           S02       S02-M
+           S03       S03-M
+           S04    IS S04-M
+      *Ko reuse same mnemonic-name
+      *Mnemonic-name"S04-M"was previously defined.  The duplicate
+      *environment-name clause was discarded.
+           S05    IS S04-M
+           AFP-5A IS AFP-5A-M
+      
+      
+           decimal-point is comma.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+               SELECT  FSYS020  ASSIGN TO UT-S-SYS020.
+       DATA DIVISION.
+       FILE SECTION.
+       FD  FSYS020
+           LABEL RECORD STANDARD
+           RECORDING MODE F
+           BLOCK 0 RECORDS
+           DATA RECORD E-EDIT.
+       01  E-EDIT                 PIC X(150).
+      *-----------------------*
+       WORKING-STORAGE SECTION.
+       01 Var1 pic X(08).
+      *Ko The name"S03-M"was used for an item that was
+      *   not defined as a data-name. References to this name
+      *   may be resolved incorrectly.
+       01 S03-M pic X.
+      
+       PROCEDURE DIVISION.
+      
+      
+      *-ACCEPT--------------------
+      *OK usage of environment-name
+           accept Var1 from SYSIN
+           accept Var1 from SYSIPT
+           accept Var1 from CONSOLE
+      
+      *OK usage of mnemonic-name
+           accept Var1 from SYSIN-M
+           accept Var1 from SYSIPT-M
+           accept Var1 from CONSOLE-M
+      
+      *-DISPLAY-------------------
+      *OK usage of environment-name
+           display " " upon  SYSOUT
+           display " " upon  SYSLIST
+           display " " upon  SYSLST
+           display " " upon  SYSPUNCH
+           display " " upon  SYSPCH
+           display " " upon  CONSOLE
+      
+      *OK usage of mnemonic-name
+           display " " upon  SYSOUT-M
+           display " " upon  SYSLIST-M
+           display " " upon  SYSLST-M
+           display " " upon  SYSPUNCH-M
+           display " " upon  SYSPCH-M
+           display " " upon  CONSOLE-M
+      
+      
+      *KO mnemonic-name cannot be used as variables
+      *    "SYSIN"was not defined as a data-name.
+      *    The statement was discarded.
+           display SYSIN
+           display SYSIPT
+           display CONSOLE
+           display SYSOUT
+           display SYSLIST
+           display SYSLST
+           display SYSPUNCH
+           display SYSPCH
+           display CONSOLE
+      
+      *KO mnemonic-name cannot be used as variables
+      *    "SYSIN-M"was not defined as a data-name.
+      *    The statement was discarded.
+           display SYSIN-M
+           display SYSIPT-M
+           display CONSOLE-M
+           display SYSOUT-M
+           display SYSLIST-M
+           display SYSLST-M
+           display SYSPUNCH-M
+           display SYSPCH-M
+           display CONSOLE-M
+      
+      *    Presence of Open before write is not currently checked
+      *    by our parser
+           OPEN OUTPUT FSYS020
+           write E-EDIT after advancing C01-M
+           write E-EDIT after advancing C02-M
+           write E-EDIT after advancing C03-M
+      
+           write E-EDIT after advancing S01-M
+           write E-EDIT after advancing S02-M
+      *    KO "S03-M"was not a uniquely defined name.
+      *      The definition to be used could not be determined
+      *      from the context.  The reference to the name was discarded.
+      *      Ambiguous reference to S03-M
+           write E-EDIT after advancing S03-M
+      *    Warning Ambiguous reference to S04-M
+      *    Not supported by our parser, but error is reported
+      *    on data definition.
+           write E-EDIT after advancing S04-M
+      *    KO "S05-M"was not defined as a data-name.
+      *      The statement was discarded.
+      *      Unable to resolve reference to S05-M
+           write E-EDIT after advancing S05-M
+           CLOSE FSYS020
+      
+           goback
+           .
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Nested.
+       PROCEDURE DIVISION.
+      *OK usage of mnemonic-name defined in parent program
+           display " " upon  SYSOUT-M
+           display " " upon  SYSLIST-M
+           display " " upon  SYSLST-M
+           display " " upon  SYSPUNCH-M
+           display " " upon  SYSPCH-M
+           display " " upon  CONSOLE-M
+           goback
+           .
+       END PROGRAM Nested.
+       end program TCOFM117.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment.rdzPGM.txt
@@ -1,0 +1,58 @@
+--- Diagnostics ---
+Line 20[12,16] <27, Error, Syntax> - Syntax error : A duplicate 'SYSIN' clause was found. RuleStack=codeElement>specialNamesParagraph>environmentNameClause>environmentName,  OffendingSymbol=[12,16:SYSIN]<UserDefinedWord>
+Line 61[22,26] <27, Error, Syntax> - Syntax error : Mnemonic name 'S04-M' was previously defined. RuleStack=codeElement>specialNamesParagraph>environmentNameClause>mnemonicForEnvironmentNameDefinition,  OffendingSymbol=[22,26:S04-M]<UserDefinedWord>
+Line 83[8,22] <27, Error, Syntax> - Syntax error : The name 'S03-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 120[20,24] <30, Error, Semantics> - Semantic error: Symbol SYSIN is not referenced OffendingSymbol=[20,24:SYSIN]<UserDefinedWord>
+Line 121[20,25] <30, Error, Semantics> - Semantic error: Symbol SYSIPT is not referenced OffendingSymbol=[20,25:SYSIPT]<UserDefinedWord>
+Line 122[20,26] <30, Error, Semantics> - Semantic error: Symbol CONSOLE is not referenced OffendingSymbol=[20,26:CONSOLE]<UserDefinedWord>
+Line 123[20,25] <30, Error, Semantics> - Semantic error: Symbol SYSOUT is not referenced OffendingSymbol=[20,25:SYSOUT]<UserDefinedWord>
+Line 124[20,26] <30, Error, Semantics> - Semantic error: Symbol SYSLIST is not referenced OffendingSymbol=[20,26:SYSLIST]<UserDefinedWord>
+Line 125[20,25] <30, Error, Semantics> - Semantic error: Symbol SYSLST is not referenced OffendingSymbol=[20,25:SYSLST]<UserDefinedWord>
+Line 126[20,27] <30, Error, Semantics> - Semantic error: Symbol SYSPUNCH is not referenced OffendingSymbol=[20,27:SYSPUNCH]<UserDefinedWord>
+Line 127[20,25] <30, Error, Semantics> - Semantic error: Symbol SYSPCH is not referenced OffendingSymbol=[20,25:SYSPCH]<UserDefinedWord>
+Line 128[20,26] <30, Error, Semantics> - Semantic error: Symbol CONSOLE is not referenced OffendingSymbol=[20,26:CONSOLE]<UserDefinedWord>
+Line 133[20,26] <30, Error, Semantics> - Semantic error: Symbol SYSIN-M is not referenced OffendingSymbol=[20,26:SYSIN-M]<UserDefinedWord>
+Line 134[20,27] <30, Error, Semantics> - Semantic error: Symbol SYSIPT-M is not referenced OffendingSymbol=[20,27:SYSIPT-M]<UserDefinedWord>
+Line 135[20,28] <30, Error, Semantics> - Semantic error: Symbol CONSOLE-M is not referenced OffendingSymbol=[20,28:CONSOLE-M]<UserDefinedWord>
+Line 136[20,27] <30, Error, Semantics> - Semantic error: Symbol SYSOUT-M is not referenced OffendingSymbol=[20,27:SYSOUT-M]<UserDefinedWord>
+Line 137[20,28] <30, Error, Semantics> - Semantic error: Symbol SYSLIST-M is not referenced OffendingSymbol=[20,28:SYSLIST-M]<UserDefinedWord>
+Line 138[20,27] <30, Error, Semantics> - Semantic error: Symbol SYSLST-M is not referenced OffendingSymbol=[20,27:SYSLST-M]<UserDefinedWord>
+Line 139[20,29] <30, Error, Semantics> - Semantic error: Symbol SYSPUNCH-M is not referenced OffendingSymbol=[20,29:SYSPUNCH-M]<UserDefinedWord>
+Line 140[20,27] <30, Error, Semantics> - Semantic error: Symbol SYSPCH-M is not referenced OffendingSymbol=[20,27:SYSPCH-M]<UserDefinedWord>
+Line 141[20,28] <30, Error, Semantics> - Semantic error: Symbol CONSOLE-M is not referenced OffendingSymbol=[20,28:CONSOLE-M]<UserDefinedWord>
+Line 156[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'S03-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:S03-M]<UserDefinedWord>
+Line 164[41,45] <30, Error, Semantics> - Semantic error: Unable to resolve reference to 'S05-M'. OffendingSymbol=[41,45:S05-M]<UserDefinedWord>
+
+--- Program ---
+PROGRAM: TCOFM117 common:False initial:False recursive:False
+ author: ? written: ? compiled: ? installation: ? security: ?
+--- Intrinsic:Namespace:Program:Global:Local
+-- DATA --------
+  FSYS020:?
+  E-EDIT:Alphanumeric
+  Var1:Alphanumeric
+  S03-M:Alphanumeric
+-- ENVIRONMENT MNEMONICS ---
+  SYSIN-M
+  SYSIPT-M
+  SYSOUT-M
+  SYSLIST-M
+  SYSLST-M
+  SYSPUNCH-M
+  SYSPCH-M
+  CONSOLE-M
+  C01-M
+  C02-M
+  C03-M
+  CSP-M
+  S01-M
+  S02-M
+  S03-M
+  S04-M
+  AFP-5A-M
+--- Intrinsic
+-- TYPES -------
+  BOOL:BOOL
+  DATE:DATE
+  CURRENCY:CURRENCY
+  STRING:STRING

--- a/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment_Nested1.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment_Nested1.rdz.cbl
@@ -1,0 +1,99 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOFM117.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER. IBM-370.
+       OBJECT-COMPUTER. IBM-370.
+       SPECIAL-NAMES.
+      *    can only be used in ACCEPT
+           SYSIN    is SYSIN-M
+           SYSIPT      SYSIPT-M
+
+      *    can only be used in DISPLAY
+           SYSOUT   is SYSOUT-M
+           SYSLIST     SYSLIST-M
+           SYSLST   is SYSLST-M
+           SYSPUNCH    SYSPUNCH-M
+           SYSPCH   is SYSPCH-M
+
+      *    Ok in ACCEPT and DISPLAY
+           CONSOLE     CONSOLE-M
+
+      *    Ok in WRITE ADVANCING
+           C01      is C01-M
+           C02         C02-M
+           C03      is C03-M
+           C04         C04-M
+           C05      is C05-M
+           C06         C06-M
+           C07      is C07-M
+           C08         C08-M
+           C09      is C09-M
+           C10         C10-M
+           C11      is C11-M
+           C12         C12-M
+           CSP      is CSP-M
+           S01         S01-M
+           S02      is S02-M
+           S03         S03-M
+           S04      is S04-M
+           S05         S05-M
+           AFP-5A   is AFP-5A-M
+           decimal-point is comma.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT  FSYS020  ASSIGN TO UT-S-SYS020.
+       DATA DIVISION.
+       FILE SECTION.
+       FD  FSYS020
+           LABEL RECORD STANDARD
+           RECORDING MODE F
+           BLOCK 0 RECORDS
+           DATA RECORD E-EDIT.
+       01  E-EDIT                 PIC X(150) global.
+       PROCEDURE DIVISION.
+           OPEN OUTPUT FSYS020
+           CALL "Nested"
+           CLOSE FSYS020
+           goback
+           .
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Nested.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 pic x.
+       PROCEDURE DIVISION.
+      * All statements are OK, mnemonics from parent program
+      * are all visible from nested.
+           accept var1 from SYSIN-M
+           accept var1 from SYSIPT-M
+           display var1 upon SYSOUT-M
+           display var1 upon SYSLIST-M
+           display var1 upon SYSLST-M
+           display var1 upon SYSPUNCH-M
+           display var1 upon SYSPCH-M
+           accept var1 from CONSOLE-M
+           display var1 upon CONSOLE-M
+           write E-EDIT after advancing C01-M
+           write E-EDIT after advancing C02-M
+           write E-EDIT after advancing C03-M
+           write E-EDIT after advancing C04-M
+           write E-EDIT after advancing C05-M
+           write E-EDIT after advancing C06-M
+           write E-EDIT after advancing C07-M
+           write E-EDIT after advancing C08-M
+           write E-EDIT after advancing C09-M
+           write E-EDIT after advancing C10-M
+           write E-EDIT after advancing C11-M
+           write E-EDIT after advancing C12-M
+           write E-EDIT after advancing CSP-M
+           write E-EDIT after advancing S01-M
+           write E-EDIT after advancing S02-M
+           write E-EDIT after advancing S03-M
+           write E-EDIT after advancing S04-M
+           write E-EDIT after advancing S05-M
+           write E-EDIT after advancing AFP-5A-M
+           goback
+           .
+       END PROGRAM Nested.
+       end program TCOFM117.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment_Nested1.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment_Nested1.rdzPGM.txt
@@ -1,0 +1,43 @@
+--- Program ---
+PROGRAM: TCOFM117 common:False initial:False recursive:False
+ author: ? written: ? compiled: ? installation: ? security: ?
+--- Intrinsic:Namespace:Program:Global:Local
+-- DATA --------
+  FSYS020:?
+--- Intrinsic:Namespace:Program:Global
+-- DATA --------
+  E-EDIT:Alphanumeric
+-- ENVIRONMENT MNEMONICS ---
+  SYSIN-M
+  SYSIPT-M
+  SYSOUT-M
+  SYSLIST-M
+  SYSLST-M
+  SYSPUNCH-M
+  SYSPCH-M
+  CONSOLE-M
+  C01-M
+  C02-M
+  C03-M
+  C04-M
+  C05-M
+  C06-M
+  C07-M
+  C08-M
+  C09-M
+  C10-M
+  C11-M
+  C12-M
+  CSP-M
+  S01-M
+  S02-M
+  S03-M
+  S04-M
+  S05-M
+  AFP-5A-M
+--- Intrinsic
+-- TYPES -------
+  BOOL:BOOL
+  DATE:DATE
+  CURRENCY:CURRENCY
+  STRING:STRING

--- a/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment_Nested2.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment_Nested2.rdz.cbl
@@ -1,0 +1,126 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOFM117.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER. IBM-370.
+       OBJECT-COMPUTER. IBM-370.
+       SPECIAL-NAMES.
+      *    can only be used in ACCEPT
+           SYSIN    is SYSIN-M
+           SYSIPT      SYSIPT-M
+
+      *    can only be used in DISPLAY
+           SYSOUT   is SYSOUT-M
+           SYSLIST     SYSLIST-M
+           SYSLST   is SYSLST-M
+           SYSPUNCH    SYSPUNCH-M
+           SYSPCH   is SYSPCH-M
+
+      *    Ok in ACCEPT and DISPLAY
+           CONSOLE     CONSOLE-M
+
+      *    Ok in WRITE ADVANCING
+           C01      is C01-M
+           C02         C02-M
+           C03      is C03-M
+           C04         C04-M
+           C05      is C05-M
+           C06         C06-M
+           C07      is C07-M
+           C08         C08-M
+           C09      is C09-M
+           C10         C10-M
+           C11      is C11-M
+           C12         C12-M
+           CSP      is CSP-M
+           S01         S01-M
+           S02      is S02-M
+           S03         S03-M
+           S04      is S04-M
+           S05         S05-M
+           AFP-5A   is AFP-5A-M
+           decimal-point is comma.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT  FSYS020  ASSIGN TO UT-S-SYS020.
+       DATA DIVISION.
+       FILE SECTION.
+       FD  FSYS020
+           LABEL RECORD STANDARD
+           RECORDING MODE F
+           BLOCK 0 RECORDS
+           DATA RECORD E-EDIT.
+       01  E-EDIT                 PIC X(150) global.
+       PROCEDURE DIVISION.
+           OPEN OUTPUT FSYS020
+           CALL "Nested"
+           CLOSE FSYS020
+           goback
+           .
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Nested.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 pic x.
+       01 SYSIN-M pic x.
+       01 SYSIPT-M pic x.
+       01 SYSOUT-M pic x.
+       01 SYSLIST-M pic x.
+       01 SYSLST-M pic x.
+       01 SYSPUNCH-M pic x.
+       01 SYSPCH-M pic x.
+       01 CONSOLE-M pic x.
+       01 C01-M pic x.
+       01 C02-M pic x.
+       01 C03-M pic x.
+       01 C04-M pic x.
+       01 C05-M pic x.
+       01 C06-M pic x.
+       01 C07-M pic x.
+       01 C08-M pic x.
+       01 C09-M pic x.
+       01 C10-M pic x.
+       01 C11-M pic x.
+       01 C12-M pic x.
+       01 CSP-M pic x.
+       01 S01-M pic x.
+       01 S02-M pic x.
+       01 S03-M pic x.
+       01 S04-M pic x.
+       01 S05-M pic x.
+       01 AFP-5A-M pic x.
+       PROCEDURE DIVISION.
+      * All statements are KO, variables from nested pgm
+      * hide environment mnemonics from parent.
+           accept var1 from SYSIN-M
+           accept var1 from SYSIPT-M
+           display var1 upon SYSOUT-M
+           display var1 upon SYSLIST-M
+           display var1 upon SYSLST-M
+           display var1 upon SYSPUNCH-M
+           display var1 upon SYSPCH-M
+           accept var1 from CONSOLE-M
+           display var1 upon CONSOLE-M
+           write E-EDIT after advancing C01-M
+           write E-EDIT after advancing C02-M
+           write E-EDIT after advancing C03-M
+           write E-EDIT after advancing C04-M
+           write E-EDIT after advancing C05-M
+           write E-EDIT after advancing C06-M
+           write E-EDIT after advancing C07-M
+           write E-EDIT after advancing C08-M
+           write E-EDIT after advancing C09-M
+           write E-EDIT after advancing C10-M
+           write E-EDIT after advancing C11-M
+           write E-EDIT after advancing C12-M
+           write E-EDIT after advancing CSP-M
+           write E-EDIT after advancing S01-M
+           write E-EDIT after advancing S02-M
+           write E-EDIT after advancing S03-M
+           write E-EDIT after advancing S04-M
+           write E-EDIT after advancing S05-M
+           write E-EDIT after advancing AFP-5A-M
+           goback
+           .
+       END PROGRAM Nested.
+       end program TCOFM117.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment_Nested2.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment_Nested2.rdzPGM.txt
@@ -1,0 +1,73 @@
+--- Diagnostics ---
+Line 95[29,35] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSIN-M', the definition to be used could not be determined from the context. OffendingSymbol=[29,35:SYSIN-M]<UserDefinedWord>
+Line 96[29,36] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSIPT-M', the definition to be used could not be determined from the context. OffendingSymbol=[29,36:SYSIPT-M]<UserDefinedWord>
+Line 97[30,37] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSOUT-M', the definition to be used could not be determined from the context. OffendingSymbol=[30,37:SYSOUT-M]<UserDefinedWord>
+Line 98[30,38] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSLIST-M', the definition to be used could not be determined from the context. OffendingSymbol=[30,38:SYSLIST-M]<UserDefinedWord>
+Line 99[30,37] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSLST-M', the definition to be used could not be determined from the context. OffendingSymbol=[30,37:SYSLST-M]<UserDefinedWord>
+Line 100[30,39] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSPUNCH-M', the definition to be used could not be determined from the context. OffendingSymbol=[30,39:SYSPUNCH-M]<UserDefinedWord>
+Line 101[30,37] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSPCH-M', the definition to be used could not be determined from the context. OffendingSymbol=[30,37:SYSPCH-M]<UserDefinedWord>
+Line 102[29,37] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'CONSOLE-M', the definition to be used could not be determined from the context. OffendingSymbol=[29,37:CONSOLE-M]<UserDefinedWord>
+Line 103[30,38] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'CONSOLE-M', the definition to be used could not be determined from the context. OffendingSymbol=[30,38:CONSOLE-M]<UserDefinedWord>
+Line 104[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C01-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C01-M]<UserDefinedWord>
+Line 105[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C02-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C02-M]<UserDefinedWord>
+Line 106[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C03-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C03-M]<UserDefinedWord>
+Line 107[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C04-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C04-M]<UserDefinedWord>
+Line 108[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C05-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C05-M]<UserDefinedWord>
+Line 109[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C06-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C06-M]<UserDefinedWord>
+Line 110[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C07-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C07-M]<UserDefinedWord>
+Line 111[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C08-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C08-M]<UserDefinedWord>
+Line 112[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C09-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C09-M]<UserDefinedWord>
+Line 113[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C10-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C10-M]<UserDefinedWord>
+Line 114[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C11-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C11-M]<UserDefinedWord>
+Line 115[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C12-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C12-M]<UserDefinedWord>
+Line 116[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'CSP-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:CSP-M]<UserDefinedWord>
+Line 117[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'S01-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:S01-M]<UserDefinedWord>
+Line 118[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'S02-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:S02-M]<UserDefinedWord>
+Line 119[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'S03-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:S03-M]<UserDefinedWord>
+Line 120[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'S04-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:S04-M]<UserDefinedWord>
+Line 121[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'S05-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:S05-M]<UserDefinedWord>
+Line 122[41,48] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'AFP-5A-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,48:AFP-5A-M]<UserDefinedWord>
+
+--- Program ---
+PROGRAM: TCOFM117 common:False initial:False recursive:False
+ author: ? written: ? compiled: ? installation: ? security: ?
+--- Intrinsic:Namespace:Program:Global:Local
+-- DATA --------
+  FSYS020:?
+--- Intrinsic:Namespace:Program:Global
+-- DATA --------
+  E-EDIT:Alphanumeric
+-- ENVIRONMENT MNEMONICS ---
+  SYSIN-M
+  SYSIPT-M
+  SYSOUT-M
+  SYSLIST-M
+  SYSLST-M
+  SYSPUNCH-M
+  SYSPCH-M
+  CONSOLE-M
+  C01-M
+  C02-M
+  C03-M
+  C04-M
+  C05-M
+  C06-M
+  C07-M
+  C08-M
+  C09-M
+  C10-M
+  C11-M
+  C12-M
+  CSP-M
+  S01-M
+  S02-M
+  S03-M
+  S04-M
+  S05-M
+  AFP-5A-M
+--- Intrinsic
+-- TYPES -------
+  BOOL:BOOL
+  DATE:DATE
+  CURRENCY:CURRENCY
+  STRING:STRING

--- a/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment_Nested3.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment_Nested3.rdz.cbl
@@ -1,0 +1,130 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOFM117.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER. IBM-370.
+       OBJECT-COMPUTER. IBM-370.
+       SPECIAL-NAMES.
+      *    can only be used in ACCEPT
+           SYSIN    is SYSIN-M
+           SYSIPT      SYSIPT-M
+
+      *    can only be used in DISPLAY
+           SYSOUT   is SYSOUT-M
+           SYSLIST     SYSLIST-M
+           SYSLST   is SYSLST-M
+           SYSPUNCH    SYSPUNCH-M
+           SYSPCH   is SYSPCH-M
+
+      *    Ok in ACCEPT and DISPLAY
+           CONSOLE     CONSOLE-M
+
+      *    Ok in WRITE ADVANCING
+           C01      is C01-M
+           C02         C02-M
+           C03      is C03-M
+           C04         C04-M
+           C05      is C05-M
+           C06         C06-M
+           C07      is C07-M
+           C08         C08-M
+           C09      is C09-M
+           C10         C10-M
+           C11      is C11-M
+           C12         C12-M
+           CSP      is CSP-M
+           S01         S01-M
+           S02      is S02-M
+           S03         S03-M
+           S04      is S04-M
+           S05         S05-M
+           AFP-5A   is AFP-5A-M
+           decimal-point is comma.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT  FSYS020  ASSIGN TO UT-S-SYS020.
+       DATA DIVISION.
+       FILE SECTION.
+       FD  FSYS020
+           LABEL RECORD STANDARD
+           RECORDING MODE F
+           BLOCK 0 RECORDS
+           DATA RECORD E-EDIT.
+       01  E-EDIT                 PIC X(150) global.
+       WORKING-STORAGE SECTION.
+      * Following variables are KO because they conflict with
+      * previously defined mnemonics.
+       01 SYSIN-M pic x global.
+       01 SYSIPT-M pic x global.
+       01 SYSOUT-M pic x global.
+       01 SYSLIST-M pic x global.
+       01 SYSLST-M pic x global.
+       01 SYSPUNCH-M pic x global.
+       01 SYSPCH-M pic x global.
+       01 CONSOLE-M pic x global.
+       01 C01-M pic x global.
+       01 C02-M pic x global.
+       01 C03-M pic x global.
+       01 C04-M pic x global.
+       01 C05-M pic x global.
+       01 C06-M pic x global.
+       01 C07-M pic x global.
+       01 C08-M pic x global.
+       01 C09-M pic x global.
+       01 C10-M pic x global.
+       01 C11-M pic x global.
+       01 C12-M pic x global.
+       01 CSP-M pic x global.
+       01 S01-M pic x global.
+       01 S02-M pic x global.
+       01 S03-M pic x global.
+       01 S04-M pic x global.
+       01 S05-M pic x global.
+       01 AFP-5A-M pic x global.
+       PROCEDURE DIVISION.
+           OPEN OUTPUT FSYS020
+           CALL "Nested"
+           CLOSE FSYS020
+           goback
+           .
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Nested.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 pic x.
+       PROCEDURE DIVISION.
+      * On IBM compiler, no error is issued on statements
+      * because conflicting variables are discarded from Global table
+      * In our parser, they are still visible here hence the errors.
+           accept var1 from SYSIN-M
+           accept var1 from SYSIPT-M
+           display var1 upon SYSOUT-M
+           display var1 upon SYSLIST-M
+           display var1 upon SYSLST-M
+           display var1 upon SYSPUNCH-M
+           display var1 upon SYSPCH-M
+           accept var1 from CONSOLE-M
+           display var1 upon CONSOLE-M
+           write E-EDIT after advancing C01-M
+           write E-EDIT after advancing C02-M
+           write E-EDIT after advancing C03-M
+           write E-EDIT after advancing C04-M
+           write E-EDIT after advancing C05-M
+           write E-EDIT after advancing C06-M
+           write E-EDIT after advancing C07-M
+           write E-EDIT after advancing C08-M
+           write E-EDIT after advancing C09-M
+           write E-EDIT after advancing C10-M
+           write E-EDIT after advancing C11-M
+           write E-EDIT after advancing C12-M
+           write E-EDIT after advancing CSP-M
+           write E-EDIT after advancing S01-M
+           write E-EDIT after advancing S02-M
+           write E-EDIT after advancing S03-M
+           write E-EDIT after advancing S04-M
+           write E-EDIT after advancing S05-M
+           write E-EDIT after advancing AFP-5A-M
+           goback
+           .
+       END PROGRAM Nested.
+       end program TCOFM117.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment_Nested3.rdzPGM.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/MnemonicsForEnvironment_Nested3.rdzPGM.txt
@@ -1,0 +1,127 @@
+--- Diagnostics ---
+Line 57[8,31] <27, Error, Syntax> - Syntax error : The name 'SYSIN-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 58[8,32] <27, Error, Syntax> - Syntax error : The name 'SYSIPT-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 59[8,32] <27, Error, Syntax> - Syntax error : The name 'SYSOUT-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 60[8,33] <27, Error, Syntax> - Syntax error : The name 'SYSLIST-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 61[8,32] <27, Error, Syntax> - Syntax error : The name 'SYSLST-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 62[8,34] <27, Error, Syntax> - Syntax error : The name 'SYSPUNCH-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 63[8,32] <27, Error, Syntax> - Syntax error : The name 'SYSPCH-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 64[8,33] <27, Error, Syntax> - Syntax error : The name 'CONSOLE-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 65[8,29] <27, Error, Syntax> - Syntax error : The name 'C01-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 66[8,29] <27, Error, Syntax> - Syntax error : The name 'C02-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 67[8,29] <27, Error, Syntax> - Syntax error : The name 'C03-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 68[8,29] <27, Error, Syntax> - Syntax error : The name 'C04-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 69[8,29] <27, Error, Syntax> - Syntax error : The name 'C05-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 70[8,29] <27, Error, Syntax> - Syntax error : The name 'C06-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 71[8,29] <27, Error, Syntax> - Syntax error : The name 'C07-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 72[8,29] <27, Error, Syntax> - Syntax error : The name 'C08-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 73[8,29] <27, Error, Syntax> - Syntax error : The name 'C09-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 74[8,29] <27, Error, Syntax> - Syntax error : The name 'C10-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 75[8,29] <27, Error, Syntax> - Syntax error : The name 'C11-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 76[8,29] <27, Error, Syntax> - Syntax error : The name 'C12-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 77[8,29] <27, Error, Syntax> - Syntax error : The name 'CSP-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 78[8,29] <27, Error, Syntax> - Syntax error : The name 'S01-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 79[8,29] <27, Error, Syntax> - Syntax error : The name 'S02-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 80[8,29] <27, Error, Syntax> - Syntax error : The name 'S03-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 81[8,29] <27, Error, Syntax> - Syntax error : The name 'S04-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 82[8,29] <27, Error, Syntax> - Syntax error : The name 'S05-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 83[8,32] <27, Error, Syntax> - Syntax error : The name 'AFP-5A-M' is already used to define a mnemonic for environment name. Rename this variable or the mnemonic to avoid ambiguous references.
+Line 99[29,35] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSIN-M', the definition to be used could not be determined from the context. OffendingSymbol=[29,35:SYSIN-M]<UserDefinedWord>
+Line 100[29,36] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSIPT-M', the definition to be used could not be determined from the context. OffendingSymbol=[29,36:SYSIPT-M]<UserDefinedWord>
+Line 101[30,37] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSOUT-M', the definition to be used could not be determined from the context. OffendingSymbol=[30,37:SYSOUT-M]<UserDefinedWord>
+Line 102[30,38] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSLIST-M', the definition to be used could not be determined from the context. OffendingSymbol=[30,38:SYSLIST-M]<UserDefinedWord>
+Line 103[30,37] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSLST-M', the definition to be used could not be determined from the context. OffendingSymbol=[30,37:SYSLST-M]<UserDefinedWord>
+Line 104[30,39] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSPUNCH-M', the definition to be used could not be determined from the context. OffendingSymbol=[30,39:SYSPUNCH-M]<UserDefinedWord>
+Line 105[30,37] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'SYSPCH-M', the definition to be used could not be determined from the context. OffendingSymbol=[30,37:SYSPCH-M]<UserDefinedWord>
+Line 106[29,37] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'CONSOLE-M', the definition to be used could not be determined from the context. OffendingSymbol=[29,37:CONSOLE-M]<UserDefinedWord>
+Line 107[30,38] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'CONSOLE-M', the definition to be used could not be determined from the context. OffendingSymbol=[30,38:CONSOLE-M]<UserDefinedWord>
+Line 108[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C01-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C01-M]<UserDefinedWord>
+Line 109[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C02-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C02-M]<UserDefinedWord>
+Line 110[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C03-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C03-M]<UserDefinedWord>
+Line 111[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C04-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C04-M]<UserDefinedWord>
+Line 112[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C05-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C05-M]<UserDefinedWord>
+Line 113[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C06-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C06-M]<UserDefinedWord>
+Line 114[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C07-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C07-M]<UserDefinedWord>
+Line 115[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C08-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C08-M]<UserDefinedWord>
+Line 116[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C09-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C09-M]<UserDefinedWord>
+Line 117[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C10-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C10-M]<UserDefinedWord>
+Line 118[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C11-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C11-M]<UserDefinedWord>
+Line 119[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'C12-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:C12-M]<UserDefinedWord>
+Line 120[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'CSP-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:CSP-M]<UserDefinedWord>
+Line 121[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'S01-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:S01-M]<UserDefinedWord>
+Line 122[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'S02-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:S02-M]<UserDefinedWord>
+Line 123[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'S03-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:S03-M]<UserDefinedWord>
+Line 124[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'S04-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:S04-M]<UserDefinedWord>
+Line 125[41,45] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'S05-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,45:S05-M]<UserDefinedWord>
+Line 126[41,48] <30, Error, Semantics> - Semantic error: Ambiguous reference to 'AFP-5A-M', the definition to be used could not be determined from the context. OffendingSymbol=[41,48:AFP-5A-M]<UserDefinedWord>
+
+--- Program ---
+PROGRAM: TCOFM117 common:False initial:False recursive:False
+ author: ? written: ? compiled: ? installation: ? security: ?
+--- Intrinsic:Namespace:Program:Global:Local
+-- DATA --------
+  FSYS020:?
+--- Intrinsic:Namespace:Program:Global
+-- DATA --------
+  E-EDIT:Alphanumeric
+  SYSIN-M:Alphanumeric
+  SYSIPT-M:Alphanumeric
+  SYSOUT-M:Alphanumeric
+  SYSLIST-M:Alphanumeric
+  SYSLST-M:Alphanumeric
+  SYSPUNCH-M:Alphanumeric
+  SYSPCH-M:Alphanumeric
+  CONSOLE-M:Alphanumeric
+  C01-M:Alphanumeric
+  C02-M:Alphanumeric
+  C03-M:Alphanumeric
+  C04-M:Alphanumeric
+  C05-M:Alphanumeric
+  C06-M:Alphanumeric
+  C07-M:Alphanumeric
+  C08-M:Alphanumeric
+  C09-M:Alphanumeric
+  C10-M:Alphanumeric
+  C11-M:Alphanumeric
+  C12-M:Alphanumeric
+  CSP-M:Alphanumeric
+  S01-M:Alphanumeric
+  S02-M:Alphanumeric
+  S03-M:Alphanumeric
+  S04-M:Alphanumeric
+  S05-M:Alphanumeric
+  AFP-5A-M:Alphanumeric
+-- ENVIRONMENT MNEMONICS ---
+  SYSIN-M
+  SYSIPT-M
+  SYSOUT-M
+  SYSLIST-M
+  SYSLST-M
+  SYSPUNCH-M
+  SYSPCH-M
+  CONSOLE-M
+  C01-M
+  C02-M
+  C03-M
+  C04-M
+  C05-M
+  C06-M
+  C07-M
+  C08-M
+  C09-M
+  C10-M
+  C11-M
+  C12-M
+  CSP-M
+  S01-M
+  S02-M
+  S03-M
+  S04-M
+  S05-M
+  AFP-5A-M
+--- Intrinsic
+-- TYPES -------
+  BOOL:BOOL
+  DATE:DATE
+  CURRENCY:CURRENCY
+  STRING:STRING

--- a/TypeCobol.Test/Parser/Scanner/ResultFiles/AlphanumericLiterals-continuations.txt
+++ b/TypeCobol.Test/Parser/Scanner/ResultFiles/AlphanumericLiterals-continuations.txt
@@ -106,6 +106,7 @@ Line 0[5,6] <22, Error, Tokens> - The alphanumeric literal was not properly cont
 -- Line 27 --
 [2,5:    ]<SpaceSeparator>
 [6,19:"and titi11c' ]<AlphanumericLiteral>(",Y,N){and titi11c' }
+Line 0[6,19] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
 
 -- Line 28 --
 =>continued:[1,7:'toto  "and titi11d']<AlphanumericLiteral>(',Y,Y){toto  "and titi11d}

--- a/TypeCobol.Test/Parser/Scanner/ResultFiles/AlphanumericLiterals1.txt
+++ b/TypeCobol.Test/Parser/Scanner/ResultFiles/AlphanumericLiterals1.txt
@@ -10,20 +10,20 @@
 -- Line 2 --
 [1,4:"ok"]<AlphanumericLiteral>(",Y,Y){ok}
 [6,14:"sans fin]<AlphanumericLiteral>(",Y,N){sans fin}
-Line 0[0,0] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 0[6,14] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
 
 -- Line 3 --
 [1,4:'ok']<AlphanumericLiteral>(',Y,Y){ok}
 [6,14:'sans fin]<AlphanumericLiteral>(',Y,N){sans fin}
-Line 0[0,0] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 0[6,14] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
 
 -- Line 4 --
 [1,1:"]<AlphanumericLiteral>(",Y,N){}
-Line 0[0,0] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 0[1,1] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
 
 -- Line 5 --
 [1,1:']<AlphanumericLiteral>(',Y,N){}
-Line 0[0,0] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 0[1,1] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
 
 -- Line 6 --
 [1,6:"toto"]<AlphanumericLiteral>(",Y,Y){toto}

--- a/TypeCobol.Test/Parser/Scanner/ResultFiles/Debug-continuations.txt
+++ b/TypeCobol.Test/Parser/Scanner/ResultFiles/Debug-continuations.txt
@@ -3,7 +3,7 @@
 
 -- Line 2 --
 [6,66:'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB]<AlphanumericLiteral>(',Y,N){BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB}
-Line 0[0,0] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 0[6,66] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
 
 -- Line 3 --
 [3,66:   'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC]<CommentLine>

--- a/TypeCobol.Test/Parser/Scanner/ResultFiles/NumericLiterals.txt
+++ b/TypeCobol.Test/Parser/Scanner/ResultFiles/NumericLiterals.txt
@@ -54,3 +54,7 @@ Line 0[65,68] <16, Error, Tokens> - Invalid numeric literal format : expecting i
 [2,9:-.321E18]<FloatingPointLiteral>{-321|3>-0.321E18>-3.21E+17}
 [10,10+:.]<PeriodSeparator>
 
+-- Line 8 --
+[1,1:+]<InvalidToken>
+[2,2+:.]<PeriodSeparator>
+

--- a/TypeCobol.Test/Parser/Scanner/TestTokenTypes.cs
+++ b/TypeCobol.Test/Parser/Scanner/TestTokenTypes.cs
@@ -180,7 +180,8 @@ namespace TypeCobol.Test.Parser.Scanner
                 "1234537",
                 "+1234567",
                 ".1234567",
-                " -.321E18."
+                " -.321E18.",
+                "+."
             };
             string result = ScannerUtils.ScanLines(testLines);
             ScannerUtils.CheckWithResultFile(result, testName);

--- a/TypeCobol/AntlrGrammar/CobolCodeElements.g4
+++ b/TypeCobol/AntlrGrammar/CobolCodeElements.g4
@@ -7263,8 +7263,8 @@ unstringStatementEnd: END_UNSTRING;
 writeStatement:
 	WRITE recordName (FROM sendingField=variable1)?
 	((BEFORE | AFTER) ADVANCING? (
-		(numberOfLines=integerVariable1 (LINE | LINES)?)  | 
-		 mnemonicForEnvironmentNameReference              | 
+		integerVariableIdentifierOrMnemonicForEnvironmentNameReference | 
+		(numberOfLines=integerVariable1 (LINE | LINES)?)               | 
 		 PAGE                                             )? )?;
 
 writeStatementEnd: END_WRITE;

--- a/TypeCobol/AntlrGrammar/CobolWords.g4
+++ b/TypeCobol/AntlrGrammar/CobolWords.g4
@@ -1355,7 +1355,7 @@ functionNameReference: UserDefinedWord;
 
 mnemonicForEnvironmentNameDefinition: UserDefinedWord;
 
-mnemonicForEnvironmentNameReference: UserDefinedWord;
+integerVariableIdentifierOrMnemonicForEnvironmentNameReference: UserDefinedWord;
 
 // [Type ambiguity] at this parsing stage
 mnemonicForEnvironmentNameReferenceOrEnvironmentName: externalNameOrSymbolReference4;

--- a/TypeCobol/Compiler/CodeElements/Expressions/StorageArea.cs
+++ b/TypeCobol/Compiler/CodeElements/Expressions/StorageArea.cs
@@ -137,16 +137,6 @@ namespace TypeCobol.Compiler.CodeElements
         [NotNull]
 		public SubscriptExpression[] Subscripts { get; }
 
-        /// <summary>Ambiguities in the grammar in the first phase of parsing</summary>
-		public SymbolType AlternativeSymbolType {
-			set {
-				if (value == SymbolType.IndexName) Kind = StorageAreaKind.DataOrConditionOrIndex;
-                else Kind = StorageAreaKind.DataOrConditionOrAlternativeSymbolReference;
-				alternativeSymbolType = value;
-			}
-			get { return alternativeSymbolType; }
-		}
-		private SymbolType alternativeSymbolType;
 
         public override bool AcceptASTVisitor(IASTVisitor astVisitor) {
             return base.AcceptASTVisitor(astVisitor) && astVisitor.Visit(this)

--- a/TypeCobol/Compiler/CodeElements/Statement/WriteStatement.cs
+++ b/TypeCobol/Compiler/CodeElements/Statement/WriteStatement.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using TypeCobol.Compiler.CodeElements.Expressions;
-
-namespace TypeCobol.Compiler.CodeElements
+﻿namespace TypeCobol.Compiler.CodeElements
 {
 	/// <summary>
 	/// p449:
@@ -85,12 +82,7 @@ namespace TypeCobol.Compiler.CodeElements
 		/// 3. If the ADVANCING phrase is omitted, LINAGE-COUNTER is increased by 1.
 		/// 4. When the device is repositioned to the first available line of a new page,
 		/// LINAGE-COUNTER is reset to 1.
-		/// </summary>
-		public IntegerVariable ByNumberOfLines { get; set; }
-
-		/// <summary>
-		/// p451:
-		/// When the ADVANCING phrase is specified, the following rules apply:
+		///
 		/// (...)
 		/// 7. When mnemonic-name is specified, a skip to channels 1 through 12, or space
 		/// suppression, takes place. mnemonic-name must be equated with
@@ -99,7 +91,7 @@ namespace TypeCobol.Compiler.CodeElements
 		/// card punch file. When using stacker selection, WRITE AFTER ADVANCING
 		/// must be used.
 		/// </summary>
-		public SymbolReference ByMnemonicForEnvironmentName { get; set; }
+		public IntegerVariable ByNumberOfLinesOrByMnemonicForEnvironmentName { get; set; }
 
 		/// <summary>
 		/// p451:
@@ -119,7 +111,7 @@ namespace TypeCobol.Compiler.CodeElements
         {
             return base.VisitCodeElement(astVisitor) && astVisitor.Visit(this)
                    && this.ContinueVisitToChildren(astVisitor, RecordName, FromSendingField,
-                   WriteBeforeAdvancing, WriteAfterAdvancing, ByNumberOfLines, ByMnemonicForEnvironmentName, ByLogicalPage);
+                   WriteBeforeAdvancing, WriteAfterAdvancing, ByNumberOfLinesOrByMnemonicForEnvironmentName, ByLogicalPage);
         }
     }
 }

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -89,7 +89,7 @@ namespace TypeCobol.Compiler.CodeModel
         }
 
         [NotNull]
-        private static List<T> GetFromTable<T>(string head, IDictionary<string, List<T>> table) where T : Node
+        private static List<T> GetFromTable<T>(string head, IDictionary<string, List<T>> table)
         {
             if (head != null)
             {
@@ -156,7 +156,7 @@ namespace TypeCobol.Compiler.CodeModel
             }
             if (!symbol.IsPartOfATypeDef)
             {
-                Add(DataEntries, symbol);
+                AddNode(DataEntries, symbol);
             }
             else
             {
@@ -174,7 +174,7 @@ namespace TypeCobol.Compiler.CodeModel
             Debug.Assert(!(data is TypeDefinition)); 
 
             //Add symbol to the dictionary
-            Add(this.DataTypeEntries, data);
+            AddNode(this.DataTypeEntries, data);
         }
 
         public IEnumerable<DataDefinition> GetVariables(SymbolReference symbolReference)
@@ -710,7 +710,7 @@ namespace TypeCobol.Compiler.CodeModel
 
         internal void AddSection(Section section)
         {
-            Add(Sections, section);
+            AddNode(Sections, section);
         }
 
         public IList<Section> GetSection(string name)
@@ -730,7 +730,7 @@ namespace TypeCobol.Compiler.CodeModel
 
         internal void AddParagraph(Paragraph paragraph)
         {
-            Add(Paragraphs, paragraph);
+            AddNode(Paragraphs, paragraph);
         }
 
         public IList<Paragraph> GetParagraph(SymbolReference symbolRef, Section sectionNode)
@@ -868,7 +868,7 @@ namespace TypeCobol.Compiler.CodeModel
 
         public void AddType(TypeDefinition type)
         {
-            Add(Types, type);
+            AddNode(Types, type);
         }
 
         /// <summary>
@@ -892,7 +892,7 @@ namespace TypeCobol.Compiler.CodeModel
             {
                 var childDataDefinition = (DataDefinition) dataChild;
 
-                Add(DataTypeEntries, childDataDefinition);
+                AddNode(DataTypeEntries, childDataDefinition);
 
                 //add child data definition
                 AddDataDefinitionsUnderType(childDataDefinition);
@@ -1027,7 +1027,7 @@ namespace TypeCobol.Compiler.CodeModel
 
         public void AddFunction(FunctionDeclaration function)
         {
-            Add(Functions, function);
+            AddNode(Functions, function);
         }
 
         public List<FunctionDeclaration> GetFunction(StorageArea storageArea, IProfile profile = null)
@@ -1178,7 +1178,7 @@ namespace TypeCobol.Compiler.CodeModel
         /// <param name="program"></param>
         public void AddProgram(Program program)
         {
-            Add(Programs, program);
+            AddNode(Programs, program);
         }
 
         [NotNull]
@@ -1211,6 +1211,73 @@ namespace TypeCobol.Compiler.CodeModel
 
         #endregion
 
+        #region SPECIAL NAMES
+
+        private readonly IDictionary<string, List<SymbolDefinition>> EnvironmentMnemonics =
+            new Dictionary<string, List<SymbolDefinition>>(StringComparer.OrdinalIgnoreCase);
+
+        private SymbolTable GetTopGlobalParentTable()
+        {
+            var globalTable = GetTableFromScope(Scope.Global);
+            if (globalTable == null)
+            {
+                return null;
+            }
+
+            while (globalTable.EnclosingScope != null && globalTable.EnclosingScope.CurrentScope == Scope.Global)
+            {
+                globalTable = globalTable.EnclosingScope;
+            }
+
+            return globalTable;
+        }
+
+        /// <summary>
+        /// Add symbols defined by SPECIAL-NAMES paragraph.
+        /// </summary>
+        /// <param name="specialNamesParagraph">Special names code element</param>
+        public void AddSpecialNames([NotNull] SpecialNamesParagraph specialNamesParagraph)
+        {
+            var targetTable = GetTopGlobalParentTable();
+            Debug.Assert(targetTable != null); // Mnemonics can be declared only by root level programs which all have a Global SymbolTable
+            
+            if (specialNamesParagraph.MnemonicsForEnvironmentNames != null)
+            {
+                foreach (var mnemonicForEnvironmentName in specialNamesParagraph.MnemonicsForEnvironmentNames.Keys)
+                {
+                    Add(targetTable.EnvironmentMnemonics, mnemonicForEnvironmentName.Name, mnemonicForEnvironmentName);
+                }
+            }
+
+            //TODO create dedicated dictionaries and add other special names
+        }
+
+        /// <summary>
+        /// Return all environment mnemonics names.
+        /// </summary>
+        /// <returns>Non-null, maybe empty list of environment mnemonics names.</returns>
+        public IList<string> GetEnvironmentMnemonicsNames()
+        {
+            var targetTable = GetTopGlobalParentTable();
+            return targetTable != null ? targetTable.EnvironmentMnemonics.Keys.ToList() : new List<string>();
+        }
+
+        /// <summary>
+        /// Retrieve environment mnemonic definitions for given environment mnemonic reference.
+        /// </summary>
+        /// <param name="symbolReference">Reference to resolve.</param>
+        /// <returns>A non-null list of definitions. May be empty when the reference could not be resolved,
+        /// may contain more than one element when the reference is ambiguous.</returns>
+        public IList<SymbolDefinition> GetEnvironmentMnemonics(SymbolReference symbolReference)
+        {
+            var targetTable = GetTopGlobalParentTable();
+            return targetTable != null
+                ? GetFromTable(symbolReference.Name, targetTable.EnvironmentMnemonics)
+                : new List<SymbolDefinition>();
+        }
+
+        #endregion
+
         #region Helpers
 
         /// <summary>
@@ -1218,10 +1285,10 @@ namespace TypeCobol.Compiler.CodeModel
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="table"></param>
+        /// <param name="key"></param>
         /// <param name="symbol"></param>
-        private static void Add<T>([NotNull] IDictionary<string, List<T>> table, [NotNull] T symbol) where T : Node
+        private static void Add<T>([NotNull] IDictionary<string, List<T>> table, [CanBeNull] string key, [NotNull] T symbol)
         {
-            string key = symbol.Name;
             //QualifiedName of symbol can be null - if we have a filler in the type definition
             if (key == null)
             {
@@ -1237,6 +1304,9 @@ namespace TypeCobol.Compiler.CodeModel
             }
             found.Add(symbol);
         }
+
+        private static void AddNode<TNode>([NotNull] IDictionary<string, List<TNode>> table, [NotNull] TNode symbol) where TNode : Node
+            => Add(table, symbol.Name, symbol);
 
         /// <summary>
         /// Cobol has compile time binding for variables, sometimes called static scope.
@@ -1332,6 +1402,19 @@ namespace TypeCobol.Compiler.CodeModel
                 foreach (var line in Functions)
                 foreach (var item in line.Value)
                     Dump(str, item, new string(' ', 2));
+            }
+            if (EnvironmentMnemonics.Count > 0)
+            {
+                str.AppendLine("-- ENVIRONMENT MNEMONICS ---");
+                foreach (var line in EnvironmentMnemonics)
+                {
+                    foreach (var item in line.Value)
+                    {
+                        str.Append(new string(' ', 2));
+                        str.Append(item.Name);
+                        str.AppendLine();
+                    }
+                }
             }
             if (verbose && EnclosingScope != null)
                 str.Append(EnclosingScope.ToString(verbose));

--- a/TypeCobol/Compiler/CompilationUnit.cs
+++ b/TypeCobol/Compiler/CompilationUnit.cs
@@ -58,9 +58,15 @@ namespace TypeCobol.Compiler
         /// </summary>
         public void RefreshCodeElementsDocumentSnapshot()
         {
+            // Track all changes applied to the document while updating this snapshot
+            DocumentChangedEvent<ICodeElementsLine> documentChangedEvent = null;
+
             // Make sure two threads don't try to update this snapshot at the same time
             lock (lockObjectForCodeElementsDocumentSnapshot)
             {
+                // Start perf measurement
+                var perfStatsForParserInvocation = PerfStatsForCodeElementsParser.OnStartRefreshParsingStep();
+
                 // Capture previous snapshots at one point in time
                 ProcessedTokensDocument processedTokensDocument = ProcessedTokensDocumentSnapshot;
                 CodeElementsDocument previousCodeElementsDocument = CodeElementsDocumentSnapshot;
@@ -75,6 +81,7 @@ namespace TypeCobol.Compiler
                 else if (processedTokensDocument.CurrentVersion == previousCodeElementsDocument.PreviousStepSnapshot.CurrentVersion)
                 {
                     // Processed tokens lines did not change since last update => nothing to do
+                    PerfStatsForCodeElementsParser.OnStopRefreshParsingStep();
                     return;
                 }
                 else
@@ -82,12 +89,6 @@ namespace TypeCobol.Compiler
                     DocumentVersion<IProcessedTokensLine> previousProcessedTokensDocumentVersion = previousCodeElementsDocument.PreviousStepSnapshot.CurrentVersion;
                     processedTokensLineChanges = previousProcessedTokensDocumentVersion.GetReducedAndOrderedChangesInNewerVersion(processedTokensDocument.CurrentVersion);
                 }
-
-                // Start perf measurement
-                var perfStatsForParserInvocation = PerfStatsForCodeElementsParser.OnStartRefreshParsingStep();
-
-                // Track all changes applied to the document while updating this snapshot
-                DocumentChangedEvent<ICodeElementsLine> documentChangedEvent = null;
 
                 // Apply text changes to the compilation document
                 if (scanAllDocumentLines)
@@ -121,13 +122,13 @@ namespace TypeCobol.Compiler
 
                 // Stop perf measurement
                 PerfStatsForCodeElementsParser.OnStopRefreshParsingStep();
+            }
 
-                // Send events to all listeners
-                EventHandler<DocumentChangedEvent<ICodeElementsLine>> codeElementsLinesChanged = CodeElementsLinesChanged; // avoid race condition
-                if (documentChangedEvent != null && codeElementsLinesChanged != null)
-                {
-                    codeElementsLinesChanged(this, documentChangedEvent);
-                }
+            // Send events to all listeners
+            EventHandler<DocumentChangedEvent<ICodeElementsLine>> codeElementsLinesChanged = CodeElementsLinesChanged; // avoid race condition
+            if (documentChangedEvent != null && codeElementsLinesChanged != null)
+            {
+                codeElementsLinesChanged(this, documentChangedEvent);
             }
 
 #if DEBUG
@@ -194,14 +195,14 @@ namespace TypeCobol.Compiler
             bool snapshotWasUpdated = false;
             lock (lockObjectForProgramClassDocumentSnapshot)
             {
+                PerfStatsForProgramCrossCheck.OnStartRefreshParsingStep();
+
                 // Capture previous snapshot at one point in time
                 TemporarySemanticDocument temporarySnapshot = TemporaryProgramClassDocumentSnapshot;
 
                 // Check if an update is necessary and compute changes to apply since last version
                 if ((TemporaryProgramClassDocumentSnapshot != null) && (ProgramClassDocumentSnapshot == null || ProgramClassDocumentSnapshot.PreviousStepSnapshot.CurrentVersion != temporarySnapshot.CurrentVersion))
                 {
-                    PerfStatsForProgramCrossCheck.OnStartRefreshParsingStep();
-
                     // Program and Class parsing is not incremental : the objects are rebuilt each time this method is called
                     SourceFile root = temporarySnapshot.Root;
                     Dictionary<CodeElement, Node> nodeCodeElementLinkers = temporarySnapshot.NodeCodeElementLinkers ?? new Dictionary<CodeElement, Node>();
@@ -211,10 +212,10 @@ namespace TypeCobol.Compiler
                     ProgramClassDocumentSnapshot = new ProgramClassDocument(
                         temporarySnapshot, ProgramClassDocumentSnapshot?.CurrentVersion + 1 ?? 0,
                         root, nodeCodeElementLinkers);
-                    snapshotWasUpdated = true;;
-
-                    PerfStatsForProgramCrossCheck.OnStopRefreshParsingStep();
+                    snapshotWasUpdated = true;
                 }
+
+                PerfStatsForProgramCrossCheck.OnStopRefreshParsingStep();
             }
 
             // Send events to all listeners
@@ -243,13 +244,14 @@ namespace TypeCobol.Compiler
         {
             lock (lockObjectForTemporarySemanticDocument)
             {
+                // Start perf measurement
+                var perfStatsForParserInvocation = PerfStatsForTemporarySemantic.OnStartRefreshParsingStep();
+
                 // Capture previous snapshot at one point in time
                 CodeElementsDocument codeElementsDocument = CodeElementsDocumentSnapshot;
 
                 if (CodeElementsDocumentSnapshot != null && (TemporaryProgramClassDocumentSnapshot == null || TemporaryProgramClassDocumentSnapshot.PreviousStepSnapshot.CurrentVersion != CodeElementsDocumentSnapshot.CurrentVersion))
                 {
-                    // Start perf measurement
-                    var perfStatsForParserInvocation = PerfStatsForTemporarySemantic.OnStartRefreshParsingStep();
                     var customAnalyzers = _analyzerProvider?.CreateSyntaxDrivenAnalyzers(CompilerOptions, TextSourceInfo);
 
                     // Program and Class parsing is not incremental : the objects are rebuilt each time this method is called
@@ -310,10 +312,10 @@ namespace TypeCobol.Compiler
                             newDiagnostics.Add(diagnostic);
                         }
                     }
-
-                    // Stop perf measurement
-                    PerfStatsForTemporarySemantic.OnStopRefreshParsingStep();
                 }
+
+                // Stop perf measurement
+                PerfStatsForTemporarySemantic.OnStopRefreshParsingStep();
             }
 
 #if DEBUG
@@ -330,11 +332,11 @@ namespace TypeCobol.Compiler
             bool documentUpdated = false;
             lock (lockObjectForCodeAnalysisDocumentSnapshot)
             {
+                PerfStatsForCodeQualityCheck.OnStartRefresh();
+
                 var programClassDocument = ProgramClassDocumentSnapshot;
                 if (programClassDocument != null && CodeAnalysisDocumentNeedsUpdate(out int version))
                 {
-                    PerfStatsForCodeQualityCheck.OnStartRefresh();
-
                     List<Diagnostic> diagnostics = new List<Diagnostic>();
                     Dictionary<string, object> results = new Dictionary<string, object>();
                     var analyzers = _analyzerProvider?.CreateQualityAnalyzers(CompilerOptions);
@@ -370,9 +372,9 @@ namespace TypeCobol.Compiler
                     //Create updated snapshot
                     CodeAnalysisDocumentSnapshot = new InspectedProgramClassDocument(programClassDocument, version, diagnostics, results);
                     documentUpdated = true;
-
-                    PerfStatsForCodeQualityCheck.OnStopRefresh();
                 }
+
+                PerfStatsForCodeQualityCheck.OnStopRefresh();
 
                 bool CodeAnalysisDocumentNeedsUpdate(out int newVersion)
                 {

--- a/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
@@ -370,7 +370,9 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
 
         public virtual void StartSpecialNamesParagraph(SpecialNamesParagraph paragraph)
         {
-            Enter(new SpecialNames(paragraph));
+            var specialNames = new SpecialNames(paragraph);
+            Enter(specialNames);
+            specialNames.SymbolTable.AddSpecialNames(paragraph);
             Dispatcher.StartSpecialNamesParagraph(paragraph);
         }
 

--- a/TypeCobol/Compiler/Diagnostics/CodeElementCheckers.cs
+++ b/TypeCobol/Compiler/Diagnostics/CodeElementCheckers.cs
@@ -683,5 +683,21 @@ namespace TypeCobol.Compiler.Diagnostics
         }
     }
 
+    static class SpecialNamesParagraphChecker
+    {
+        public static void OnCodeElement(SpecialNamesParagraph paragraph, CodeElementsParser.SpecialNamesParagraphContext context, List<RuleContext> duplicateEnvironments, List<RuleContext> duplicateMnemonicsForEnvironment)
+        {
+            foreach (var environment in duplicateEnvironments)
+            {
+                DiagnosticUtils.AddError(paragraph, $"A duplicate '{environment.GetText()}' clause was found.", environment);
+            }
+
+            foreach (var mnemonic in duplicateMnemonicsForEnvironment)
+            {
+                DiagnosticUtils.AddError(paragraph, $"Mnemonic name '{mnemonic.GetText()}' was previously defined.", mnemonic);
+            }
+        }
+    }
+
     #endregion
 }

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
@@ -366,6 +366,9 @@ namespace TypeCobol.Compiler.Parser
 		public override void EnterSpecialNamesParagraph(CodeElementsParser.SpecialNamesParagraphContext context)
 		{
 			var paragraph = new SpecialNamesParagraph();
+			var environments = new HashSet<ExternalName>();
+			var duplicateEnvironments = new List<RuleContext>();
+			var duplicateMnemonicsForEnvironment = new List<RuleContext>();
 			
 			if(context.upsiSwitchNameClause() != null && context.upsiSwitchNameClause().Length > 0)
 			{
@@ -414,10 +417,22 @@ namespace TypeCobol.Compiler.Parser
 				}
 				foreach(var environmentNameContext in context.environmentNameClause())
 				{
-					var environmentName = _cobolWordsBuilder.CreateEnvironmentName(
-						environmentNameContext.environmentName());
-					var mnemonicForEnvironmentName = _cobolWordsBuilder.CreateMnemonicForEnvironmentNameDefinition(
-						environmentNameContext.mnemonicForEnvironmentNameDefinition());
+					var environmentName = _cobolWordsBuilder.CreateEnvironmentName(environmentNameContext.environmentName());
+					if (!environments.Add(environmentName))
+					{
+						// Duplicate environment, add to duplicate list and skip definition
+						duplicateEnvironments.Add(environmentNameContext.environmentName());
+						continue;
+					}
+					
+					var mnemonicForEnvironmentName = _cobolWordsBuilder.CreateMnemonicForEnvironmentNameDefinition(environmentNameContext.mnemonicForEnvironmentNameDefinition());
+					if (paragraph.MnemonicsForEnvironmentNames.ContainsKey(mnemonicForEnvironmentName))
+					{
+						// Duplicate mnemonic, add to duplicate list and skip definition
+						duplicateMnemonicsForEnvironment.Add(environmentNameContext.mnemonicForEnvironmentNameDefinition());
+						continue;
+					}
+					
 					paragraph.MnemonicsForEnvironmentNames.Add(mnemonicForEnvironmentName, environmentName);
 				}
 			}
@@ -569,6 +584,7 @@ namespace TypeCobol.Compiler.Parser
 
 			Context = context;
 			CodeElement = paragraph;
+			SpecialNamesParagraphChecker.OnCodeElement(paragraph, context, duplicateEnvironments, duplicateMnemonicsForEnvironment);
 		}
 
 		private CharactersRangeInCollatingSequence CreateCharactersRange(CodeElementsParser.CharactersRangeContext context) {

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolExpressionsBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolExpressionsBuilder.cs
@@ -124,7 +124,6 @@ namespace TypeCobol.Compiler.Parser
 				storageArea = new DataOrConditionStorageArea(qualifiedDataNameOrQualifiedConditionNameOrIndexName,
 					CreateSubscriptExpressions(context.subscript()), _insideFunctionArgument);
 			}
-			storageArea.AlternativeSymbolType = SymbolType.IndexName;
 			return storageArea;
 		}
 
@@ -141,7 +140,6 @@ namespace TypeCobol.Compiler.Parser
 				storageArea = new DataOrConditionStorageArea(qualifiedDataNameOrQualifiedConditionNameOrFileName,
 					CreateSubscriptExpressions(context.subscript()), _insideFunctionArgument);
 			}
-			storageArea.AlternativeSymbolType = SymbolType.IndexName;
 			return storageArea;
 		}
 
@@ -158,8 +156,14 @@ namespace TypeCobol.Compiler.Parser
 				storageArea = new DataOrConditionStorageArea(qualifiedDataNameOrQualifiedConditionNameOrClassName,
 					CreateSubscriptExpressions(context.subscript()), _insideFunctionArgument);
 			}
-			storageArea.AlternativeSymbolType = SymbolType.IndexName;
 			return storageArea;
+		}
+
+		internal DataOrConditionStorageArea CreateDataItemReferenceOrMnemonicForEnvironmentName(CodeElementsParser.IntegerVariableIdentifierOrMnemonicForEnvironmentNameReferenceContext context)
+		{
+			AmbiguousSymbolReference symbolReference = CobolWordsBuilder.CreateAmbiguousSymbolReference(
+				context.UserDefinedWord(), new [] { SymbolType.DataName, SymbolType.MnemonicForEnvironmentName });
+			return new DataOrConditionStorageArea(symbolReference, _insideFunctionArgument);
 		}
 
 		internal SubscriptExpression[] CreateSubscriptExpressions(CodeElementsParser.SubscriptContext[] contextArray)
@@ -1074,6 +1078,23 @@ namespace TypeCobol.Compiler.Parser
             }
 
             return variable;
+		}
+
+		[CanBeNull]
+		internal IntegerVariable CreateIntegerVariableOrMnemonicForEnvironmentName([CanBeNull] CodeElementsParser.IntegerVariableIdentifierOrMnemonicForEnvironmentNameReferenceContext context)
+		{
+			if (context == null) return null;
+		
+			var dataItemReferenceOrMnemonicForEnvironmentName = CreateDataItemReferenceOrMnemonicForEnvironmentName(context);
+			IntegerVariable variable = new IntegerVariable(dataItemReferenceOrMnemonicForEnvironmentName);
+		
+			// Collect storage area read/writes at the code element level
+			if (variable.StorageArea != null)
+			{
+				this.storageAreaReads.Add(variable.StorageArea);
+			}
+		
+			return variable;
 		}
 
 		internal NumericVariable CreateNumericVariable(CodeElementsParser.NumericVariable1Context context)

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolStatementsBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolStatementsBuilder.cs
@@ -1514,11 +1514,11 @@ namespace TypeCobol.Compiler.Parser
             }
             if (context.numberOfLines != null)
             {
-                statement.ByNumberOfLines = CobolExpressionsBuilder.CreateIntegerVariable(context.numberOfLines);
+                statement.ByNumberOfLinesOrByMnemonicForEnvironmentName = CobolExpressionsBuilder.CreateIntegerVariable(context.numberOfLines);
             }
-            if (context.mnemonicForEnvironmentNameReference() != null)
+            if (context.integerVariableIdentifierOrMnemonicForEnvironmentNameReference() != null)
             {
-                statement.ByMnemonicForEnvironmentName = CobolWordsBuilder.CreateMnemonicForEnvironmentNameReference(context.mnemonicForEnvironmentNameReference());
+                statement.ByNumberOfLinesOrByMnemonicForEnvironmentName = CobolExpressionsBuilder.CreateIntegerVariableOrMnemonicForEnvironmentName(context.integerVariableIdentifierOrMnemonicForEnvironmentNameReference());
             }
             if (context.PAGE() != null)
             {

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolWordsBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolWordsBuilder.cs
@@ -566,13 +566,6 @@ namespace TypeCobol.Compiler.Parser
             return CreateSymbolDefinition(context.UserDefinedWord(), SymbolType.MnemonicForEnvironmentName);
         }
 
-        [CanBeNull]
-        internal SymbolReference CreateMnemonicForEnvironmentNameReference([CanBeNull] CodeElementsParser.MnemonicForEnvironmentNameReferenceContext context)
-        {
-            if (context == null) return null;
-            return CreateSymbolReference(context.UserDefinedWord(), SymbolType.MnemonicForEnvironmentName);
-        }
-
         internal ExternalNameOrSymbolReference CreateMnemonicForEnvironmentNameReferenceOrEnvironmentName(CodeElementsParser.MnemonicForEnvironmentNameReferenceOrEnvironmentNameContext context)
         {
             return CreateExternalNameOrSymbolReference(context.externalNameOrSymbolReference4(), new SymbolType[] { SymbolType.EnvironmentName, SymbolType.MnemonicForEnvironmentName });

--- a/TypeCobol/Compiler/Parser/CodeElementsParserStep.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementsParserStep.cs
@@ -278,6 +278,8 @@ namespace TypeCobol.Compiler.Parser
                             }
                             codeElementsLine.AddParserDiagnostic(new ParserDiagnostic(ex.ToString(), position, null, code, ex));
                         }
+                        perfStatsForParserInvocation.OnStopTreeBuilding();
+
                         CodeElement codeElement = codeElementBuilder.CodeElement;
                         if (codeElement != null)
                         {
@@ -388,9 +390,7 @@ namespace TypeCobol.Compiler.Parser
                         }
                     }
                 }
-                perfStatsForParserInvocation.OnStopTreeBuilding();
             }
-
 
             if (AntlrPerformanceProfiler != null)
                 AntlrPerformanceProfiler.EndParsingFile(cobolParser.ParseInfo.DecisionInfo, (int)(cobolParser.ParseInfo.GetTotalTimeInPrediction() / 1000000));

--- a/TypeCobol/Compiler/Parser/ProgramClassParserStep.cs
+++ b/TypeCobol/Compiler/Parser/ProgramClassParserStep.cs
@@ -88,7 +88,7 @@ namespace TypeCobol.Compiler.Parser
                 }
             }
 
-            // Try to parse a Cobol program or class, with cup w are also building the The Syntax Tree Node
+            // Try to parse a Cobol program or class, with cup we are also building the The Syntax Tree Node
             perfStatsForParserInvocation.OnStartParsing();
             try
             {
@@ -108,12 +108,6 @@ namespace TypeCobol.Compiler.Parser
             System.Diagnostics.Debug.WriteLine("Time[" + textSourceInfo.Name + "];" + t.Milliseconds);
 #endif
             root = builder.SyntaxTree.Root; //Set output root node
-
-            perfStatsForParserInvocation.OnStartTreeBuilding();
-
-
-            //Stop measuring tree building performance
-            perfStatsForParserInvocation.OnStopTreeBuilding();
 
             // Register compiler results
             diagnostics = diagReporter.Diagnostics ?? new List<Diagnostic>();

--- a/TypeCobol/Compiler/Preprocessor/PreprocessorStep.cs
+++ b/TypeCobol/Compiler/Preprocessor/PreprocessorStep.cs
@@ -238,6 +238,8 @@ namespace TypeCobol.Compiler.Preprocessor
                         }
                     }
                 }
+
+                perfStatsForParserInvocation.OnStopTreeBuilding();
             }
 
             // 8. Advance the state off all ProcessedTokensLines : 
@@ -261,8 +263,6 @@ namespace TypeCobol.Compiler.Preprocessor
                     parsedLine.PreprocessingState = ProcessedTokensLine.PreprocessorState.Ready;
                 }
             }
-
-            perfStatsForParserInvocation.OnStopTreeBuilding();
 
             // --- COPY IMPORT PHASE : Process COPY (REPLACING) directives ---
             missingCopies = new List<string>();

--- a/TypeCobol/Compiler/Scanner/AbstractScanner.cs
+++ b/TypeCobol/Compiler/Scanner/AbstractScanner.cs
@@ -177,10 +177,15 @@ namespace TypeCobol.Compiler.Scanner
                         type = TokenType.DecimalLiteral;
                         value = new DecimalLiteralTokenValue(decMatch.Groups[1].Value, decMatch.Groups[2].Value, decMatch.Groups[3].Value);
                     }
-                    else
+                    else if (decMatch.Groups[2].Value.Length > 0)
                     {
                         type = TokenType.IntegerLiteral;
                         value = new IntegerLiteralTokenValue(decMatch.Groups[1].Value, decMatch.Groups[2].Value);
+                    }
+                    else
+                    {
+                        type = TokenType.InvalidToken;
+                        value = null;
                     }
                     Token token = new Token(type, startIndex, endIndex, tokensLine)
                     {

--- a/TypeCobol/Compiler/Scanner/TokensLine.cs
+++ b/TypeCobol/Compiler/Scanner/TokensLine.cs
@@ -108,6 +108,9 @@ namespace TypeCobol.Compiler.Scanner
         /// <summary>
         /// Use this method to attach a diagnostic to this line 
         /// (never call directly Diagnostics.Add)
+        ///
+        /// WARNING: diagnostics added using this method cannot be copied onto another line !
+        /// Do not use on temporary/virtual lines otherwise you risk losing diagnostics.
         /// </summary>
         internal void AddDiagnostic(MessageCode messageCode, int columnStart, int columnEnd, params object[] messageArgs)
         {


### PR DESCRIPTION
## Changelog

### New feature
- WI #1860 Add semantic support for environment mnemonics (#2369)

### Bug fix
- WI #2374 Allow comma as separator between REPLACE clauses (#2384)
- WI #2356 Ensure "literal not correctly delimited" diagnostic is reported for continuation lines (#2380)
- WI #2387 Fix numeric literal creation when decimal part is missing (#2394)

### Internal
- WI #2372 Improve accuracy of performance counters (#2396)
