### PR TITLE
WI #2482 did save only rescan whole document if LSP server don't lag

### DIFF
--- a/TypeCobol.LanguageServer/JsonRPC/IRPCHandler.cs
+++ b/TypeCobol.LanguageServer/JsonRPC/IRPCHandler.cs
@@ -7,10 +7,10 @@ namespace TypeCobol.LanguageServer.JsonRPC
     /// <summary>
     /// Handle a notification received from a remote client
     /// </summary>
-    public delegate void NotificationHandler(NotificationType notificationType, object parameters);
+    public delegate void NotificationHandler(NotificationType notificationType, object parameters, LSPProfiling lspProfiling);
 
     /// <summary>
     /// Execute a request received from a remote client and return a ressult or error
     /// </summary>
-    public delegate ResponseResultOrError RequestHandler(RequestType requestType, object parameters);
+    public delegate ResponseResultOrError RequestHandler(RequestType requestType, object parameters, LSPProfiling lspProfiling);
 }

--- a/TypeCobol.LanguageServer/StdioHttp/IMessageHandler.cs
+++ b/TypeCobol.LanguageServer/StdioHttp/IMessageHandler.cs
@@ -10,6 +10,6 @@ namespace TypeCobol.LanguageServer.StdioHttp
         /// <summary>
         /// Do something useful with the message received, use the server interface to reply
         /// </summary>
-        void HandleMessage(string message, IMessageServer server);
+        void HandleMessage(string message, IMessageServer server, LSPProfiling lspProfiling);
     }
 }

--- a/TypeCobol.LanguageServer/TypeCobolCustomLanguageServer/TypeCobolCustomLanguageServer.cs
+++ b/TypeCobol.LanguageServer/TypeCobolCustomLanguageServer/TypeCobolCustomLanguageServer.cs
@@ -72,16 +72,21 @@ namespace TypeCobol.LanguageServer.TypeCobolCustomLanguageServerProtocol
             base.OnShutdown();
         }
 
-        protected override void OnDidSaveTextDocument(DidSaveTextDocumentParams parameters)
+        protected override void OnDidSaveTextDocument(DidSaveTextDocumentParams parameters, LSPProfiling lspProfiling)
         {
-            base.OnDidSaveTextDocument(parameters);
+            //Too much server lag: skip this notification. The only drawbacks is that diagnostics might not be totally accurate are we still have some incremental bugs
+            if (lspProfiling.InQueueDuration > 2000)
+            {
+                return;
+            }
+            base.OnDidSaveTextDocument(parameters, lspProfiling);
             if (parameters.text != null && UseOutlineRefresh)
             {
                 OnDidReceiveRefreshOutline(parameters.textDocument.uri, true);
             }
         }
 
-        private void CallReceiveMissingCopies(NotificationType notificationType, object parameters)
+        private void CallReceiveMissingCopies(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             try
             {
@@ -93,7 +98,7 @@ namespace TypeCobol.LanguageServer.TypeCobolCustomLanguageServerProtocol
             }
         }
 
-        private void ReceivedRefreshNodeDemand(NotificationType notificationType, object parameters)
+        private void ReceivedRefreshNodeDemand(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             try
             {
@@ -105,7 +110,7 @@ namespace TypeCobol.LanguageServer.TypeCobolCustomLanguageServerProtocol
             }
         }
 
-        private ResponseResultOrError ReceivedRefreshNodeRequest(RequestType requestType, object parameters)
+        private ResponseResultOrError ReceivedRefreshNodeRequest(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -122,7 +127,7 @@ namespace TypeCobol.LanguageServer.TypeCobolCustomLanguageServerProtocol
         }
 
 #if EUROINFO_RULES
-        private ResponseResultOrError ReceivedExtractRemarksDataRequest(RequestType requestType, object parameters)
+        private ResponseResultOrError ReceivedExtractRemarksDataRequest(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError;
             try
@@ -145,7 +150,7 @@ namespace TypeCobol.LanguageServer.TypeCobolCustomLanguageServerProtocol
         }
 #endif
 
-        private void ReceivedSignatureHelpContext(NotificationType notificationType, object parameters)
+        private void ReceivedSignatureHelpContext(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             try
             {
@@ -206,7 +211,7 @@ namespace TypeCobol.LanguageServer.TypeCobolCustomLanguageServerProtocol
         }
 #endif
 
-        private void ReceivedExtractUseCopiesNotification(NotificationType notificationType, object parameters)
+        private void ReceivedExtractUseCopiesNotification(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             try
             {
@@ -223,7 +228,7 @@ namespace TypeCobol.LanguageServer.TypeCobolCustomLanguageServerProtocol
         /// </summary>
         /// <param name="notificationType"></param>
         /// <param name="parameters"></param>
-        private void ReceivedDidOpenProjectTextDocument(NotificationType notificationType, object parameters)
+        private void ReceivedDidOpenProjectTextDocument(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             DidOpenProjectTextDocumentParams didOpenParams = (DidOpenProjectTextDocumentParams)parameters;            
             try
@@ -242,7 +247,7 @@ namespace TypeCobol.LanguageServer.TypeCobolCustomLanguageServerProtocol
         /// </summary>
         /// <param name="notificationType">Notification's type</param>
         /// <param name="parameters">Notification's parameters</param>
-        private void ReceivedDidChangeProjectConfiguration(NotificationType notificationType, object parameters)
+        private void ReceivedDidChangeProjectConfiguration(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             DidChangeProjectConfigurationParams docChangeConfParams = (DidChangeProjectConfigurationParams)parameters;
             try

--- a/TypeCobol.LanguageServer/TypeCobolCustomLanguageServer/TypeCobolCustomLanguageServer.cs
+++ b/TypeCobol.LanguageServer/TypeCobolCustomLanguageServer/TypeCobolCustomLanguageServer.cs
@@ -72,10 +72,13 @@ namespace TypeCobol.LanguageServer.TypeCobolCustomLanguageServerProtocol
             base.OnShutdown();
         }
 
+
+        public static readonly TimeSpan MaxQueueWaitForDidSave = TimeSpan.FromSeconds(2);
+
         protected override void OnDidSaveTextDocument(DidSaveTextDocumentParams parameters, LSPProfiling lspProfiling)
         {
             //Too much server lag: skip this notification. The only drawbacks is that diagnostics might not be totally accurate are we still have some incremental bugs
-            if (lspProfiling.InQueueDuration > 2000)
+            if (lspProfiling.InQueueDuration > MaxQueueWaitForDidSave)
             {
                 return;
             }

--- a/TypeCobol.LanguageServer/TypeCobolServer.cs
+++ b/TypeCobol.LanguageServer/TypeCobolServer.cs
@@ -432,7 +432,7 @@ namespace TypeCobol.LanguageServer
             }
         }
 
-        protected override void OnDidSaveTextDocument(DidSaveTextDocumentParams parameters)
+        protected override void OnDidSaveTextDocument(DidSaveTextDocumentParams parameters, LSPProfiling lspProfiling)
         {
             if (parameters.text != null)
             {

--- a/TypeCobol.LanguageServer/TypeCobolServerHost.cs
+++ b/TypeCobol.LanguageServer/TypeCobolServerHost.cs
@@ -419,12 +419,19 @@ namespace TypeCobol.LanguageServer
 
     public class LSPProfiling
     {
+        /// <summary>
+        /// </summary>
+        /// <param name="inQueueDuration">Time waited in the queue in milliseconds</param>
+        /// <param name="numberOfMessagesToProcess"></param>
         public LSPProfiling(long inQueueDuration, int numberOfMessagesToProcess)
         {
             this.InQueueDuration = inQueueDuration;
             this.NumberOfMessagesToProcess = numberOfMessagesToProcess;
         }
 
+        /// <summary>
+        /// Time waited in the queue in milliseconds.
+        /// </summary>
         public long InQueueDuration { get; }
         /// <summary>
         /// Number of messages left to process

--- a/TypeCobol.LanguageServer/TypeCobolServerHost.cs
+++ b/TypeCobol.LanguageServer/TypeCobolServerHost.cs
@@ -390,12 +390,12 @@ namespace TypeCobol.LanguageServer
 
                 if (MessagesActionQueue.TryDequeue(out MessageActionWrapper messageActionWrapper)) //Pop out message from queue
                 {
-                    messageActionWrapper.BeginProcess();
+                    messageActionWrapper.InQueueDuration.Stop();
                     //processDuration is here just to help during debug or when we need to add temporary code to check process duration of messages
                     Stopwatch processDuration = new Stopwatch();
                     processDuration.Start();
 
-                    LSPProfiling lspProfiling = new LSPProfiling(messageActionWrapper.InQueueDuration.ElapsedMilliseconds, MessagesActionQueue.Count);
+                    LSPProfiling lspProfiling = new LSPProfiling(messageActionWrapper.InQueueDuration.Elapsed, MessagesActionQueue.Count);
 
                     if (messageActionWrapper.MessageKind == MessageKind.JSonMessage)
                         messageHandler.HandleMessage(messageActionWrapper.Message, messageActionWrapper.MessageServer, lspProfiling); //Give this message to the real handler
@@ -422,8 +422,8 @@ namespace TypeCobol.LanguageServer
         /// <summary>
         /// </summary>
         /// <param name="inQueueDuration">Time waited in the queue in milliseconds</param>
-        /// <param name="numberOfMessagesToProcess"></param>
-        public LSPProfiling(long inQueueDuration, int numberOfMessagesToProcess)
+        /// <param name="numberOfMessagesToProcess">Number of messages left to process after this one</param>
+        public LSPProfiling(TimeSpan inQueueDuration, int numberOfMessagesToProcess)
         {
             this.InQueueDuration = inQueueDuration;
             this.NumberOfMessagesToProcess = numberOfMessagesToProcess;
@@ -432,10 +432,10 @@ namespace TypeCobol.LanguageServer
         /// <summary>
         /// Time waited in the queue in milliseconds.
         /// </summary>
-        public long InQueueDuration { get; }
+        public TimeSpan InQueueDuration { get; }
         /// <summary>
-        /// Number of messages left to process
+        /// Number of messages left to process after this one
         /// </summary>
-        public long NumberOfMessagesToProcess { get; }
+        public int NumberOfMessagesToProcess { get; }
     }
 }

--- a/TypeCobol.LanguageServer/Utilities/MessageActionWrapper.cs
+++ b/TypeCobol.LanguageServer/Utilities/MessageActionWrapper.cs
@@ -1,20 +1,22 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics;
 using TypeCobol.LanguageServer.StdioHttp;
 
 namespace TypeCobol.LanguageServer
 {
     public class MessageActionWrapper
     {
+        private MessageActionWrapper()
+        {
+            InQueueDuration = new Stopwatch();
+            InQueueDuration.Start();
+        }
         /// <summary>
         /// Constructor for JSonMessage Queue Element
         /// </summary>
         /// <param name="message">JSonRPC message</param>
         /// <param name="messageHandler">A class object that inherit from interface IMessageHandler</param>
-        public MessageActionWrapper(string message, IMessageServer messageHandler)
+        public MessageActionWrapper(string message, IMessageServer messageHandler) : this()
         {
             MessageKind = MessageKind.JSonMessage;
             Message = message;
@@ -25,7 +27,7 @@ namespace TypeCobol.LanguageServer
         /// Constructor for Action Queue Element
         /// </summary>
         /// <param name="action">Delegated Action to be executed</param>
-        public MessageActionWrapper(Action action)
+        public MessageActionWrapper(Action action) : this()
         {
             MessageKind = MessageKind.Action;
             Action = action;
@@ -35,6 +37,15 @@ namespace TypeCobol.LanguageServer
         public Action Action { get; private set; }
         public string Message { get; private set; }
         public IMessageServer MessageServer { get; private set; } 
+        public Stopwatch InQueueDuration { get; }
+
+        /// <summary>
+        /// Call this method when this message is dequeue and will be processed
+        /// </summary>
+        public void BeginProcess()
+        {
+            InQueueDuration.Stop();
+        }
     }
 
     public enum MessageKind

--- a/TypeCobol.LanguageServer/Utilities/MessageActionWrapper.cs
+++ b/TypeCobol.LanguageServer/Utilities/MessageActionWrapper.cs
@@ -38,14 +38,6 @@ namespace TypeCobol.LanguageServer
         public string Message { get; private set; }
         public IMessageServer MessageServer { get; private set; } 
         public Stopwatch InQueueDuration { get; }
-
-        /// <summary>
-        /// Call this method when this message is dequeue and will be processed
-        /// </summary>
-        public void BeginProcess()
-        {
-            InQueueDuration.Stop();
-        }
     }
 
     public enum MessageKind

--- a/TypeCobol.LanguageServer/VsCodeProtocol/LanguageServer.cs
+++ b/TypeCobol.LanguageServer/VsCodeProtocol/LanguageServer.cs
@@ -88,7 +88,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
 
         // --- Generic notification and request handlers ---
 
-        private ResponseResultOrError CallCodeAction(RequestType requestType, object parameters)
+        private ResponseResultOrError CallCodeAction(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -104,7 +104,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallCodeLens(RequestType requestType, object parameters)
+        private ResponseResultOrError CallCodeLens(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -120,7 +120,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallCodeLensResolve(RequestType requestType, object parameters)
+        private ResponseResultOrError CallCodeLensResolve(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -136,7 +136,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallCompletion(RequestType requestType, object parameters)
+        private ResponseResultOrError CallCompletion(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -152,7 +152,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallCompletionResolve(RequestType requestType, object parameters)
+        private ResponseResultOrError CallCompletionResolve(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -168,7 +168,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallDocumentHighlight(RequestType requestType, object parameters)
+        private ResponseResultOrError CallDocumentHighlight(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -184,7 +184,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallDocumentSymbol(RequestType requestType, object parameters)
+        private ResponseResultOrError CallDocumentSymbol(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -200,7 +200,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallDocumentFormatting(RequestType requestType, object parameters)
+        private ResponseResultOrError CallDocumentFormatting(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -216,7 +216,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallDocumentOnTypeFormatting(RequestType requestType, object parameters)
+        private ResponseResultOrError CallDocumentOnTypeFormatting(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -232,7 +232,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallDocumentRangeFormatting(RequestType requestType, object parameters)
+        private ResponseResultOrError CallDocumentRangeFormatting(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -248,7 +248,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallDefinition(RequestType requestType, object parameters)
+        private ResponseResultOrError CallDefinition(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -264,7 +264,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallHoverRequest(RequestType requestType, object parameters)
+        private ResponseResultOrError CallHoverRequest(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -280,7 +280,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallInitialize(RequestType requestType, object parameters)
+        private ResponseResultOrError CallInitialize(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -296,7 +296,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallReferences(RequestType requestType, object parameters)
+        private ResponseResultOrError CallReferences(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -312,7 +312,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallRename(RequestType requestType, object parameters)
+        private ResponseResultOrError CallRename(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -330,7 +330,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
 
         private bool shutdownReceived = false;
 
-        private ResponseResultOrError CallShutdown(RequestType requestType, object parameters)
+        private ResponseResultOrError CallShutdown(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -347,7 +347,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallSignatureHelp(RequestType requestType, object parameters)
+        private ResponseResultOrError CallSignatureHelp(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -363,7 +363,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private ResponseResultOrError CallWorkspaceSymbol(RequestType requestType, object parameters)
+        private ResponseResultOrError CallWorkspaceSymbol(RequestType requestType, object parameters, LSPProfiling lspProfiling)
         {
             ResponseResultOrError resultOrError = null;
             try
@@ -379,7 +379,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             return resultOrError;
         }
 
-        private void CallDidChangeConfiguration(NotificationType notificationType, object parameters)
+        private void CallDidChangeConfiguration(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             try
             {
@@ -392,7 +392,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             }
         }
 
-        private void CallExit(NotificationType notificationType, object parameters)
+        private void CallExit(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             try
             {
@@ -415,7 +415,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             }
         }
 
-        private void CallDidChangeWatchedFiles(NotificationType notificationType, object parameters)
+        private void CallDidChangeWatchedFiles(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             try
             {
@@ -428,7 +428,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             }
         }
 
-        private void CallDidChangeTextDocument(NotificationType notificationType, object parameters)
+        private void CallDidChangeTextDocument(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             try
             {
@@ -441,7 +441,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             }
         }
 
-        private void CallDidCloseTextDocument(NotificationType notificationType, object parameters)
+        private void CallDidCloseTextDocument(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             try
             {
@@ -454,7 +454,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             }
         }
 
-        private void CallDidOpenTextDocument(NotificationType notificationType, object parameters)
+        private void CallDidOpenTextDocument(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             try
             {
@@ -467,11 +467,11 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             }
         }
 
-        private void CallDidSaveTextDocument(NotificationType notificationType, object parameters)
+        private void CallDidSaveTextDocument(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             try
             {
-                OnDidSaveTextDocument((DidSaveTextDocumentParams)parameters);
+                OnDidSaveTextDocument((DidSaveTextDocumentParams)parameters, lspProfiling);
             }
             catch (Exception e)
             {
@@ -480,7 +480,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
             }
         }
 
-        private void CallClientInitialized(NotificationType notificationType, object parameters)
+        private void CallClientInitialized(NotificationType notificationType, object parameters, LSPProfiling lspProfiling)
         {
             try
             {
@@ -597,7 +597,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
         /// <summary>
         /// The document save notification is sent from the client to the server when the document for saved in the client.
         /// </summary>
-        protected virtual void OnDidSaveTextDocument(DidSaveTextDocumentParams parameters)
+        protected virtual void OnDidSaveTextDocument(DidSaveTextDocumentParams parameters, LSPProfiling lspProfiling)
         { }
 
         /// <summary>


### PR DESCRIPTION
Fix #2482.
Add a new LSPProfiling object which is passed to all LSP methods that process a message.
LSPProfiling contains:
```C#
        /// <summary>
        /// Time waited in the queue in milliseconds.
        /// </summary>
        public long InQueueDuration { get; }
        /// <summary>
        /// Number of messages left to process
        /// </summary>
        public long NumberOfMessagesToProcess { get; }
```

DidSave method will return without doing anything if the message waited in the queue more than 2 seconds.