### PR TITLE
WI #2509 Fix crash when getting value on an EnumeratedValue

### DIFF
--- a/TypeCobol/Compiler/CodeElements/Expressions/SyntaxValue.cs
+++ b/TypeCobol/Compiler/CodeElements/Expressions/SyntaxValue.cs
@@ -559,6 +559,16 @@ namespace TypeCobol.Compiler.CodeElements
         public override bool AcceptASTVisitor(IASTVisitor astVisitor) {
             return base.AcceptASTVisitor(astVisitor) && astVisitor.Visit(this);
         }
+
+        // Enum value should logically depends on nothing
+        public override bool ValueNeedsCompilationContext => false;
+
+        public override bool ValueNeedsSymbolicCharactersMap => false;
+
+        public override bool ValueNeedsCharactersCountContext => false;
+
+        // Enum value should logically always be the token text
+        public override string Value => Token.Text;
     }
 
     /// <summary>


### PR DESCRIPTION
Actually getting the value on a `EnumeratedValue ` might crash because `ValueNeedsCompilationContext`, `ValueNeedsSymbolicCharactersMap `and `ValueNeedsCharactersCountContext `are not defined.

As a result `ToString `on a `EnumeratedValue ` returns 'Illegal &lt;token&gt;'.

Enumerated value should logically always be the token text and depend on nothing.
