### PR TITLE
WI #2536 Support REPOSITORY paragraph (intrinsic function declarations)

### DIFF
--- a/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithALLFunctions.mix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithALLFunctions.mix.txt
@@ -1,0 +1,15 @@
+      ****** Support REPOSITORY PARAGRAPH *****
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. pgm2536.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SPECIAL-NAMES. DECIMAL-POINT IS COMMA.
+       REPOSITORY.
+           Class Base is "java.lang.Object"
+           Class Customer is "com.ei.Customer"
+           FUNCTION ALL INTRINSIC.
+       DATA DIVISION.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE DIVISION.
+            GOBACK.
+       END PROGRAM pgm2536.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithALLFunctions.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithALLFunctions.rdz.cbl
@@ -1,0 +1,15 @@
+      ****** Support REPOSITORY PARAGRAPH *****
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. pgm2536.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SPECIAL-NAMES. DECIMAL-POINT IS COMMA.
+       REPOSITORY.
+           Class Base is "java.lang.Object"
+           Class Customer is "com.ei.Customer"
+           FUNCTION ALL INTRINSIC.
+       DATA DIVISION.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE DIVISION.
+            GOBACK.
+       END PROGRAM pgm2536.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithFunctionDeclarations.mix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithFunctionDeclarations.mix.txt
@@ -10,7 +10,11 @@
            FUNCTION EXP COMBINED-DATETIME FORMATTED-CURRENT-DATE
            FORMATTED-DATETIME SIGN INTRINSIC
            Class Base is "java.lang.Object"
+Line 13[21,33] <27, Error, Syntax> - Syntax error : "WHEN-COMPILED" was specified in the "FUNCTION" phrase of the "REPOSITORY" paragraph, but the keyword "FUNCTION" is always required for this function.
+           FUNCTION when-compiled INTRINSIC
            Class Customer is "com.ei.Customer"
+Line 15[21,33] <27, Error, Syntax> - Syntax error : "WHEN-COMPILED" was specified in the "FUNCTION" phrase of the "REPOSITORY" paragraph, but the keyword "FUNCTION" is always required for this function.
+           FUNCTION WHEN-COMPILED INTRINSIC
            FUNCTION PI TRIM INTRINSIC.
        DATA DIVISION.
        WORKING-STORAGE  SECTION.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithFunctionDeclarations.mix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithFunctionDeclarations.mix.txt
@@ -1,0 +1,19 @@
+      ****** Support REPOSITORY PARAGRAPH *****
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. pgm2536.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SPECIAL-NAMES. DECIMAL-POINT IS COMMA.
+       REPOSITORY.
+           FUNCTION ABS INTRINSIC
+           Class Dummy
+           FUNCTION EXP COMBINED-DATETIME FORMATTED-CURRENT-DATE
+           FORMATTED-DATETIME SIGN INTRINSIC
+           Class Base is "java.lang.Object"
+           Class Customer is "com.ei.Customer"
+           FUNCTION PI TRIM INTRINSIC.
+       DATA DIVISION.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE DIVISION.
+            GOBACK.
+       END PROGRAM pgm2536.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithFunctionDeclarations.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithFunctionDeclarations.rdz.cbl
@@ -10,7 +10,9 @@
            FUNCTION EXP COMBINED-DATETIME FORMATTED-CURRENT-DATE
            FORMATTED-DATETIME SIGN INTRINSIC
            Class Base is "java.lang.Object"
+           FUNCTION when-compiled INTRINSIC
            Class Customer is "com.ei.Customer"
+           FUNCTION WHEN-COMPILED INTRINSIC
            FUNCTION PI TRIM INTRINSIC.
        DATA DIVISION.
        WORKING-STORAGE  SECTION.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithFunctionDeclarations.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithFunctionDeclarations.rdz.cbl
@@ -1,0 +1,19 @@
+      ****** Support REPOSITORY PARAGRAPH *****
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. pgm2536.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SPECIAL-NAMES. DECIMAL-POINT IS COMMA.
+       REPOSITORY.
+           FUNCTION ABS INTRINSIC
+           Class Dummy
+           FUNCTION EXP COMBINED-DATETIME FORMATTED-CURRENT-DATE
+           FORMATTED-DATETIME SIGN INTRINSIC
+           Class Base is "java.lang.Object"
+           Class Customer is "com.ei.Customer"
+           FUNCTION PI TRIM INTRINSIC.
+       DATA DIVISION.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE DIVISION.
+            GOBACK.
+       END PROGRAM pgm2536.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithInvalidDeclarations.mix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithInvalidDeclarations.mix.txt
@@ -1,0 +1,30 @@
+      ****** Support REPOSITORY PARAGRAPH *****
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. pgm2536.
+Line 4[8,15] <27, Error, Syntax> - Syntax error : extraneous input 'FUNCTION' expecting {separator, numeric literal, character string, symbol, statement starting keyword, keyword, Formalized Comments elements, Sql statement starting keyword}
+Line 4[30,30] <27, Error, Syntax> - Syntax error : extraneous input '.' expecting {ProgramIdentification, ProgramEnd, ClassIdentification, EnvironmentDivisionHeader, DataDivisionHeader, ProcedureDivisionHeader, LibraryCopy}
+       FUNCTION ABS INTRINSIC.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SPECIAL-NAMES. DECIMAL-POINT IS COMMA.
+       REPOSITORY.
+           Class Base is "java.lang.Object"
+           Class Customer is "com.ei.Customer"
+Line 11[25,27] <27, Error, Syntax> - Syntax error : rule repositoryFunctionDeclaration failed predicate: { string.Equals(CurrentToken.Text, "INTRINSIC", System.StringComparison.OrdinalIgnoreCase) }?
+           FUNCTION ALL ABS INTRINSIC
+Line 12[21,32] <27, Error, Syntax> - Syntax error : mismatched input 'INVALID-NAME' expecting {intrinsic function name, ALL}
+           FUNCTION INVALID-NAME INTRINSIC.
+       DATA DIVISION.
+Line 14[12,19] <27, Error, Syntax> - Syntax error : extraneous input 'FUNCTION' expecting {separator, numeric literal, character string, symbol, statement starting keyword, keyword, Formalized Comments elements, Sql statement starting keyword}
+           FUNCTION ABS INTRINSIC.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE DIVISION.
+Line 17[12,19] <27, Error, Syntax> - Syntax error : extraneous input 'FUNCTION' expecting {separator, numeric literal, character string, symbol, statement starting keyword, keyword, Formalized Comments elements, Sql statement starting keyword}
+           FUNCTION ABS TRIM INTRINSIC.
+            
+Line 19[36,37] <27, Error, Syntax> - Syntax error : extraneous input '> ' expecting {separator, numeric literal, character string, symbol, statement starting keyword, keyword, Formalized Comments elements, Sql statement starting keyword}
+            IF FUNCTION ABS(10) PI > 0
+              DISPLAY "PI OK"
+            END-IF
+            GOBACK.
+       END PROGRAM pgm2536.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithInvalidDeclarations.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/RepositoryWithInvalidDeclarations.rdz.cbl
@@ -1,0 +1,23 @@
+      ****** Support REPOSITORY PARAGRAPH *****
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. pgm2536.
+       FUNCTION ABS INTRINSIC.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SPECIAL-NAMES. DECIMAL-POINT IS COMMA.
+       REPOSITORY.
+           Class Base is "java.lang.Object"
+           Class Customer is "com.ei.Customer"
+           FUNCTION ALL ABS INTRINSIC
+           FUNCTION INVALID-NAME INTRINSIC.
+       DATA DIVISION.
+           FUNCTION ABS INTRINSIC.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE DIVISION.
+           FUNCTION ABS TRIM INTRINSIC.
+            
+            IF FUNCTION ABS(10) PI > 0
+              DISPLAY "PI OK"
+            END-IF
+            GOBACK.
+       END PROGRAM pgm2536.

--- a/TypeCobol/AntlrGrammar/CobolCodeElements.g4
+++ b/TypeCobol/AntlrGrammar/CobolCodeElements.g4
@@ -1051,6 +1051,8 @@ xmlSchemaClause:
 // the object-oriented classes that are intended to be referenced in that program or
 // class definition. Optionally, the REPOSITORY paragraph defines associations
 // between class-names and external class-names.
+// It also allows declaration of intrinsic function names that may be used without
+// specifying the keyword FUNCTION.
 
 // p122: See the general rules of the REPOSITORY paragraph.
 // 1. All referenced class-names must have an entry in the repository paragraph of
@@ -1112,12 +1114,24 @@ xmlSchemaClause:
 // Class Employee is "com.acme.Employee" 
 // Class Department is "jobjectArray:com.acme.Employee". 
 
+// ALL
+// If ALL is specified, it is as if all supported Enterprise COBOL intrinsic function names were specified.
+
+// IntrinsicFunctionName
+// The name of a supported Enterprise COBOL intrinsic function.
+
 repositoryParagraph: 
     REPOSITORY PeriodSeparator 
-    ( repositoryClassDeclaration+ PeriodSeparator )?;
+    ( repositoryDeclaration+ PeriodSeparator )?;
+
+repositoryDeclaration:
+    repositoryClassDeclaration | repositoryFunctionDeclaration;
 
 repositoryClassDeclaration:
-	CLASS classNameDefOrRef (IS? externalClassNameDefOrRef)?;
+    CLASS classNameDefOrRef (IS? externalClassNameDefOrRef)?;
+
+repositoryFunctionDeclaration:
+    FUNCTION (IntrinsicFunctionName+ | ALL) ({ string.Equals(CurrentToken.Text, "INTRINSIC", System.StringComparison.OrdinalIgnoreCase) }? KeywordINTRINSIC=UserDefinedWord);
 
 // p122: java-array-class-reference
 // A reference that enables a COBOL program to access a class that represents

--- a/TypeCobol/Compiler/CodeElements/Paragraph/RepositoryParagraph.cs
+++ b/TypeCobol/Compiler/CodeElements/Paragraph/RepositoryParagraph.cs
@@ -17,5 +17,15 @@ namespace TypeCobol.Compiler.CodeElements
         /// Optionally, the REPOSITORY paragraph defines associations between class-names and external class-names.
         /// </summary>
         public IDictionary<SymbolDefinitionOrReference, SymbolDefinitionOrReference> ClassNames { get; set; }
+
+        /// <summary>
+        /// Optionally, the REPOSITORY paragraph allows to declare all intrinsic functions
+        /// </summary>
+        public bool IsAllIntrinsicFunctions { get; set; }
+
+        /// <summary>
+        /// Optionally, the REPOSITORY paragraph allows to declare one or several intrinsic functions
+        /// </summary>
+        public List<string> IntrinsicFunctions { get; set; }
     }
 }

--- a/TypeCobol/Compiler/CodeElements/Paragraph/RepositoryParagraph.cs
+++ b/TypeCobol/Compiler/CodeElements/Paragraph/RepositoryParagraph.cs
@@ -1,15 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
+using TypeCobol.Compiler.Scanner;
 
 namespace TypeCobol.Compiler.CodeElements
 {
     /// <summary>
     /// The REPOSITORY paragraph is used in a program or class definition to identify all
     /// the object-oriented classes that are intended to be referenced in that program or
-    /// class definition.
+    /// class definition. It also allows declaration of intrinsic function names that may be used without
+    /// specifying the keyword FUNCTION.
     /// </summary>
     public class RepositoryParagraph : CodeElement
     {
+        /// <summary>
+        /// Intrinsic functions which are not allowed in the REPOSITORY paragraph
+        /// </summary>
+        public static readonly HashSet<string> NotAllowedIntrinsicFunctions = new[] { "WHEN-COMPILED" }.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         public RepositoryParagraph() : base(CodeElementType.RepositoryParagraph)
         { }
 
@@ -27,5 +34,13 @@ namespace TypeCobol.Compiler.CodeElements
         /// Optionally, the REPOSITORY paragraph allows to declare one or several intrinsic functions
         /// </summary>
         public List<string> IntrinsicFunctions { get; set; }
+
+        /// <summary>
+        /// Get the tokens corresponding to intrinsic functions
+        /// </summary>
+        internal IEnumerable<Token> GetIntrinsicFunctionTokens()
+        {
+            return ConsumedTokens.Where(t => t.TokenType == TokenType.IntrinsicFunctionName);
+        }
     }
 }

--- a/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
@@ -1031,6 +1031,25 @@ namespace TypeCobol.Compiler.Diagnostics
             return true;
         }
 
+        public override bool Visit(Repository repository)
+        {
+            if (repository.CodeElement is RepositoryParagraph repositoryParagraph && repositoryParagraph.IntrinsicFunctions != null)
+            {
+                var notAllowedIntrinsicFunctions = RepositoryParagraph.NotAllowedIntrinsicFunctions;
+                var intrinsicFunctionTokens = repositoryParagraph.GetIntrinsicFunctionTokens();
+                foreach (var token in intrinsicFunctionTokens)
+                {
+                    string intrinsicFunctionName = token.SourceText.ToUpper();
+                    if (notAllowedIntrinsicFunctions.Contains(intrinsicFunctionName))
+                    {
+                        DiagnosticUtils.AddError(repository, $"\"{intrinsicFunctionName}\" was specified in the \"FUNCTION\" phrase of the \"REPOSITORY\" paragraph, but the keyword \"FUNCTION\" is always required for this function.", token);
+                    }
+                }
+            }
+
+            return true;
+        }
+
         private static void CheckEnvironmentNameOrMnemonicForEnvironmentName(Node node, SymbolReference environmentOrMnemonicReference)
         {
             var name = environmentOrMnemonicReference?.Name;

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
@@ -647,7 +647,7 @@ namespace TypeCobol.Compiler.Parser
             else if (context.IntrinsicFunctionName() != null)
             {
                 paragraph.IntrinsicFunctions ??= new List<string>();
-                paragraph.IntrinsicFunctions.AddRange(context.IntrinsicFunctionName().Select(f => f.GetText()).ToList());
+                paragraph.IntrinsicFunctions.AddRange(context.IntrinsicFunctionName().Select(f => f.GetText().ToUpper()).ToList());
             }
         }
 

--- a/TypeCobol/Compiler/Scanner/MultilineScanState.cs
+++ b/TypeCobol/Compiler/Scanner/MultilineScanState.cs
@@ -548,9 +548,9 @@ namespace TypeCobol.Compiler.Scanner
             get { return LastSignificantToken != null && LastSignificantToken.TokenType == TokenType.CommentEntry; }
         }
 
-        public bool AfterFUNCTION
+        public bool AfterFUNCTIONOrIntrinsicFunctionName
         {
-            get { return LastSignificantToken != null && LastSignificantToken.TokenType == TokenType.FUNCTION; }
+            get { return LastSignificantToken != null && (LastSignificantToken.TokenType == TokenType.FUNCTION || LastSignificantToken.TokenType == TokenType.IntrinsicFunctionName); }
         }
 
         /// <summary>

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -2046,7 +2046,7 @@ namespace TypeCobol.Compiler.Scanner
             //.WHEN_COMPILED |
             //.YEAR_TO_YYYY;
             Debug.Assert(tokensLine.ScanState != null);
-            if (tokensLine.ScanState.AfterFUNCTION && TokenUtils.CobolIntrinsicFunctions.IsMatch(tokenText))
+            if (tokensLine.ScanState.AfterFUNCTIONOrIntrinsicFunctionName && TokenUtils.CobolIntrinsicFunctions.IsMatch(tokenText))
             {
                 tokenType = TokenType.IntrinsicFunctionName;
             }


### PR DESCRIPTION
Fixes #2536 

This is a 1st step: we only support the declaration of intrinsic functions in the REPOSITORY paragraph (except for the function WHEN-COMPILED which is not allowed).

In a 2nd step we will ensure that the declared intrinsic functions may be used without specifying the keyword FUNCTION.