### PR TITLE
WI #2457 Temporary exclude failing tests for ClearDocumentThenRewriteLineByLine

### DIFF
--- a/TypeCobol.Test/Parser/Incremental/TestIncrementalPipeline.cs
+++ b/TypeCobol.Test/Parser/Incremental/TestIncrementalPipeline.cs
@@ -51,12 +51,12 @@ namespace TypeCobol.Test.Parser.Incremental
         [TestProperty("Time", "fast")]
         public void ContinuationLines() => TestFolder();
 
-        private static void TestProgramsWithChangesGenerator<TChangesGenerator>()
+        private static void TestProgramsWithChangesGenerator<TChangesGenerator>(params string[] exclude)
             where TChangesGenerator : IIncrementalChangesGenerator, new()
         {
             string[] extensions = { ".cbl", ".pgm", ".tcbl" };
             Console.WriteLine("Entering directory \"" + _RootPrograms + "\" [" + string.Join(", ", extensions) + "]:");
-            var folderTester = new FolderTester(_RootPrograms, extensions) { ChangesGenerator = new TChangesGenerator() };
+            var folderTester = new FolderTester(_RootPrograms, extensions, exclude: exclude) { ChangesGenerator = new TChangesGenerator() };
             int nbOfTests = folderTester.Test();
             Console.Write("Number of tests: " + nbOfTests + "\n");
             Assert.IsTrue(nbOfTests > 0, "No tests found");
@@ -74,9 +74,25 @@ namespace TypeCobol.Test.Parser.Incremental
         [TestCategory("Incremental")]
         public void AddEmptyLineInTheMiddleThenRemove() => TestProgramsWithChangesGenerator<AddEmptyLineInTheMiddleThenRemove>();
 
-        [Ignore]
         [TestMethod]
         [TestCategory("Incremental")]
-        public void ClearDocumentThenRewriteLineByLine() => TestProgramsWithChangesGenerator<ClearDocumentThenRewriteLineByLine>();
+        public void ClearDocumentThenRewriteLineByLine() => TestProgramsWithChangesGenerator<ClearDocumentThenRewriteLineByLine>(
+            "DebugLinesNotDebugging",
+            "InvalidReplace",
+            "InvalidReplace2",
+            "MaximumNameLength",
+            "NonUsualProcedureName",
+            "PgmEmptyPartialWordReplace",
+            "Replace",
+            "ReplaceMultipleTokens",
+            "ReplaceOccurs",
+            "ReplaceSimilarStatements",
+            "ReplaceTokenInsideDataDiv",
+            "ReplaceTokenInsideDataDiv2",
+            "ReplaceWithCommentLine",
+            "ReplaceWithLineBreak",
+            "Replace_SeparatorsForPartialCobolWords",
+            "REPLACPGM"
+        );
     }
 }

--- a/TypeCobol.Test/Utils/FolderTester.cs
+++ b/TypeCobol.Test/Utils/FolderTester.cs
@@ -119,11 +119,13 @@ namespace TypeCobol.Test.Utils
         private readonly HashSet<string> _resultExtensions;
         private readonly bool _recursive;
         private readonly string _filterPrefix;
+        private readonly string[] _exclude;
 
         public bool IsCobolLanguage { get; set; } = false;
         public IIncrementalChangesGenerator ChangesGenerator { get; set; } = null;
 
-        public FolderTester(string rootFolder, string[] sourceExtensions, string[] changeExtensions = null, string[] resultExtensions = null, bool recursive = true, string filterPrefix = null)
+        public FolderTester(string rootFolder, string[] sourceExtensions, string[] changeExtensions = null, string[] resultExtensions = null, bool recursive = true,
+            string filterPrefix = null, params string[] exclude)
         {
             if (string.IsNullOrEmpty(rootFolder))
             {
@@ -141,6 +143,7 @@ namespace TypeCobol.Test.Utils
             _resultExtensions = (IsNullOrEmpty(resultExtensions) ? _DefaultResultExtensions : resultExtensions).ToHashSet(StringComparer.OrdinalIgnoreCase);
             _recursive = recursive;
             _filterPrefix = filterPrefix;
+            _exclude = exclude;
 
             // Consistency checks, extension categories should not overlap
             CheckNoOverlap(nameof(sourceExtensions), _sourceExtensions, nameof(changeExtensions), _changeExtensions);
@@ -193,6 +196,12 @@ namespace TypeCobol.Test.Utils
                 int cut = fileName.IndexOf('.');
                 string testName = fileName.Substring(0, cut);
                 string extension = Path.GetExtension(fileName); // Includes dot
+
+                // Apply exclusions
+                if (_exclude.Contains(testName, StringComparer.InvariantCultureIgnoreCase))
+                {
+                    continue;
+                }
 
                 // Categorize file based on its extension
                 Action<TestUnitData> addFile;


### PR DESCRIPTION
16 exclusions but will go back to 1 failing tests after fixing #2474 and #2476.