### PR TITLE
WI #2170 Remove multiple LINQ enumerations to optimize completion

### DIFF
--- a/TypeCobol.LanguageServer/Completion Factory/CompletionFactory.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionFactory.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using TypeCobol.Compiler;
+﻿using TypeCobol.Compiler;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.CodeElements.Expressions;
 using TypeCobol.Compiler.CodeModel;
@@ -20,9 +17,10 @@ namespace TypeCobol.LanguageServer
         /// Get the paragraph that can be associated to PERFORM Completion token.
         /// </summary>
         /// <param name="fileCompiler">The target FileCompiler instance</param>
-        /// <param name="performToken">The PERFORM token</param>
+        /// <param name="codeElement">The PERFORM CodeElement</param>
+        /// <param name="userFilterToken">The PERFORM token</param>
         /// <returns></returns>
-        public static IEnumerable<CompletionItem> GetCompletionPerformParagraph(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken)
+        public static List<CompletionItem> GetCompletionPerformParagraph(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken)
         {
             var performNode = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
             IEnumerable<Paragraph> pargraphs = null;
@@ -65,7 +63,7 @@ namespace TypeCobol.LanguageServer
         #endregion
 
         #region Procedure Completion 
-        public static IEnumerable<CompletionItem> GetCompletionForProcedure(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken, Dictionary<SignatureInformation, FunctionDeclaration> functionDeclarationSignatureDictionary)
+        public static List<CompletionItem> GetCompletionForProcedure(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken, Dictionary<SignatureInformation, FunctionDeclaration> functionDeclarationSignatureDictionary)
         {
             IEnumerable<FunctionDeclaration> procedures = null;
             IEnumerable<DataDefinition> variables = null;
@@ -104,7 +102,7 @@ namespace TypeCobol.LanguageServer
 
             return completionItems;
         }
-        public static IEnumerable<CompletionItem> GetCompletionForProcedureParameter(Position position, FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken, Token lastSignificantToken, FunctionDeclaration procedureSignatureContext)
+        public static List<CompletionItem> GetCompletionForProcedureParameter(Position position, FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken, Token lastSignificantToken, FunctionDeclaration procedureSignatureContext)
         {
             var completionItems = new List<CompletionItem>();
             var arrangedCodeElement = codeElement as CodeElementWrapper;
@@ -314,23 +312,22 @@ namespace TypeCobol.LanguageServer
         #endregion
 
         #region Library Completion
-        public static IEnumerable<CompletionItem> GetCompletionForLibrary(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken)
+        public static List<CompletionItem> GetCompletionForLibrary(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken)
         {
             var callNode = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
-            IEnumerable<Program> programs = null;
-            if (callNode?.SymbolTable != null)
+            if (callNode?.SymbolTable == null)
             {
-                programs =
-                    callNode.SymbolTable.GetPrograms(userFilterToken != null ? userFilterToken.Text : string.Empty);
+                return new List<CompletionItem>();
             }
 
-            return programs?.Select(prog => new CompletionItem(prog.Name) {kind = CompletionItemKind.Module}) ?? new List<CompletionItem>();
+            IEnumerable<Program> programs = callNode.SymbolTable.GetPrograms(userFilterToken != null ? userFilterToken.Text : string.Empty);
+            return programs.Select(prog => new CompletionItem(prog.Name) { kind = CompletionItemKind.Module }).ToList();
         }
 
         #endregion
 
         #region Types Completion
-        public static IEnumerable<CompletionItem> GetCompletionForType(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken)
+        public static List<CompletionItem> GetCompletionForType(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken)
         {
             var node = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
             IEnumerable<TypeDefinition> types = null;
@@ -354,7 +351,7 @@ namespace TypeCobol.LanguageServer
         #endregion
 
         #region QualifiedName Completion
-        public static IEnumerable<CompletionItem> GetCompletionForQualifiedName(Position position, FileCompiler fileCompiler, CodeElement codeElement, Token qualifiedNameSeparatorToken, Token userFilterToken, Dictionary<SignatureInformation, FunctionDeclaration> functionDeclarationSignatureDictionary)
+        public static List<CompletionItem> GetCompletionForQualifiedName(Position position, FileCompiler fileCompiler, CodeElement codeElement, Token qualifiedNameSeparatorToken, Token userFilterToken, Dictionary<SignatureInformation, FunctionDeclaration> functionDeclarationSignatureDictionary)
         {
             var completionItems = new List<CompletionItem>();
             var arrangedCodeElement = codeElement as CodeElementWrapper;
@@ -413,10 +410,10 @@ namespace TypeCobol.LanguageServer
                         .Select(t => t.Text)
                         .ToArray();
 
-               var possibleVariables = qualifiedName.Length > 0 ? node.SymbolTable.GetVariablesExplicit(new URI(qualifiedName)) : null;
+               var possibleVariables = qualifiedName.Length > 0 ? node.SymbolTable.GetVariablesExplicit(new URI(qualifiedName)).ToArray() : null;
 
                 List<DataDefinition> childrenCandidates = new List<DataDefinition>();
-                if (possibleVariables != null && possibleVariables.Any()) 
+                if (possibleVariables != null && possibleVariables.Length > 0) 
                 {
                     //Get children of a type to get completion possibilities
                     foreach (var variable in possibleVariables)
@@ -495,11 +492,11 @@ namespace TypeCobol.LanguageServer
                         {
                             functionDeclarationSignatureDictionary.Clear(); //Clear to avoid key collision
                             //On CALL get possible procedures and functions in the seeked program
-                            var programs = node.SymbolTable.GetPrograms(userTokenToSeek.Text, true);
-                            if (programs != null && programs.Any())
+                            var program = node.SymbolTable.GetPrograms(userTokenToSeek.Text, true).FirstOrDefault();
+                            if (program != null)
                             {
                                 var procedures =
-                                    programs.First()
+                                    program
                                         .SymbolTable.GetFunctions(
                                             f =>
                                                 f.Name.StartsWith(userFilterText,
@@ -517,11 +514,11 @@ namespace TypeCobol.LanguageServer
                         case TokenType.TYPE:
                         {
                             //On TYPE get possible public types in the seeked program
-                            var programs = node.SymbolTable.GetPrograms(userTokenToSeek.Text, true);
-                            if (programs != null && programs.Any())
+                            var program = node.SymbolTable.GetPrograms(userTokenToSeek.Text, true).FirstOrDefault();
+                            if (program != null)
                             {
                                 var types =
-                                    programs.First()
+                                    program
                                         .SymbolTable.GetTypes(
                                             t =>
                                                 t.Name.StartsWith(userFilterText,
@@ -536,12 +533,12 @@ namespace TypeCobol.LanguageServer
                 }
             }
 
-            return completionItems.Distinct();
+            return completionItems.Distinct().ToList();
         }
         #endregion
 
         #region Variable Completion
-        public static IEnumerable<CompletionItem> GetCompletionForVariable(FileCompiler fileCompiler, CodeElement codeElement, Func<DataDefinition, bool> predicate)
+        public static List<CompletionItem> GetCompletionForVariable(FileCompiler fileCompiler, CodeElement codeElement, Func<DataDefinition, bool> predicate)
         {
             var completionItems = new List<CompletionItem>();
             var node = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
@@ -556,7 +553,7 @@ namespace TypeCobol.LanguageServer
         #endregion
 
         #region TO Completion
-        public static IEnumerable<CompletionItem> GetCompletionForTo(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken, Token lastSignificantToken)
+        public static List<CompletionItem> GetCompletionForTo(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken, Token lastSignificantToken)
         {
             var compatibleDataTypes = new HashSet<DataType>();
             var completionItems = new List<CompletionItem>();
@@ -673,7 +670,7 @@ namespace TypeCobol.LanguageServer
             var items = CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, fileCompiler.CompilerOptions);
             completionItems.AddRange(items);
 
-            return completionItems.Where(c => c.insertText.IndexOf(userFilterText, StringComparison.InvariantCultureIgnoreCase) >= 0);
+            return completionItems.Where(c => c.insertText.IndexOf(userFilterText, StringComparison.InvariantCultureIgnoreCase) >= 0).ToList();
         }
         #endregion
 
@@ -684,10 +681,11 @@ namespace TypeCobol.LanguageServer
         /// <param name="fileCompiler"></param>
         /// <param name="codeElement"></param>
         /// <param name="userFilterToken"></param>
+        /// <param name="position"></param>
         /// <returns></returns>
-        public static IEnumerable<CompletionItem> GetCompletionForOf(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken, Position position)
+        public static List<CompletionItem> GetCompletionForOf(FileCompiler fileCompiler, CodeElement codeElement, Token userFilterToken, Position position)
         {
-            IEnumerable<CompletionItem> completionItems = new List<CompletionItem>();
+            var completionItems = new List<CompletionItem>();
             var userFilterText = userFilterToken == null ? string.Empty : userFilterToken.Text;
             var arrangedCodeElement = codeElement as CodeElementWrapper;
             var node = CompletionFactoryHelpers.GetMatchingNode(fileCompiler, codeElement);
@@ -696,7 +694,9 @@ namespace TypeCobol.LanguageServer
 
             var tokensUntilCursor = arrangedCodeElement?.ArrangedConsumedTokens
             .Except(new List<Token>() { userFilterToken })
-            .Where(t => (t.Line == position.line + 1 && t.StopIndex + 1 <= position.character) || t.Line < position.line + 1).Reverse();
+            .Where(t => (t.Line == position.line + 1 && t.StopIndex + 1 <= position.character) || t.Line < position.line + 1)
+            .Reverse()
+            .ToList();
             
             //Detect what's before the OF token
             var tokenBeforeOf = tokensUntilCursor?.Skip(1).FirstOrDefault(); //Skip(1) will skip the OF token
@@ -731,7 +731,7 @@ namespace TypeCobol.LanguageServer
         /// <param name="contextToken">ContextToken to select if it's a SET or something else</param>
         /// <param name="userFilterText">Variable Name Filter</param>
         /// <param name="options">Current TypeCobolOptions</param>
-        public static IEnumerable<CompletionItem> GetCompletionForAddressOf(Node node, Token contextToken, string userFilterText, TypeCobolOptions options)
+        public static List<CompletionItem> GetCompletionForAddressOf(Node node, Token contextToken, string userFilterText, TypeCobolOptions options)
         {
             IEnumerable<DataDefinition> potentialVariables;
             if (node == null)
@@ -767,7 +767,7 @@ namespace TypeCobol.LanguageServer
         }
 
 
-        public static IEnumerable<CompletionItem> GetCompletionForOfParent(Node node, Token variableNameToken, string userFilterText, TypeCobolOptions options)
+        public static List<CompletionItem> GetCompletionForOfParent(Node node, Token variableNameToken, string userFilterText, TypeCobolOptions options)
         {
             var completionItems = new List<CompletionItem>();
             if (node == null)

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionFactoryHelpers.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionFactoryHelpers.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using TypeCobol.Compiler;
+﻿using TypeCobol.Compiler;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.CodeModel;
 using TypeCobol.Compiler.Directives;
@@ -82,7 +79,7 @@ namespace TypeCobol.LanguageServer
             return aggregatedTokens.ToArray().Reverse();
         }
 
-        public static IEnumerable<CompletionItem> CreateCompletionItemsForType(IEnumerable<TypeDefinition> types, Node node, bool enablePublicFlag = true)
+        public static List<CompletionItem> CreateCompletionItemsForType(IEnumerable<TypeDefinition> types, Node node, bool enablePublicFlag = true)
         {
             var completionItems = new List<CompletionItem>();
 
@@ -125,7 +122,7 @@ namespace TypeCobol.LanguageServer
             return completionItems;
         }
 
-        public static IEnumerable<CompletionItem> CreateCompletionItemsForProcedures(IEnumerable<FunctionDeclaration> procedures, Node node, Dictionary<SignatureInformation, FunctionDeclaration> functionDeclarationSignatureDictionary,  bool enablePublicFlag = true)
+        public static List<CompletionItem> CreateCompletionItemsForProcedures(IEnumerable<FunctionDeclaration> procedures, Node node, Dictionary<SignatureInformation, FunctionDeclaration> functionDeclarationSignatureDictionary,  bool enablePublicFlag = true)
         {
             var completionItems = new List<CompletionItem>();
 

--- a/TypeCobol/Compiler/Diagnostics/Cobol2002Checker.cs
+++ b/TypeCobol/Compiler/Diagnostics/Cobol2002Checker.cs
@@ -175,21 +175,21 @@ namespace TypeCobol.Compiler.Diagnostics
 
         private static void Check(SymbolReference renames, Node node)
         {
-            var founds = node.SymbolTable.GetVariables(renames);
-            if (founds.Count() > 1)
+            var founds = node.SymbolTable.GetVariables(renames).ToArray();
+            if (founds.Length > 1)
             {
                 string message = "Illegal RENAMES: Ambiguous reference to symbol \'" + renames + "\'";
                 DiagnosticUtils.AddError(node, message, renames, code: MessageCode.SemanticTCErrorInParser);
                 return;
             }
-            if (!founds.Any())
+            if (founds.Length == 0)
             {
                 string message = "Illegal RENAMES: Symbol \'" + renames + "\' is not referenced";
                 DiagnosticUtils.AddError(node, message, renames, code: MessageCode.SemanticTCErrorInParser);
                 return;
             }
 
-            var found = founds.First();
+            var found = founds[0];
             var foundCodeElement = found.CodeElement;
            
             if (found.IsStronglyTyped || found.IsStrictlyTyped)

--- a/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
@@ -138,7 +138,7 @@ namespace TypeCobol.Compiler.Diagnostics
                         //If there is more than one variable with the same name, it's ambiguous
                         message = string.Format("Call to '{0}'(no arguments) is ambigous. '{0}' is defined {1} times",
                             functionName,
-                            potentialVariables.Count() + functionDeclarations.Count);
+                            potentialVariablesCount + functionDeclarations.Count);
                         DiagnosticUtils.AddError(node, message);
                         return;
                     }


### PR DESCRIPTION
Fixes #2170.

No need to do anything on the `*QualifiedName*` properties as they are backed up by a field to avoid multiple computations.
