### PR TITLE
WI #2477 Check for 'replace separator' around token to replace

### DIFF
--- a/TypeCobol.Test/Parser/Programs/Cobol85/ReplaceWithMultipleRules.ProcessedTokens.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ReplaceWithMultipleRules.ProcessedTokens.txt
@@ -1,0 +1,62 @@
+Line 5[38,46] <37, Warning, General> - Warning: Debugging mode is active
+Line 21[14,14] <27, Error, Syntax> - Syntax error : no viable alternative at input '01 ... :'
+Line 22[14,14] <27, Error, Syntax> - Syntax error : no viable alternative at input '01 ... :'
+Line 24[14,14] <27, Error, Syntax> - Syntax error : no viable alternative at input '01 ... ('
+Line 25[14,14] <27, Error, Syntax> - Syntax error : no viable alternative at input '01 ... ('
+Line 29[11,19] <27, Error, Syntax> - Syntax error : no viable alternative at input '01 ... 1'
+Line 30[11,20] <27, Error, Syntax> - Syntax error : no viable alternative at input '01 ... 3'
+Line 40[15,18] <27, Error, Syntax> - Syntax error : no viable alternative at input '01 ... 1'
+Line 41[15,19] <27, Error, Syntax> - Syntax error : no viable alternative at input '01 ... 3'
+Line 21[28,28] <27, Error, Syntax> - Syntax error : extraneous input '.' expecting {ProgramIdentification, ProgramEnd, ClassIdentification, ClassEnd, FactoryEnd, ObjectIdentification, ObjectEnd, MethodEnd, ProcedureDivisionHeader, WorkingStorageSectionHeader, LocalStorageSectionHeader, LinkageSectionHeader, FileDescriptionEntry, DataDescriptionEntry, DataRedefinesEntry, DataRenamesEntry, DataConditionEntry, ExecStatement, FunctionDeclarationEnd, GlobalStorageSectionHeader}
+--- Processed Tokens ---
+
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DVZS0OSM.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER. IBM-370 WITH DEBUGGING MODE.
+       data division.
+       working-storage section.
+       REPLACE
+          ==C-Nb==                 BY ==1==
+          ==C-NbX==                BY ==3==
+          ==3== by ==4==
+      
+          ==:TOTO:==              BY ==3==
+          .
+      
+      *Parenthesis separator  -  Replace APPLY
+       01 Var         pic X(1)   .
+       01 Var         pic X(3)    .
+       
+      *Semi colon separator   -  Replace APPLY
+       01 Var:1       pic X.
+       01 Var:3       pic X.
+      *Parenthesis separator  -  Replace APPLY
+       01 Var(1       pic X.
+       01 Var(3       pic X.
+      *Semi colon separator  -  Replace APPLY
+      *Bug: replace mechanism will replace the whole token
+      *since the replace operation is considered a single replacement token
+       01 1            pic X.
+       01 3            pic X.
+      
+
+      *No separator     -  Replace don't apply
+       01 VarC-Nb     PIC X.
+       01 VarC-NbX    PIC X.
+      
+      *Comma separator  -  Replace don't apply
+      *Bug: our parser will produce 3 tokens here and the replace
+      *mechanism will match the replace operation on 1 token at a time
+       01 Var 1       pic X.
+       01 Var 3       pic X.
+      
+      
+      
+      
+       procedure division.
+      
+           goback
+           .
+       end program DVZS0OSM.

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ReplaceWithMultipleRules.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ReplaceWithMultipleRules.rdz.cbl
@@ -1,0 +1,50 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DVZS0OSM.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER. IBM-370 WITH DEBUGGING MODE.
+       data division.
+       working-storage section.
+       REPLACE
+          ==C-Nb==                 BY ==1==
+          ==C-NbX==                BY ==3==
+          ==3== by ==4==
+      
+          ==:TOTO:==              BY ==3==
+          .
+      
+      *Parenthesis separator  -  Replace APPLY
+       01 Var         pic X(C-Nb).
+       01 Var         pic X(C-NbX).
+       
+      *Semi colon separator   -  Replace APPLY
+       01 Var:C-Nb    pic X.
+       01 Var:C-NbX   pic X.
+      *Parenthesis separator  -  Replace APPLY
+       01 Var(C-Nb    pic X.
+       01 Var(C-NbX   pic X.
+      *Semi colon separator  -  Replace APPLY
+      *Bug: replace mechanism will replace the whole token
+      *since the replace operation is considered a single replacement token
+       01 Var:C-Nb:    pic X.
+       01 Var:C-NbX:   pic X.
+      
+
+      *No separator     -  Replace don't apply
+       01 VarC-Nb     PIC X.
+       01 VarC-NbX    PIC X.
+      
+      *Comma separator  -  Replace don't apply
+      *Bug: our parser will produce 3 tokens here and the replace
+      *mechanism will match the replace operation on 1 token at a time
+       01 Var,C-Nb    pic X.
+       01 Var,C-NbX   pic X.
+      
+      
+      
+      
+       procedure division.
+      
+           goback
+           .
+       end program DVZS0OSM.

--- a/TypeCobol.Test/Utils/Comparators.cs
+++ b/TypeCobol.Test/Utils/Comparators.cs
@@ -344,6 +344,7 @@ namespace TypeCobol.Test.Utils
                 if (currentLine < processedTokensLine.Line)
                 {
                     result.AppendLine();
+                    //Append lines without tokens
                     while (currentLine < processedTokensLine.Line - 1)
                     {
                         result.AppendLine(compilationResult.ProcessedTokensDocumentSnapshot.Lines[currentLine].Text);

--- a/TypeCobol.Test/Utils/Comparators.cs
+++ b/TypeCobol.Test/Utils/Comparators.cs
@@ -344,36 +344,36 @@ namespace TypeCobol.Test.Utils
             var currentLine = 0;
             var currentCol = 1;
 
-            foreach (var processedTokens in compilationResult.ProcessedTokensDocumentSnapshot.GetProcessedTokens())
+            foreach (var processedToken in compilationResult.ProcessedTokensDocumentSnapshot.GetProcessedTokens())
             {
-                if (processedTokens is ImportedToken)
+                if (processedToken is ImportedToken)
                 {
                     continue;//TODO Handle token from COPY
                              //Token from COPY require to expand the COPY correctly.
                              //Then line number in the output document will not be synced with line number in original document
                 }
 
-                if (currentLine < processedTokens.Line)
+                if (currentLine < processedToken.Line)
                 {
                     result.AppendLine();
                     //Append lines without tokens
-                    while (currentLine < processedTokens.Line - 1)
+                    while (currentLine < processedToken.Line - 1)
                     {
                         result.AppendLine(compilationResult.ProcessedTokensDocumentSnapshot.Lines[currentLine].Text);
                         currentLine++;
                     }
 
-                    currentLine = processedTokens.Line;
+                    currentLine = processedToken.Line;
                     currentCol = 1;
                 }
 
-                var count = processedTokens.Column - currentCol;
-                if(count > 0) 
+                var count = processedToken.Column - currentCol;
+                if (count > 0)
                 {
                    result.Append(new string(' ', count));
                 }
-                result.Append(processedTokens.Text);
-                currentCol = processedTokens.Column + processedTokens.Text.Length;
+                result.Append(processedToken.Text);
+                currentCol = processedToken.Column + processedToken.Text.Length;
             }
 
             return result.ToString();

--- a/TypeCobol/Compiler/Scanner/Token.cs
+++ b/TypeCobol/Compiler/Scanner/Token.cs
@@ -431,7 +431,9 @@ namespace TypeCobol.Compiler.Scanner
             //PartialCobolWord and PictureCharacterString are text based (and must be rescanned later as a whole)
             if (TokenType == TokenType.PartialCobolWord || TokenType == TokenType.PictureCharacterString)
             {
-                var startIndexFound = NormalizedText.IndexOf(comparisonToken.NormalizedText, StringComparison.OrdinalIgnoreCase);
+                var normalizedText = NormalizedText;
+                var comparisonNormalizedText = comparisonToken.NormalizedText;
+                var startIndexFound = normalizedText.IndexOf(comparisonNormalizedText, StringComparison.OrdinalIgnoreCase);
                 if (startIndexFound < 0)
                 {
                     return false;
@@ -443,11 +445,11 @@ namespace TypeCobol.Compiler.Scanner
                     return true;
                 }
 
-                var endIndex = startIndexFound + comparisonToken.NormalizedText.Length - 1;
+                var endIndex = startIndexFound + comparisonNormalizedText.Length - 1;
 
                 //Check if comparisonToken.NormalizedText begin/end with replace separator or is surrounded with replace separator 
-                return (startIndexFound == 0 || CobolChar.IsReplaceSeparator(NormalizedText[startIndexFound - 1]) || CobolChar.IsReplaceSeparator(comparisonToken.NormalizedText[0]))
-                       && (endIndex >= NormalizedText.Length - 1 || CobolChar.IsReplaceSeparator(NormalizedText[endIndex + 1]) || CobolChar.IsReplaceSeparator(comparisonToken.NormalizedText[comparisonToken.NormalizedText.Length-1]));
+                return (startIndexFound == 0 || CobolChar.IsReplaceSeparator(normalizedText[startIndexFound - 1]) || CobolChar.IsReplaceSeparator(comparisonNormalizedText[0]))
+                       && (endIndex >= normalizedText.Length - 1 || CobolChar.IsReplaceSeparator(normalizedText[endIndex + 1]) || CobolChar.IsReplaceSeparator(comparisonNormalizedText[comparisonNormalizedText.Length - 1]));
             }
 
             //Text-based comparison for AlphanumericLiteral, NumericLiteral, Symbol and SyntaxLiteral families

--- a/TypeCobol/Compiler/Text/CobolChar.cs
+++ b/TypeCobol/Compiler/Text/CobolChar.cs
@@ -51,6 +51,26 @@ namespace TypeCobol.Compiler.Text
         }
 
         /// <summary>
+        /// Separators allowed around the target of a replace inside a single word (token).
+        /// See "Comparison rules" of REPLACE in IBM Enterprise Cobol specifications.
+        /// </summary>
+        /// <param name="chr"></param>
+        /// <returns></returns>
+        public static bool IsReplaceSeparator(char chr)
+        {
+            switch (chr)
+            {
+                case ' ':
+                case ':':
+                case '(':
+                case ')':
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
         /// True if the current char is allowed in a PseudoText
         /// </summary>
         public static bool IsAllowedInsidePseudoText(char chr)


### PR DESCRIPTION
WI #2477 Check for 'replace separator' around token to replace
'replace separator' can be around token to replace or there can be at the beginning and end of the replacement token.

New ICompilationResultFormatter/Comparisons : ProcessedTokens.
This allow to see the source code with replaced token applied.