### PR TITLE
WI #2538 Split EI-Legacy REPLACING syntax option over 2 separate options

### DIFF
--- a/CLI/src/CLI.cs
+++ b/CLI/src/CLI.cs
@@ -252,14 +252,7 @@ namespace TypeCobol.Server
         {
             foreach (var textNameVariation in usedCopies)
             {
-#if EUROINFO_RULES
-                string copyName = _configuration.EILegacy_ApplyCopySuffixing
-                    ? textNameVariation.TextName
-                    : textNameVariation.TextNameWithSuffix;
-#else
-                string copyName = textNameVariation.TextNameWithSuffix;
-#endif
-                _usedCopies.Add(copyName);
+                _usedCopies.Add(textNameVariation.GetFileName(_configuration));
             }
         }
 

--- a/CLI/src/CLI.cs
+++ b/CLI/src/CLI.cs
@@ -253,7 +253,7 @@ namespace TypeCobol.Server
             foreach (var textNameVariation in usedCopies)
             {
 #if EUROINFO_RULES
-                string copyName = _configuration.UseEuroInformationLegacyReplacingSyntax
+                string copyName = _configuration.EILegacy_ApplyCopySuffixing
                     ? textNameVariation.TextName
                     : textNameVariation.TextNameWithSuffix;
 #else

--- a/CLI/test/CLITest.cs
+++ b/CLI/test/CLITest.cs
@@ -201,6 +201,8 @@ namespace CLI.Test
         {
 #if EUROINFO_RULES
             CLITestHelper.Test("replacingSyntaxOption", ReturnCode.ParsingDiagnostics);
+            CLITestHelper.Test("replacingSyntaxOption_OnlyApplyCopySuffixing", ReturnCode.ParsingDiagnostics);
+            CLITestHelper.Test("replacingSyntaxOption_OnlyRemoveFirst01Level", ReturnCode.MissingCopy);
 #endif
         }
 

--- a/CLI/test/ressources/replacingSyntaxOption/CLIArguments.txt
+++ b/CLI/test/ressources/replacingSyntaxOption/CLIArguments.txt
@@ -1,1 +1,1 @@
-﻿-i input\replacingSyntaxOff.rdz.tcbl -o output\replacingSyntaxOff.rdz.tcbl -d output\error.txt -e rdz -dcs
+﻿-i input\replacingSyntaxOff.rdz.tcbl -o output\replacingSyntaxOff.rdz.tcbl -d output\error.txt -e rdz -drfl -dcsm

--- a/CLI/test/ressources/replacingSyntaxOption_OnlyApplyCopySuffixing/CLIArguments.txt
+++ b/CLI/test/ressources/replacingSyntaxOption_OnlyApplyCopySuffixing/CLIArguments.txt
@@ -1,0 +1,1 @@
+﻿-i input\replacingSyntaxPartial.rdz.tcbl -o output\replacingSyntaxPartial.rdz.tcbl -d output\error.txt -e rdz -drfl -ycpl input\CPY.list

--- a/CLI/test/ressources/replacingSyntaxOption_OnlyApplyCopySuffixing/input/CPY.list
+++ b/CLI/test/ressources/replacingSyntaxOption_OnlyApplyCopySuffixing/input/CPY.list
@@ -1,0 +1,1 @@
+YCONVEA

--- a/CLI/test/ressources/replacingSyntaxOption_OnlyApplyCopySuffixing/input/YCONVEA.CPY
+++ b/CLI/test/ressources/replacingSyntaxOption_OnlyApplyCopySuffixing/input/YCONVEA.CPY
@@ -1,0 +1,10 @@
+       01 CONVEA.
+         05  CONVEA-VEA-VEA-OUT-VEA pic X.
+         05  CONVEA-VEA-VEA-OUT-VEA-2 pic X.
+         05  CONVEA pic X.
+         05  CONVEA-VEA pic X.
+         05  ANOTHER-DATA pic X.
+         05  CONVEA-VEATEST pic X.
+         05  CONVEA-TESTVEA pic X.
+         05  CONVEA-TESTVEA-TEST pic X.
+         05  CONVEA-TESTVEATEST pic X.

--- a/CLI/test/ressources/replacingSyntaxOption_OnlyApplyCopySuffixing/input/replacingSyntaxPartial.rdz.tcbl
+++ b/CLI/test/ressources/replacingSyntaxOption_OnlyApplyCopySuffixing/input/replacingSyntaxPartial.rdz.tcbl
@@ -1,0 +1,41 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DVZS0OSM.
+       
+       data division.
+       working-storage section.
+       
+       COPY YCONVEA.
+       COPY YCONVEAL.
+       
+       PROCEDURE DIVISION.
+      * Data items from non-suffixed copy / 01 level is kept
+      * Ambiguous
+           DISPLAY CONVEA
+           DISPLAY CONVEA-VEA-VEA-OUT-VEA
+           DISPLAY CONVEA-VEA-VEA-OUT-VEA-2
+      * Ambiguous
+           DISPLAY CONVEA
+           DISPLAY CONVEA-VEA
+      * Ambiguous
+           DISPLAY ANOTHER-DATA
+           DISPLAY CONVEA-VEATEST
+           DISPLAY CONVEA-TESTVEA
+           DISPLAY CONVEA-TESTVEA-TEST
+           DISPLAY CONVEA-TESTVEATEST
+      * Data items from suffixed copy / 01 level is kept
+      * Ambiguous
+           DISPLAY CONVEA
+           DISPLAY CONVEAL-VEAL-VEAL-OUT-VEA
+           DISPLAY CONVEAL-VEAL-VEAL-OUT-VEAL-2
+      * Ambiguous
+           DISPLAY CONVEA
+           DISPLAY CONVEAL-VEA
+      * Ambiguous
+           DISPLAY ANOTHER-DATA
+           DISPLAY CONVEAL-VEATEST
+           DISPLAY CONVEAL-TESTVEA
+           DISPLAY CONVEAL-TESTVEAL-TEST
+           DISPLAY CONVEAL-TESTVEATEST
+           GOBACK
+           .
+       END PROGRAM DVZS0OSM.

--- a/CLI/test/ressources/replacingSyntaxOption_OnlyApplyCopySuffixing/output_expected/error.txt
+++ b/CLI/test/ressources/replacingSyntaxOption_OnlyApplyCopySuffixing/output_expected/error.txt
@@ -1,0 +1,14 @@
+ReturnCode=ParsingDiagnostics_
+6 errors in "input\replacingSyntaxPartial.rdz.tcbl":
+Line 13[20,25] <30, Error, Semantics> - Semantic error: Ambiguous reference to symbol CONVEA 
+Symbols found: DVZS0OSM::CONVEA | DVZS0OSM::CONVEA::CONVEA | DVZS0OSM::CONVEA | DVZS0OSM::CONVEA::CONVEA
+Line 17[20,25] <30, Error, Semantics> - Semantic error: Ambiguous reference to symbol CONVEA 
+Symbols found: DVZS0OSM::CONVEA | DVZS0OSM::CONVEA::CONVEA | DVZS0OSM::CONVEA | DVZS0OSM::CONVEA::CONVEA
+Line 20[20,31] <30, Error, Semantics> - Semantic error: Ambiguous reference to symbol ANOTHER-DATA 
+Symbols found: DVZS0OSM::CONVEA::ANOTHER-DATA | DVZS0OSM::CONVEA::ANOTHER-DATA
+Line 27[20,25] <30, Error, Semantics> - Semantic error: Ambiguous reference to symbol CONVEA 
+Symbols found: DVZS0OSM::CONVEA | DVZS0OSM::CONVEA::CONVEA | DVZS0OSM::CONVEA | DVZS0OSM::CONVEA::CONVEA
+Line 31[20,25] <30, Error, Semantics> - Semantic error: Ambiguous reference to symbol CONVEA 
+Symbols found: DVZS0OSM::CONVEA | DVZS0OSM::CONVEA::CONVEA | DVZS0OSM::CONVEA | DVZS0OSM::CONVEA::CONVEA
+Line 34[20,31] <30, Error, Semantics> - Semantic error: Ambiguous reference to symbol ANOTHER-DATA 
+Symbols found: DVZS0OSM::CONVEA::ANOTHER-DATA | DVZS0OSM::CONVEA::ANOTHER-DATA

--- a/CLI/test/ressources/replacingSyntaxOption_OnlyRemoveFirst01Level/CLIArguments.txt
+++ b/CLI/test/ressources/replacingSyntaxOption_OnlyRemoveFirst01Level/CLIArguments.txt
@@ -1,0 +1,1 @@
+﻿-i input\replacingSyntaxPartial.rdz.tcbl -o output\replacingSyntaxPartial.rdz.tcbl -d output\error.txt -e rdz -dcsm -ycpl input\CPY.list

--- a/CLI/test/ressources/replacingSyntaxOption_OnlyRemoveFirst01Level/input/CPY.list
+++ b/CLI/test/ressources/replacingSyntaxOption_OnlyRemoveFirst01Level/input/CPY.list
@@ -1,0 +1,1 @@
+YCONVEA

--- a/CLI/test/ressources/replacingSyntaxOption_OnlyRemoveFirst01Level/input/YCONVEA.CPY
+++ b/CLI/test/ressources/replacingSyntaxOption_OnlyRemoveFirst01Level/input/YCONVEA.CPY
@@ -1,0 +1,10 @@
+       01 CONVEA.
+         05  CONVEA-VEA-VEA-OUT-VEA pic X.
+         05  CONVEA-VEA-VEA-OUT-VEA-2 pic X.
+         05  CONVEA pic X.
+         05  CONVEA-VEA pic X.
+         05  ANOTHER-DATA pic X.
+         05  CONVEA-VEATEST pic X.
+         05  CONVEA-TESTVEA pic X.
+         05  CONVEA-TESTVEA-TEST pic X.
+         05  CONVEA-TESTVEATEST pic X.

--- a/CLI/test/ressources/replacingSyntaxOption_OnlyRemoveFirst01Level/input/replacingSyntaxPartial.rdz.tcbl
+++ b/CLI/test/ressources/replacingSyntaxOption_OnlyRemoveFirst01Level/input/replacingSyntaxPartial.rdz.tcbl
@@ -1,0 +1,24 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DVZS0OSM.
+       
+       data division.
+       working-storage section.
+       
+       01 group1. COPY YCONVEA.
+      * Missing copy
+       COPY YCONVEAL.
+       
+       PROCEDURE DIVISION.
+      * Data items from non-suffixed copy / 01 level is removed
+           DISPLAY CONVEA-VEA-VEA-OUT-VEA
+           DISPLAY CONVEA-VEA-VEA-OUT-VEA-2
+           DISPLAY CONVEA
+           DISPLAY CONVEA-VEA
+           DISPLAY ANOTHER-DATA
+           DISPLAY CONVEA-VEATEST
+           DISPLAY CONVEA-TESTVEA
+           DISPLAY CONVEA-TESTVEA-TEST
+           DISPLAY CONVEA-TESTVEATEST
+           GOBACK
+           .
+       END PROGRAM DVZS0OSM.

--- a/CLI/test/ressources/replacingSyntaxOption_OnlyRemoveFirst01Level/output_expected/error.txt
+++ b/CLI/test/ressources/replacingSyntaxOption_OnlyRemoveFirst01Level/output_expected/error.txt
@@ -1,0 +1,3 @@
+ReturnCode=MissingCopy_
+1 error in "input\replacingSyntaxPartial.rdz.tcbl":
+Line 9[8,21] <28, Error, Directives> - Failed to load COPY : Cobol source file not found: YCONVEAL

--- a/Codegen/src/Actions/Remarks.cs
+++ b/Codegen/src/Actions/Remarks.cs
@@ -43,10 +43,11 @@ namespace TypeCobol.Codegen.Actions
         public IList<Action> Execute()
         {
 #if EUROINFO_RULES
-            if (!CompilationDocument.CompilerOptions.UseEuroInformationLegacyReplacingSyntax || CompilationDocument.CompilerOptions.IsCobolLanguage)
+            bool useEuroInformationLegacyReplacingSyntax = CompilationDocument.CompilerOptions.EILegacy_RemoveFirst01Level && CompilationDocument.CompilerOptions.EILegacy_ApplyCopySuffixing;
+            if (!useEuroInformationLegacyReplacingSyntax || CompilationDocument.CompilerOptions.IsCobolLanguage)
             {
                 /*
-                 * The original REMARKS directive (if any) is parsed only when UseEuroInformationLegacyReplacingSyntax is active
+                 * The original REMARKS directive (if any) is parsed only when Euro-Information legacy REPLACING syntax is fully active
                  * and only for TypeCobol. So here we use the negation: if the legacy syntax is disabled or if we are in pure cobol mode,
                  * we do not attempt to generate the REMARKS directive.
                  *

--- a/Codegen/test/CodegenTestUtils.cs
+++ b/Codegen/test/CodegenTestUtils.cs
@@ -33,7 +33,8 @@ namespace TypeCobol.Codegen {
         {
             var options = new TypeCobolOptions() {
                                                      OptimizeWhitespaceScanning = false,
-                                                     UseEuroInformationLegacyReplacingSyntax = enableRemarksParsingAndGeneration
+                                                     EILegacy_RemoveFirst01Level = enableRemarksParsingAndGeneration,
+                                                     EILegacy_ApplyCopySuffixing = enableRemarksParsingAndGeneration
                                                  };
 #if EUROINFO_RULES
             if (cpyCopyNamesMapFilePath != null) options.CpyCopyNameMap = new CopyNameMapFile(cpyCopyNamesMapFilePath);

--- a/TypeCobol.LanguageServer/TypeCobolServer.cs
+++ b/TypeCobol.LanguageServer/TypeCobolServer.cs
@@ -56,11 +56,6 @@ namespace TypeCobol.LanguageServer
         /// </summary>
         public bool UseAntlrProgramParsing { get; set; }
 
-        /// <summary>
-        /// true to use Euro-Information replacement rules
-        /// </summary>
-        public bool UseEuroInformationLegacyReplacingSyntax { get; set; }
-
 #if EUROINFO_RULES
         /// <summary>
         /// The Cpy Copy names file
@@ -266,7 +261,6 @@ namespace TypeCobol.LanguageServer
             this.Workspace.LsrTestOptions = LsrTestingLevel;
             this.Workspace.UseSyntaxColoring = UseSyntaxColoring;
             this.Workspace.UseAntlrProgramParsing = UseAntlrProgramParsing;
-            this.Workspace.UseEuroInformationLegacyReplacingSyntax = UseEuroInformationLegacyReplacingSyntax;
             this.Workspace.TimerDisabledOption = TimerDisabledOption;
 
             // Attach event handlers.

--- a/TypeCobol.LanguageServer/TypeCobolServerHost.cs
+++ b/TypeCobol.LanguageServer/TypeCobolServerHost.cs
@@ -1,11 +1,7 @@
 ﻿using Mono.Options;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Reflection;
 using System.Text;
-using System.Threading;
 using TypeCobol.LanguageServer.JsonRPC;
 using TypeCobol.LanguageServer.StdioHttp;
 using TypeCobol.LanguageServer.TypeCobolCustomLanguageServerProtocol;
@@ -107,11 +103,6 @@ namespace TypeCobol.LanguageServer
         /// True to use ANTLR for parsing a program
         /// </summary>
         public static bool UseAntlrProgramParsing { get; set; }
-
-        /// <summary>
-        /// True to use Euro-Information replacement rules
-        /// </summary>
-        public static bool UseEuroInformationLegacyReplacingSyntax { get; set; }
 
         /// <summary>
         /// Are we supporting Syntax Coloring Notifications.    
@@ -236,7 +227,6 @@ namespace TypeCobol.LanguageServer
                 { "tsemantic",  "Semantic analysis testing mode.", _ => LsrSemanticTesting = true},
                 { "tcodeanalysis",  "Code quality analysis testing mode.", _ => LsrCodeAnalysisTesting = true},
                 { "antlrp",  "Use ANTLR to parse a Program.", _ => UseAntlrProgramParsing = true},
-                { "dcs|disablecopysuffixing", "Deactictivate Euro Information suffixing", v => UseEuroInformationLegacyReplacingSyntax = false },
                 { "sc|syntaxcolor",  "Syntax Coloring Support.", _ => UseSyntaxColoring = true},
                 { "ol|outlineRefresh",  "Outline Support.", _ => UseOutlineRefresh = true},
 #if EUROINFO_RULES
@@ -332,7 +322,6 @@ namespace TypeCobol.LanguageServer
                 if (LsrCodeAnalysisTesting) typeCobolServer.LsrTestingLevel = LsrTestingOptions.LsrCodeAnalysisPhaseTesting;
                 typeCobolServer.TimerDisabledOption = TimerDisabledOption;
                 typeCobolServer.UseAntlrProgramParsing = UseAntlrProgramParsing;
-                typeCobolServer.UseEuroInformationLegacyReplacingSyntax = UseEuroInformationLegacyReplacingSyntax;
                 typeCobolServer.UseSyntaxColoring = UseSyntaxColoring;
                 typeCobolServer.UseOutlineRefresh = UseOutlineRefresh;
                 typeCobolServer.UseCfgDfaDataRefresh = UseCfg;

--- a/TypeCobol.LanguageServer/Workspace.cs
+++ b/TypeCobol.LanguageServer/Workspace.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading;
+﻿using System.Text;
 using TypeCobol.Analysis;
 using TypeCobol.Compiler;
 using TypeCobol.Compiler.CodeModel;
@@ -128,12 +123,17 @@ namespace TypeCobol.LanguageServer
         public bool UseAntlrProgramParsing { get; set; }
 
         /// <summary>
-        /// True to use Euro-Information replacement rules
+        /// True to use EI Legacy automatic removal of first 01 level from CPY copy.
         /// </summary>
-        public bool UseEuroInformationLegacyReplacingSyntax { get; set; }
+        public bool EILegacy_RemoveFirst01Level { get; set; }
 
         /// <summary>
-        /// Are we supporting Syntax Coloring Notifications.    
+        /// True to use EI Legacy copy suffixing mechanism
+        /// </summary>
+        public bool EILegacy_ApplyCopySuffixing { get; set; }
+
+        /// <summary>
+        /// Are we supporting Syntax Coloring Notifications.
         /// </summary>
         public bool UseSyntaxColoring { get; set; }
 
@@ -647,7 +647,10 @@ namespace TypeCobol.LanguageServer
                 UseAntlrProgramParsing = true;
 
             if (Configuration.UseEuroInformationLegacyReplacingSyntax)
-                UseEuroInformationLegacyReplacingSyntax = true;
+            {
+                EILegacy_RemoveFirst01Level = true;
+                EILegacy_ApplyCopySuffixing = true;
+            }
 
             if (Configuration.ExecToStep >= ExecutionStep.Generate)
                 Configuration.ExecToStep = ExecutionStep.CodeAnalysis; //Language Server does not support Cobol Generation for now

--- a/TypeCobol.LanguageServer/Workspace.cs
+++ b/TypeCobol.LanguageServer/Workspace.cs
@@ -646,11 +646,11 @@ namespace TypeCobol.LanguageServer
             if (Configuration.UseAntlrProgramParsing)
                 UseAntlrProgramParsing = true;
 
-            if (Configuration.UseEuroInformationLegacyReplacingSyntax)
-            {
+            if (Configuration.EILegacy_RemoveFirst01Level)
                 EILegacy_RemoveFirst01Level = true;
+
+            if (Configuration.EILegacy_ApplyCopySuffixing)
                 EILegacy_ApplyCopySuffixing = true;
-            }
 
             if (Configuration.ExecToStep >= ExecutionStep.Generate)
                 Configuration.ExecToStep = ExecutionStep.CodeAnalysis; //Language Server does not support Cobol Generation for now

--- a/TypeCobol.LanguageServer/Workspace.cs
+++ b/TypeCobol.LanguageServer/Workspace.cs
@@ -805,7 +805,8 @@ namespace TypeCobol.LanguageServer
 
                 foreach (var usedCopy in usedCopies)
                 {
-                    if (evicted.Contains(usedCopy.TextName))
+                    string fileName = usedCopy.GetFileName(openedDocument.FileCompiler.CompilerOptions);
+                    if (evicted.Contains(fileName))
                     {
                         dependentPrograms.Add(openedDocument);
                         break;

--- a/TypeCobol.LanguageServer/WorkspaceProjectStore.cs
+++ b/TypeCobol.LanguageServer/WorkspaceProjectStore.cs
@@ -79,7 +79,8 @@ namespace TypeCobol.LanguageServer
             var defaultOptions = new TypeCobolOptions()
             {
                 UseAntlrProgramParsing = _workspace.UseAntlrProgramParsing,
-                UseEuroInformationLegacyReplacingSyntax = _workspace.EILegacy_RemoveFirst01Level && _workspace.EILegacy_ApplyCopySuffixing
+                EILegacy_RemoveFirst01Level = _workspace.EILegacy_RemoveFirst01Level,
+                EILegacy_ApplyCopySuffixing = _workspace.EILegacy_ApplyCopySuffixing
             };
             //We don't have the information about the real RootDirectory.
             //We use the RootDirectory from the Workspace because it has no consequences as long as

--- a/TypeCobol.LanguageServer/WorkspaceProjectStore.cs
+++ b/TypeCobol.LanguageServer/WorkspaceProjectStore.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
 using System.Text;
 using TypeCobol.Compiler;
 using TypeCobol.Compiler.Directives;
@@ -81,7 +79,7 @@ namespace TypeCobol.LanguageServer
             var defaultOptions = new TypeCobolOptions()
             {
                 UseAntlrProgramParsing = _workspace.UseAntlrProgramParsing,
-                UseEuroInformationLegacyReplacingSyntax = _workspace.UseEuroInformationLegacyReplacingSyntax
+                UseEuroInformationLegacyReplacingSyntax = _workspace.EILegacy_RemoveFirst01Level && _workspace.EILegacy_ApplyCopySuffixing
             };
             //We don't have the information about the real RootDirectory.
             //We use the RootDirectory from the Workspace because it has no consequences as long as

--- a/TypeCobol/Compiler/CompilationDocumentCache.cs
+++ b/TypeCobol/Compiler/CompilationDocumentCache.cs
@@ -105,9 +105,9 @@ namespace TypeCobol.Compiler
                     {
                         _documents.Remove(keyToRemove);
                     }
-
-                    evicted.Add(textName);
                 }
+
+                evicted.Add(textName);
             }
         }
 

--- a/TypeCobol/Compiler/CompilationDocumentCache.cs
+++ b/TypeCobol/Compiler/CompilationDocumentCache.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using TypeCobol.Compiler.Directives;
 using TypeCobol.Compiler.File;
 using TypeCobol.Compiler.Scanner;
 
@@ -69,10 +70,11 @@ namespace TypeCobol.Compiler
                 var importedCopies = document.Value.CopyTextNamesVariations;
                 foreach (var importedCopy in importedCopies)
                 {
-                    if (!importedBy.TryGetValue(importedCopy.TextName, out var dependentCopies))
+                    string fileName = importedCopy.GetFileName(document.Value.CompilerOptions);
+                    if (!importedBy.TryGetValue(fileName, out var dependentCopies))
                     {
                         dependentCopies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                        importedBy.Add(importedCopy.TextName, dependentCopies);
+                        importedBy.Add(fileName, dependentCopies);
                     }
 
                     dependentCopies.Add(copy);

--- a/TypeCobol/Compiler/CupPreprocessor/CompilerDirectiveBuilder.cs
+++ b/TypeCobol/Compiler/CupPreprocessor/CompilerDirectiveBuilder.cs
@@ -97,13 +97,15 @@ namespace TypeCobol.Compiler.CupPreprocessor
                 var variation = RemarksDirective.TextNameVariation.FindOrAdd(CopyTextNameVariations, copy);
 
 #if  EUROINFO_RULES
-                if (TypeCobolOptions.UseEuroInformationLegacyReplacingSyntax)
+                bool removeFirst01Level = TypeCobolOptions.EILegacy_RemoveFirst01Level;
+                bool applyCopySuffixing = TypeCobolOptions.EILegacy_ApplyCopySuffixing;
+                if (removeFirst01Level || applyCopySuffixing)
                 {
                     if (this.TypeCobolOptions.IsCpyCopy(variation.TextName))
                     {
                         // Declaration found and copy name starts with Y => apply the legacy REPLACING semantics to the copy directive
-                        copy.RemoveFirst01Level = true;
-                        if (variation.HasSuffix)
+                        copy.RemoveFirst01Level = removeFirst01Level;
+                        if (applyCopySuffixing && variation.HasSuffix)
                         {
                             copy.TextName = variation.TextName;
                             copy.Suffix = variation.Suffix;

--- a/TypeCobol/Compiler/Directives/CompilerDirective.cs
+++ b/TypeCobol/Compiler/Directives/CompilerDirective.cs
@@ -3,6 +3,7 @@
 using System.Text;
 using TypeCobol.Compiler.Diagnostics;
 using TypeCobol.Compiler.Scanner;
+using TypeCobol.Tools.Options_Config;
 
 namespace TypeCobol.Compiler.Directives
 {
@@ -976,6 +977,41 @@ namespace TypeCobol.Compiler.Directives
         }
     }
 
+    public static class TextNameVariationExtensions
+    {
+        private static string GetFileName(RemarksDirective.TextNameVariation variation, bool applyCopySuffixing)
+        {
+#if EUROINFO_RULES
+            /*
+             * For regular copies, the file has the name of the text-name itself.
+             * However for suffixed copy with server-side copy suffixing enabled, there is no physical file.
+             * The content is derived from the corresponding base copy, so return text-name without suffix.
+             */
+            return applyCopySuffixing ? variation.TextName : variation.TextNameWithSuffix;
+#else
+            // No suffixing involved, return full text-name
+            return variation.TextNameWithSuffix;
+#endif
+        }
+
+        /// <summary>
+        /// Get the expected file name for the given variation.
+        /// </summary>
+        /// <param name="variation">TextNameVariation instance, must be non-null</param>
+        /// <param name="options">TypeCobolOptions instance, must be non-null</param>
+        /// <returns>The name of the physical file in which the content for this variation is expected to be found.</returns>
+        public static string GetFileName(this RemarksDirective.TextNameVariation variation, TypeCobolOptions options) =>
+            GetFileName(variation, options.EILegacy_ApplyCopySuffixing);
+
+        /// <summary>
+        /// Get the expected file name for the given variation.
+        /// </summary>
+        /// <param name="variation">TextNameVariation instance, must be non-null</param>
+        /// <param name="configuration">TypeCobolConfiguration instance, must be non-null</param>
+        /// <returns>The name of the physical file in which the content for this variation is expected to be found.</returns>
+        public static string GetFileName(this RemarksDirective.TextNameVariation variation, TypeCobolConfiguration configuration) =>
+            GetFileName(variation, configuration.EILegacy_ApplyCopySuffixing);
+    }
 
     /// <summary>
     /// p541: REPLACE statement

--- a/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
+++ b/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
@@ -52,7 +52,7 @@ namespace TypeCobol.Compiler.Directives
         public CopyNameMapFile? CpyCopyNameMap { get; set; }
 #else
         public bool EILegacy_RemoveFirst01Level { get; set; } = false;
-        public bool EILegacy_ApplyCopySuffixing { get; set; } = true;
+        public bool EILegacy_ApplyCopySuffixing { get; set; } = false;
 #endif
 
         /// <summary>

--- a/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
+++ b/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
@@ -101,7 +101,7 @@ namespace TypeCobol.Compiler.Directives
             HaltOnMissingCopy = config.HaltOnMissingCopyFilePath != null;
             ExecToStep = config.ExecToStep;
             UseAntlrProgramParsing = config.UseAntlrProgramParsing;
-            UseEuroInformationLegacyReplacingSyntax = config.UseEuroInformationLegacyReplacingSyntax;
+            UseEuroInformationLegacyReplacingSyntax = config.EILegacy_RemoveFirst01Level && config.EILegacy_ApplyCopySuffixing;
 
 #if EUROINFO_RULES
             CpyCopyNameMap = config.CpyCopyNameMap;

--- a/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
+++ b/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
@@ -34,24 +34,25 @@ namespace TypeCobol.Compiler.Directives
         /// </summary>
         public bool UseAntlrProgramParsing { get; set; }
 
-        /// <summary>
-        /// Shall we use EI legacy replacing mechanism when including copys ?
-        /// </summary>
-        public bool UseEuroInformationLegacyReplacingSyntax
-        {
-            get { return _useEuroInformationLegacyReplacingSyntax; }
-            set { _useEuroInformationLegacyReplacingSyntax = value; }
-        }
-
 #if EUROINFO_RULES
-        private bool _useEuroInformationLegacyReplacingSyntax = true;
+        /// <summary>
+        /// Euro-Information Legacy REPLACING syntax: automatically remove first 01 level from included CPY copies.
+        /// </summary>
+        public bool EILegacy_RemoveFirst01Level { get; set; } = true;
+
+        /// <summary>
+        /// Euro-Information Legacy REPLACING syntax: automatically suffix data items coming
+        /// from CPY copies when they are included using an additional char at the end of their text name.
+        /// </summary>
+        public bool EILegacy_ApplyCopySuffixing { get; set; } = true;
 
         /// <summary>
         /// Instance of the CPY Copy name map
         /// </summary>
         public CopyNameMapFile? CpyCopyNameMap { get; set; }
 #else
-        private bool _useEuroInformationLegacyReplacingSyntax = false;
+        public bool EILegacy_RemoveFirst01Level { get; set; } = false;
+        public bool EILegacy_ApplyCopySuffixing { get; set; } = true;
 #endif
 
         /// <summary>
@@ -101,7 +102,8 @@ namespace TypeCobol.Compiler.Directives
             HaltOnMissingCopy = config.HaltOnMissingCopyFilePath != null;
             ExecToStep = config.ExecToStep;
             UseAntlrProgramParsing = config.UseAntlrProgramParsing;
-            UseEuroInformationLegacyReplacingSyntax = config.EILegacy_RemoveFirst01Level && config.EILegacy_ApplyCopySuffixing;
+            EILegacy_RemoveFirst01Level = config.EILegacy_RemoveFirst01Level;
+            EILegacy_ApplyCopySuffixing = config.EILegacy_ApplyCopySuffixing;
 
 #if EUROINFO_RULES
             CpyCopyNameMap = config.CpyCopyNameMap;

--- a/TypeCobol/Compiler/Preprocessor/ImportedTokensDocument.cs
+++ b/TypeCobol/Compiler/Preprocessor/ImportedTokensDocument.cs
@@ -45,7 +45,7 @@ namespace TypeCobol.Compiler.Preprocessor
 
             if (HasReplacingDirective
 #if EUROINFO_RULES
-                || CompilerOptions.UseEuroInformationLegacyReplacingSyntax && (CopyDirective.RemoveFirst01Level || CopyDirective.InsertSuffixChar)
+                || (CopyDirective.RemoveFirst01Level || CopyDirective.InsertSuffixChar)
 #endif
                )
             {

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -53,7 +53,7 @@ namespace TypeCobol.Compiler.Scanner
             int lastIndex = textLine.Source.EndIndex;
 
 #if EUROINFO_RULES
-            if (compilerOptions.UseEuroInformationLegacyReplacingSyntax && !compilerOptions.IsCobolLanguage)
+            if (compilerOptions.EILegacy_RemoveFirst01Level && compilerOptions.EILegacy_ApplyCopySuffixing && !compilerOptions.IsCobolLanguage)
             {
                 if (tokensLine.ScanState.LeavingRemarksDirective) //If last scanned line was the end of a remarksDirective then mark scanstate as outside of remarksDirective for this new line
                     tokensLine.ScanState.InsideRemarksDirective = tokensLine.ScanState.LeavingRemarksDirective = false;

--- a/TypeCobol/LanguageServices/CodeAnalysis/Statistics/StatsGenerator.cs
+++ b/TypeCobol/LanguageServices/CodeAnalysis/Statistics/StatsGenerator.cs
@@ -184,7 +184,7 @@ namespace TypeCobol.LanguageServices.CodeAnalysis.Statistics
                                         copyDirectiveType = CopyDirectiveType.CopyRemarks;
                                     }
 #endif
-                                if (copyDirective.ReplaceOperations != null && copyDirective.ReplaceOperations.Count > 0)
+                                    if (copyDirective.ReplaceOperations != null && copyDirective.ReplaceOperations.Count > 0)
                                     {
                                         copyDirectiveType = CopyDirectiveType.CopyReplacing;
                                     }

--- a/TypeCobol/LanguageServices/CodeAnalysis/Statistics/StatsGenerator.cs
+++ b/TypeCobol/LanguageServices/CodeAnalysis/Statistics/StatsGenerator.cs
@@ -175,8 +175,6 @@ namespace TypeCobol.LanguageServices.CodeAnalysis.Statistics
                                     // + count COPY directives
                                     CopyDirectiveType copyDirectiveType = CopyDirectiveType.Copy;
 #if EUROINFO_RULES
-                                if (compilationResult.CompilerOptions.UseEuroInformationLegacyReplacingSyntax)
-                                {
                                     if (copyDirective.InsertSuffixChar)
                                     {
                                         copyDirectiveType = CopyDirectiveType.CopyReplacingRemarks;
@@ -185,10 +183,8 @@ namespace TypeCobol.LanguageServices.CodeAnalysis.Statistics
                                     {
                                         copyDirectiveType = CopyDirectiveType.CopyRemarks;
                                     }
-                                }
-                                    
 #endif
-                                    if (copyDirective.ReplaceOperations != null && copyDirective.ReplaceOperations.Count > 0)
+                                if (copyDirective.ReplaceOperations != null && copyDirective.ReplaceOperations.Count > 0)
                                     {
                                         copyDirectiveType = CopyDirectiveType.CopyReplacing;
                                     }

--- a/TypeCobol/Tools/Options-Config/TypeCobolConfiguration.cs
+++ b/TypeCobol/Tools/Options-Config/TypeCobolConfiguration.cs
@@ -36,10 +36,12 @@ namespace TypeCobol.Tools.Options_Config
         public const string DefaultLogFileName = "TypeCobol.CLI.log";
 
 #if EUROINFO_RULES
-        public bool UseEuroInformationLegacyReplacingSyntax = true;
+        public bool EILegacy_RemoveFirst01Level = true;
+        public bool EILegacy_ApplyCopySuffixing = true;
         public string ReportUsedCopyNamesPath;
 #else
-        public bool UseEuroInformationLegacyReplacingSyntax = false;
+        public bool EILegacy_RemoveFirst01Level = false;
+        public bool EILegacy_ApplyCopySuffixing = false;
 #endif
         // Checks
         public TypeCobolCheckOption CheckEndAlignment { get; set; }
@@ -282,7 +284,9 @@ namespace TypeCobol.Tools.Options_Config
                 { "alr|antlrprogparse", "Use ANTLR to parse a program.", v => typeCobolConfig.UseAntlrProgramParsing = true},
                 { "cmr|copymovereport=", "{PATH} to Report all Move and Initialize statements that target a COPY.", v => typeCobolConfig.ReportCopyMoveInitializeFilePath = v },
                 { "zcr|zcallreport=", "{PATH} to report of all program called by zcallpgm.", v => typeCobolConfig.ReportZCallFilePath = v },
-                { "dcs|disablecopysuffixing", "Deactivate Euro-Information suffixing.", v => typeCobolConfig.UseEuroInformationLegacyReplacingSyntax = false },
+                { "dcs|disablecopysuffixing", "OBSOLETE - Use 'drfl' and 'dcsm' options instead.'.", v => { typeCobolConfig.EILegacy_RemoveFirst01Level = false; typeCobolConfig.EILegacy_ApplyCopySuffixing = false; } },
+                { "drfl|disableremovefirst01level", "Disable EI Legacy automatic removal of first 01 level from CPY copies.", v => typeCobolConfig.EILegacy_RemoveFirst01Level = false },
+                { "dcsm|disablecopysuffixingmechanism", "Disable EI Legacy automatic suffixing of data names from CPY copies.", v => typeCobolConfig.EILegacy_ApplyCopySuffixing = false },
                 { "glm|genlinemap=", "{PATH} to an output file where line mapping will be generated.", v => typeCobolConfig.LineMapFiles.Add(v) },
                 { "diag.cea|diagnostic.checkEndAlignment=", "Indicate level of check end aligment: warning, error, info, ignore.", v => typeCobolConfig.CheckEndAlignment = TypeCobolCheckOption.Parse(v) },
                 { "diag.cep|diagnostic.checkEndProgram=", "Indicate level of check end program: warning, error, info, ignore.", v => typeCobolConfig.CheckEndProgram = TypeCobolCheckOption.Parse(v) },

--- a/TypeCobol/Tools/Options-Config/TypeCobolConfiguration.cs
+++ b/TypeCobol/Tools/Options-Config/TypeCobolConfiguration.cs
@@ -297,7 +297,7 @@ namespace TypeCobol.Tools.Options_Config
                 { "cfg|cfgbuild=", "CFG build option, recognized values are: None/0, Standard/1, Extended/2, WithDfa/3.", v => typeCobolConfig.RawCfgBuildingMode = v },
                 { "cob|cobol", "Indicate that it's a pure Cobol85 input file.", v => typeCobolConfig.IsCobolLanguage = true },
 #if EUROINFO_RULES
-                { "cpyr|cpyreport=", "{PATH} to report of all COPY names used by a programm.", v => typeCobolConfig.ReportUsedCopyNamesPath = v }
+                { "cpyr|cpyreport=", "{PATH} to report of all COPY names used by a program.", v => typeCobolConfig.ReportUsedCopyNamesPath = v }
 #endif
             };
             return commonOptions;


### PR DESCRIPTION
Fixes #2538

a40fad3336132b7795dffb177b8cc7b6cad94b9f is incorrectly linked to #2358 instead of #2538. Sorry about that.