### PR TITLE
WI #2434 #2441 Check builder state before attempting to close current statement

### DIFF
--- a/TypeCobol.Test/Parser/Programs/Cobol85/UncommentedInsidePerform.Nodes.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/UncommentedInsidePerform.Nodes.txt
@@ -1,0 +1,19 @@
+Line 14[21,24] <27, Error, Syntax> - Syntax error : extraneous input 'TODO' expecting {separator, numeric literal, character string, symbol, statement starting keyword, keyword, Formalized Comments elements, Sql statement starting keyword}
+Line 15[26,26] <27, Error, Syntax> - Syntax error : no viable alternative at input 'TODO ... :'
+Line 16[12,22] <27, Error, Syntax> - Syntax error : extraneous input 'end-perform' expecting {ProgramIdentification, ProgramEnd, ClassIdentification, MethodEnd, DeclarativesEnd, SectionHeader, ParagraphHeader, SentenceEnd, AcceptStatement, AddStatement, AllocateStatement, AlterStatement, CallStatement, CancelStatement, CloseStatement, ComputeStatement, ContinueStatement, DeleteStatement, DisplayStatement, DivideStatement, EntryStatement, EvaluateStatement, ExecStatement, ExitMethodStatement, ExitProgramStatement, ExitStatement, FreeStatement, GobackStatement, GotoStatement, IfStatement, InitializeStatement, InspectStatement, InvokeStatement, JsonGenerateStatement, JsonParseStatement, MergeStatement, MoveStatement, MultiplyStatement, OpenStatement, PerformProcedureStatement, PerformStatement, ReadStatement, ReleaseStatement, ReturnStatement, RewriteStatement, SearchStatement, SetStatement, SortStatement, StartStatement, StopStatement, StringStatement, SubtractStatement, UnstringStatement, WriteStatement, XmlGenerateStatement, XmlParseStatement, FunctionDeclarationHeader, FunctionDeclarationEnd, ProcedureStyleCall}
+--- Nodes ---
+?
+  MyPGM
+    data-division
+      working-storage
+        MyArray
+          TAB-EXC-ELE
+            TAB-EXC-IDX
+            TAB-EXC-CLE
+    procedure-division
+      sentence-0
+        [[PerformStatement]] [12,18:perform]<PERFORM> --> [42,43:50]<IntegerLiteral>{50}
+
+        end
+      end
+    end

--- a/TypeCobol.Test/Parser/Programs/Cobol85/UncommentedInsidePerform.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/UncommentedInsidePerform.rdz.cbl
@@ -1,0 +1,18 @@
+       IDENTIFICATION division.
+       PROGRAM-ID. MyPGM.
+       data division.
+       working-storage section.
+       01  MyArray.
+          05 TAB-EXC-ELE occurs 1 to 50
+                          indexed by TAB-EXC-IDX.
+             10 TAB-EXC-CLE   pic X(08).
+
+       procedure division.
+           perform varying TAB-EXC-IDX from 1 by 1
+                   until   TAB-EXC-IDX > 50
+
+                    TODO : case1.
+                    TODO : case2.
+           end-perform
+           .
+       end program MyPGM.

--- a/TypeCobol/Compiler/CupParser/NodeBuilder/CupParserTypeCobolProgramDiagnosticErrorReporter.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/CupParserTypeCobolProgramDiagnosticErrorReporter.cs
@@ -4,6 +4,7 @@ using TUVienna.CS_CUP.Runtime;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.CupCommon;
 using TypeCobol.Compiler.Diagnostics;
+using TypeCobol.Compiler.Nodes;
 
 namespace TypeCobol.Compiler.CupParser.NodeBuilder
 {
@@ -112,10 +113,10 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
                 }
             }
 
-            // Try to close current statement if current token is an END-Statement
-            if (ce is CodeElementEnd codeElementEnd)
+            // Try to close current statement if current token is a matching END-Statement
+            if (((ProgramClassBuilder)tcpParser.Builder).CurrentNode is StatementWithBody currentStatement && ce?.Type == currentStatement.EndType)
             {
-                lr_parser stmtParser = CloneParser(parser, TypeCobolProgramSymbols.StatementClosingPoint, codeElementEnd, true);
+                lr_parser stmtParser = CloneParser(parser, TypeCobolProgramSymbols.StatementClosingPoint, ce, true);
                 stmtParser.parse();
             }
 

--- a/TypeCobol/Compiler/Nodes/Statement.cs
+++ b/TypeCobol/Compiler/Nodes/Statement.cs
@@ -6,10 +6,13 @@ namespace TypeCobol.Compiler.Nodes {
 
     public interface Statement { }
 
-
+    public interface StatementWithBody : Statement
+    {
+        CodeElementType EndType { get; }
+    }
 
     public class Accept: GenericNode<AcceptStatement>, Statement {
-	    public Accept(AcceptStatement statement): base(statement) { }
+        public Accept(AcceptStatement statement): base(statement) { }
 
         public override bool VisitNode(IASTVisitor astVisitor)
         {
@@ -32,21 +35,23 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class Alter: GenericNode<AlterStatement>, Statement {
-	    public Alter(AlterStatement statement): base(statement) { }
+        public Alter(AlterStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
     }
 
-    public class Call: GenericNode<CallStatement>, Statement {
-	    public Call(CallStatement statement): base(statement) { }
+    public class Call: GenericNode<CallStatement>, StatementWithBody {
+        public Call(CallStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+
+        public CodeElementType EndType => CodeElementType.CallStatementEnd;
     }
-    public class ProcedureStyleCall : GenericNode<ProcedureStyleCallStatement>, Statement, FunctionCaller {
+    public class ProcedureStyleCall : GenericNode<ProcedureStyleCallStatement>, StatementWithBody, FunctionCaller {
         public ProcedureStyleCall(ProcedureStyleCallStatement statement) : base(statement) { }
 
         public FunctionCall FunctionCall
@@ -79,10 +84,12 @@ namespace TypeCobol.Compiler.Nodes {
 
             return string.Empty;
         }
+
+        public CodeElementType EndType => CodeElementType.CallStatementEnd;
     }
 
     public class Cancel: GenericNode<CancelStatement>, Statement {
-	    public Cancel(CancelStatement statement): base(statement) { }
+        public Cancel(CancelStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
@@ -90,23 +97,24 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class Continue: GenericNode<ContinueStatement>, Statement {
-	    public Continue(ContinueStatement statement): base(statement) { }
+        public Continue(ContinueStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
     }
 
-    public class Delete: GenericNode<DeleteStatement>, Statement {
-	    public Delete(DeleteStatement statement): base(statement) { }
+    public class Delete: GenericNode<DeleteStatement>, StatementWithBody {
+        public Delete(DeleteStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.DeleteStatementEnd;
     }
 
     public class Display: GenericNode<DisplayStatement>, Statement {
-	    public Display(DisplayStatement statement): base(statement) { }
+        public Display(DisplayStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
@@ -114,19 +122,20 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class Entry: GenericNode<EntryStatement>, Statement {
-	    public Entry(EntryStatement statement): base(statement) { }
+        public Entry(EntryStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
     }
 
-    public class Exec: GenericNode<ExecStatement>, Statement {
-	    public Exec(ExecStatement statement): base(statement) { }
+    public class Exec: GenericNode<ExecStatement>, StatementWithBody {
+        public Exec(ExecStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.ExecStatementEnd;
     }
 
     public class ExecText : GenericNode<ExecStatementText>, Statement
@@ -139,7 +148,7 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class Exit: GenericNode<ExitStatement>, Statement {
-	    public Exit(ExitStatement statement): base(statement) { }
+        public Exit(ExitStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
@@ -147,7 +156,7 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class ExitMethod: GenericNode<ExitMethodStatement>, Statement {
-	    public ExitMethod(ExitMethodStatement statement): base(statement) { }
+        public ExitMethod(ExitMethodStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
@@ -155,7 +164,7 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class ExitProgram: GenericNode<ExitProgramStatement>, Statement {
-	    public ExitProgram(ExitProgramStatement statement): base(statement) { }
+        public ExitProgram(ExitProgramStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
@@ -177,7 +186,7 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class Goback: GenericNode<GobackStatement>, Statement {
-	    public Goback(GobackStatement statement): base(statement) { }
+        public Goback(GobackStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
@@ -185,7 +194,7 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class Goto: GenericNode<GotoStatement>, Statement {
-	    public Goto(GotoStatement statement): base(statement) { }
+        public Goto(GotoStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
@@ -193,7 +202,7 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class Initialize: GenericNode<InitializeStatement>, Statement {
-	    public Initialize(InitializeStatement statement): base(statement) { }
+        public Initialize(InitializeStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
@@ -201,24 +210,25 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class Inspect: GenericNode<InspectStatement>, Statement, VariableWriter {
-	    public Inspect(InspectStatement statement): base(statement) { }
-	    public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
-	    public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
+        public Inspect(InspectStatement statement): base(statement) { }
+        public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
+        public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this) && astVisitor.VisitVariableWriter(this);
         }
     }
 
-    public class Invoke: GenericNode<InvokeStatement>, Statement {
-	    public Invoke(InvokeStatement statement): base(statement) { }
+    public class Invoke: GenericNode<InvokeStatement>, StatementWithBody {
+        public Invoke(InvokeStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.InvokeStatementEnd;
     }
 
-    public class JsonGenerate : GenericNode<JsonGenerateStatement>, Statement
+    public class JsonGenerate : GenericNode<JsonGenerateStatement>, StatementWithBody
     {
         public JsonGenerate(JsonGenerateStatement statement)
             : base(statement)
@@ -230,9 +240,11 @@ namespace TypeCobol.Compiler.Nodes {
         {
             return astVisitor.Visit(this);
         }
+
+        public CodeElementType EndType => CodeElementType.JsonStatementEnd;
     }
 
-    public class JsonParse : GenericNode<JsonParseStatement>, Statement
+    public class JsonParse : GenericNode<JsonParseStatement>, StatementWithBody
     {
         public JsonParse(JsonParseStatement statement)
             : base(statement)
@@ -244,10 +256,12 @@ namespace TypeCobol.Compiler.Nodes {
         {
             return astVisitor.Visit(this);
         }
+
+        public CodeElementType EndType => CodeElementType.JsonStatementEnd;
     }
 
     public class Merge: GenericNode<MergeStatement>, Statement {
-	    public Merge(MergeStatement statement): base(statement) { }
+        public Merge(MergeStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
@@ -255,11 +269,11 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class Move: GenericNode<MoveStatement>, Statement, VariableWriter,FunctionCaller {
-	    public Move(MoveStatement statement): base(statement) { }
-	    public FunctionCall FunctionCall { get { return this.CodeElement.FunctionCall; } }
-	   
-	    public IDictionary<StorageArea, object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
-	    public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
+        public Move(MoveStatement statement): base(statement) { }
+        public FunctionCall FunctionCall { get { return this.CodeElement.FunctionCall; } }
+       
+        public IDictionary<StorageArea, object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
+        public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
 
         public FunctionDeclaration FunctionDeclaration { get; set; }
 
@@ -270,25 +284,26 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class Release: GenericNode<ReleaseStatement>, Statement {
-	    public Release(ReleaseStatement statement): base(statement) { }
+        public Release(ReleaseStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
     }
 
-    public class Return: GenericNode<ReturnStatement>, Statement {
-	    public Return(ReturnStatement statement): base(statement) { }
+    public class Return: GenericNode<ReturnStatement>, StatementWithBody {
+        public Return(ReturnStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.ReturnStatementEnd;
     }
 
     public class Set: GenericNode<SetStatement>, Statement, VariableWriter {
-	    public Set(SetStatement statement): base(statement) { }
-	    public IDictionary<StorageArea, object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
-	    public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
+        public Set(SetStatement statement): base(statement) { }
+        public IDictionary<StorageArea, object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
+        public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this) && astVisitor.VisitVariableWriter(this);
@@ -296,7 +311,7 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class Sort: GenericNode<SortStatement>, Statement {
-	    public Sort(SortStatement statement): base(statement) { }
+        public Sort(SortStatement statement): base(statement) { }
 
         public ParagraphSymbol InputProcedureParagraphSymbol { get; internal set; }
         public ParagraphSymbol InputThroughProcedureParagraphSymbol { get; internal set; }
@@ -314,70 +329,77 @@ namespace TypeCobol.Compiler.Nodes {
         }
     }
 
-    public class Start: GenericNode<StartStatement>, Statement {
-	    public Start(StartStatement statement): base(statement) { }
+    public class Start: GenericNode<StartStatement>, StatementWithBody {
+        public Start(StartStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.StartStatementEnd;
     }
 
     public class Stop: GenericNode<StopStatement>, Statement {
-	    public Stop(StopStatement statement): base(statement) { }
+        public Stop(StopStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
     }
 
-    public class String: GenericNode<StringStatement>, Statement, VariableWriter {
-	    public String(StringStatement statement): base(statement) { }
-	    public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
-	    public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
+    public class String: GenericNode<StringStatement>, StatementWithBody, VariableWriter {
+        public String(StringStatement statement): base(statement) { }
+        public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
+        public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this) && astVisitor.VisitVariableWriter(this);
         }
+        public CodeElementType EndType => CodeElementType.StringStatementEnd;
     }
 
-    public class Unstring: GenericNode<UnstringStatement>, Statement, VariableWriter {
-	    public Unstring(UnstringStatement statement): base(statement) { }
-	    public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
-	    public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
+    public class Unstring: GenericNode<UnstringStatement>, StatementWithBody, VariableWriter {
+        public Unstring(UnstringStatement statement): base(statement) { }
+        public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
+        public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this) && astVisitor.VisitVariableWriter(this);
         }
+        public CodeElementType EndType => CodeElementType.UnstringStatementEnd;
     }
 
-    public class XmlGenerate: GenericNode<XmlGenerateStatement>, Statement {
-	    public XmlGenerate(XmlGenerateStatement statement): base(statement) { }
+    public class XmlGenerate: GenericNode<XmlGenerateStatement>, StatementWithBody {
+        public XmlGenerate(XmlGenerateStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.XmlStatementEnd;
     }
 
-    public class XmlParse: GenericNode<XmlParseStatement>, Statement {
-	    public XmlParse(XmlParseStatement statement): base(statement) { }
+    public class XmlParse: GenericNode<XmlParseStatement>, StatementWithBody {
+        public XmlParse(XmlParseStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.XmlStatementEnd;
     }
 
 
 
     // --- ARITHMETIC STATEMENTS ---
 
-    public class Add: GenericNode<AddStatement>, Statement, VariableWriter {
-	    public Add(AddStatement statement): base(statement) { }
-	    public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
-	    public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
+    public class Add: GenericNode<AddStatement>, StatementWithBody, VariableWriter {
+        public Add(AddStatement statement): base(statement) { }
+        public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
+        public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this) && astVisitor.VisitVariableWriter(this);
         }
+
+        public CodeElementType EndType => CodeElementType.AddStatementEnd;
     }
 
     public class Use : GenericNode<UseStatement>, Statement
@@ -390,44 +412,48 @@ namespace TypeCobol.Compiler.Nodes {
         }
     }
 
-    public class Subtract: GenericNode<SubtractStatement>, Statement, VariableWriter {
-	    public Subtract(SubtractStatement statement): base(statement) { }
-	    public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
-	    public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
+    public class Subtract: GenericNode<SubtractStatement>, StatementWithBody, VariableWriter {
+        public Subtract(SubtractStatement statement): base(statement) { }
+        public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
+        public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this) && astVisitor.VisitVariableWriter(this);
         }
+        public CodeElementType EndType => CodeElementType.SubtractStatementEnd;
     }
 
-    public class Multiply: GenericNode<MultiplyStatement>, Statement, VariableWriter {
-	    public Multiply(MultiplyStatement statement): base(statement) { }
-	    public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
-	    public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
+    public class Multiply: GenericNode<MultiplyStatement>, StatementWithBody, VariableWriter {
+        public Multiply(MultiplyStatement statement): base(statement) { }
+        public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
+        public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this) && astVisitor.VisitVariableWriter(this);
         }
+        public CodeElementType EndType => CodeElementType.MultiplyStatementEnd;
     }
 
-    public class Divide: GenericNode<DivideStatement>, Statement, VariableWriter {
-	    public Divide(DivideStatement statement): base(statement) { }
-	    public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
-	    public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
+    public class Divide: GenericNode<DivideStatement>, StatementWithBody, VariableWriter {
+        public Divide(DivideStatement statement): base(statement) { }
+        public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
+        public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this) && astVisitor.VisitVariableWriter(this);
         }
+        public CodeElementType EndType => CodeElementType.DivideStatementEnd;
     }
 
-    public class Compute: GenericNode<ComputeStatement>, Statement, VariableWriter {
-	    public Compute(ComputeStatement statement): base(statement) { }
-	    public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
-	    public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
+    public class Compute: GenericNode<ComputeStatement>, StatementWithBody, VariableWriter {
+        public Compute(ComputeStatement statement): base(statement) { }
+        public IDictionary<StorageArea,object> VariablesWritten { get { return this.CodeElement.VariablesWritten; } }
+        public bool IsUnsafe { get { return this.CodeElement.IsUnsafe; } }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this) && astVisitor.VisitVariableWriter(this);
         }
+        public CodeElementType EndType => CodeElementType.ComputeStatementEnd;
     }
 
 
@@ -435,7 +461,7 @@ namespace TypeCobol.Compiler.Nodes {
     // --- FILE STATEMENTS ---
 
     public class Open: GenericNode<OpenStatement>, Statement {
-	    public Open(OpenStatement statement): base(statement) { }
+        public Open(OpenStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
@@ -443,35 +469,38 @@ namespace TypeCobol.Compiler.Nodes {
     }
 
     public class Close: GenericNode<CloseStatement>, Statement {
-	    public Close(CloseStatement statement): base(statement) { }
+        public Close(CloseStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
     }
 
-    public class Read: GenericNode<ReadStatement>, Statement {
-	    public Read(ReadStatement statement): base(statement) { }
+    public class Read: GenericNode<ReadStatement>, StatementWithBody {
+        public Read(ReadStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.ReadStatementEnd;
     }
 
-    public class Write: GenericNode<WriteStatement>, Statement {
-	    public Write(WriteStatement statement): base(statement) { }
+    public class Write: GenericNode<WriteStatement>, StatementWithBody {
+        public Write(WriteStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.WriteStatementEnd;
     }
 
-    public class Rewrite: GenericNode<RewriteStatement>, Statement {
-	    public Rewrite(RewriteStatement statement): base(statement) { }
+    public class Rewrite: GenericNode<RewriteStatement>, StatementWithBody {
+        public Rewrite(RewriteStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.RewriteStatementEnd;
     }
 
 
@@ -487,15 +516,16 @@ namespace TypeCobol.Compiler.Nodes {
     //  \---> ELSE
     //         \--> statements
 
-    public class If: GenericNode<IfStatement>, Statement {
-	    public If(IfStatement statement): base(statement) { }
+    public class If: GenericNode<IfStatement>, StatementWithBody {
+        public If(IfStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.IfStatementEnd;
     }
     public class Then: Node, StatementCondition {
-	    public Then()
+        public Then()
         {
             SetFlag(Node.Flag.GeneratorCanIgnoreIt, true);
         }
@@ -508,14 +538,14 @@ namespace TypeCobol.Compiler.Nodes {
         }
     }
     public class Else: GenericNode<ElseCondition>, StatementCondition {
-	    public Else(ElseCondition statement): base(statement) { }
+        public Else(ElseCondition statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
     }
     public class NextSentence: GenericNode<NextSentenceStatement>, Statement {
-	    public NextSentence(NextSentenceStatement statement): base(statement) { }
+        public NextSentence(NextSentenceStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
@@ -550,15 +580,16 @@ namespace TypeCobol.Compiler.Nodes {
     //  \---> WHEN-OTHER
     //         \--> statements
 
-    public class Evaluate: GenericNode<EvaluateStatement>, Statement {
-	    public Evaluate(EvaluateStatement statement): base(statement) { }
+    public class Evaluate: GenericNode<EvaluateStatement>, StatementWithBody {
+        public Evaluate(EvaluateStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.EvaluateStatementEnd;
     }
     public class WhenGroup: Node, StatementCondition {
-	    public WhenGroup()
+        public WhenGroup()
         {
             SetFlag(Node.Flag.GeneratorCanIgnoreIt, true);
         }
@@ -570,14 +601,14 @@ namespace TypeCobol.Compiler.Nodes {
         }
     }
     public class When: GenericNode<WhenCondition>, StatementCondition {
-	    public When(WhenCondition statement): base(statement) { }
+        public When(WhenCondition statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
     }
     public class WhenOther: GenericNode<WhenOtherCondition>, StatementCondition {
-	    public WhenOther(WhenOtherCondition statement): base(statement) { }
+        public WhenOther(WhenOtherCondition statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
@@ -588,15 +619,16 @@ namespace TypeCobol.Compiler.Nodes {
     // PERFORM
     //  \---> statements
 
-        public class Perform: GenericNode<PerformStatement>, Statement {
-	        public Perform(PerformStatement statement): base(statement) { }
+        public class Perform: GenericNode<PerformStatement>, StatementWithBody {
+            public Perform(PerformStatement statement): base(statement) { }
 
             public override bool VisitNode(IASTVisitor astVisitor) {
                 return astVisitor.Visit(this);
             }
-        }
+            public CodeElementType EndType => CodeElementType.PerformStatementEnd;
+    }
     public class PerformProcedure: GenericNode<PerformProcedureStatement>, Statement {
-	    public PerformProcedure(PerformProcedureStatement statement): base(statement) { }
+        public PerformProcedure(PerformProcedureStatement statement): base(statement) { }
 
             public ParagraphSymbol ProcedureParagraphSymbol { get; internal set; }
             public ParagraphSymbol ThroughProcedureParagraphSymbol { get; internal set; }
@@ -630,11 +662,12 @@ namespace TypeCobol.Compiler.Nodes {
     //         |--> conditions
     //         \--> THEN
     //               \--> statements
-    public class Search: GenericNode<SearchStatement>, Statement {
-	    public Search(SearchStatement statement): base(statement) { }
+    public class Search: GenericNode<SearchStatement>, StatementWithBody {
+        public Search(SearchStatement statement): base(statement) { }
         public override bool VisitNode(IASTVisitor astVisitor)
         {
             return astVisitor.Visit(this);
         }
+        public CodeElementType EndType => CodeElementType.SearchStatementEnd;
     }
 } // end of namespace TypeCobol.Compiler.Nodes


### PR DESCRIPTION
Fixes #2441.

This is a WIP as we should test on other cases of invalid AST logged in our traces.
Does the code should attempt to `Exit` up to the appropriate opening statement ? To discuss.