### PR TITLE
WI #2218 Preserve column and line while rescanning during a REPLACE

### DIFF
--- a/TypeCobol/Compiler/Preprocessor/AbstractReplaceTokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Preprocessor/AbstractReplaceTokensLinesIterator.cs
@@ -132,6 +132,7 @@ namespace TypeCobol.Compiler.Preprocessor
                 var line = new StringBuilder();
                 if (_returnedTokensForCurrentLine.Count > 0)
                 {
+                    //Keep original spaces before first token
                     line.Append(new string(' ', _returnedTokensForCurrentLine[0].StartIndex));
                 }
                 for (; tokenIndex < _returnedTokensForCurrentLine.Count; tokenIndex++)
@@ -477,8 +478,8 @@ namespace TypeCobol.Compiler.Preprocessor
 
         internal static Token GenerateReplacementToken(Token originalToken, string replacedTokenText, MultilineScanState scanState, TypeCobolOptions scanOptions)
         {
-            //Keep original column in text to scan
-            var textToScan = new string(' ', originalToken.StartIndex) + replacedTokenText;
+            var textToScan = new string(' ', originalToken.StartIndex) //Keep original spaces before first token
+                             + replacedTokenText;
             TokensLine tempTokensLine = TokensLine.CreateVirtualLineForInsertedToken(originalToken.TokensLine.LineIndex, textToScan, originalToken.TokensLine.ColumnsLayout);
             tempTokensLine.InitializeScanState(scanState);
 
@@ -519,6 +520,7 @@ namespace TypeCobol.Compiler.Preprocessor
                 int i = 0;
                 int[] columns = new int[replacementTokens.Length + 1];
                 StringBuilder sb = new StringBuilder();
+                //Keep original spaces before first token
                 sb.Append(new string(' ', firstOriginalToken.StartIndex));
                 foreach (var t in replacementTokens)
                 {

--- a/TypeCobol/Compiler/Preprocessor/AbstractReplaceTokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Preprocessor/AbstractReplaceTokensLinesIterator.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Diagnostics;
+using System.Text;
 using TypeCobol.Compiler.Directives;
 using TypeCobol.Compiler.Parser;
 using TypeCobol.Compiler.Scanner;
@@ -129,6 +130,10 @@ namespace TypeCobol.Compiler.Preprocessor
 
                 // Build text to scan from accumulated tokens
                 var line = new StringBuilder();
+                if (_returnedTokensForCurrentLine.Count > 0)
+                {
+                    line.Append(new string(' ', _returnedTokensForCurrentLine[0].StartIndex));
+                }
                 for (; tokenIndex < _returnedTokensForCurrentLine.Count; tokenIndex++)
                 {
                     line.Append(_returnedTokensForCurrentLine[tokenIndex].Text);
@@ -136,7 +141,7 @@ namespace TypeCobol.Compiler.Preprocessor
                 }
 
                 // Scan
-                var virtualLine = TokensLine.CreateVirtualLineForInsertedToken(0, line.ToString(), ColumnsLayout.FreeTextFormat);
+                var virtualLine = TokensLine.CreateVirtualLineForInsertedToken(_currentLine.LineIndex, line.ToString(), _currentLine.ColumnsLayout);
                 Scanner.Scanner.ScanTokensLine(virtualLine, initialScanState, _parentIterator.CompilerOptions, new List<RemarksDirective.TextNameVariation>());
 
                 // Update state variables
@@ -223,7 +228,7 @@ namespace TypeCobol.Compiler.Preprocessor
                 Token nextToken = check.NextToken;
                 _currentPosition.ReplaceOperations = check.UpdatedReplaceOperations;
 
-                if (!check.ApplyReplace)
+                if (!check.HasReplaceOperations)
                 {
                     _currentPosition.CurrentToken = nextToken;
                     _scanStateTracker.AccumulateToken(nextToken);
@@ -288,10 +293,10 @@ namespace TypeCobol.Compiler.Preprocessor
 
         protected struct CheckTokenStatus
         {
-            //TODO wait to rewrite AutoReplace iterator with this class to see if this bool is useful or not
-            public bool ApplyReplace;
             public Token NextToken;
             public IReadOnlyList<ReplaceOperation> UpdatedReplaceOperations;
+
+            public bool HasReplaceOperations => UpdatedReplaceOperations != null && UpdatedReplaceOperations.Count > 0;
         }
 
         protected abstract CheckTokenStatus CheckNextTokenBeforeReplace(IReadOnlyList<ReplaceOperation> currentReplaceOperations);
@@ -472,13 +477,15 @@ namespace TypeCobol.Compiler.Preprocessor
 
         internal static Token GenerateReplacementToken(Token originalToken, string replacedTokenText, MultilineScanState scanState, TypeCobolOptions scanOptions)
         {
-            TokensLine tempTokensLine = TokensLine.CreateVirtualLineForInsertedToken(0, replacedTokenText, originalToken.TokensLine.ColumnsLayout);
+            //Keep original column in text to scan
+            var textToScan = new string(' ', originalToken.StartIndex) + replacedTokenText;
+            TokensLine tempTokensLine = TokensLine.CreateVirtualLineForInsertedToken(originalToken.TokensLine.LineIndex, textToScan, originalToken.TokensLine.ColumnsLayout);
             tempTokensLine.InitializeScanState(scanState);
 
             Token generatedToken;
             if (replacedTokenText.Length > 0)
             {
-                Scanner.Scanner tempScanner = new Scanner.Scanner(replacedTokenText, 0, replacedTokenText.Length - 1, tempTokensLine, scanOptions);
+                Scanner.Scanner tempScanner = new Scanner.Scanner(textToScan, originalToken.StartIndex, textToScan.Length - 1, tempTokensLine, scanOptions);
                 generatedToken = tempScanner.GetNextToken();
             }
             else
@@ -488,6 +495,11 @@ namespace TypeCobol.Compiler.Preprocessor
             }
 
             // TODO scanning may have produced errors, they are lost here.
+            //It may be tricky to report these Diagnostics as they are created on a virtual line with replaced tokens
+            //They could have no real meaning on the original source code for the end user
+            //Idea : prefix diagnostic message with "During Replace operation" or something like this.
+            //For now just check if don't actually lose Diagnostics
+            Debug.Assert(tempTokensLine.ScannerDiagnostics.Count == 0);
 
             return generatedToken;
         }
@@ -507,6 +519,7 @@ namespace TypeCobol.Compiler.Preprocessor
                 int i = 0;
                 int[] columns = new int[replacementTokens.Length + 1];
                 StringBuilder sb = new StringBuilder();
+                sb.Append(new string(' ', firstOriginalToken.StartIndex));
                 foreach (var t in replacementTokens)
                 {
                     columns[i++] = sb.Length;
@@ -517,10 +530,11 @@ namespace TypeCobol.Compiler.Preprocessor
                 int startTokIdx = 0;
                 int endTokIdx;
                 List<T> newReplacedTokens = new List<T>(replacementTokens.Length);
-                TokensLine tempTokensLine = TokensLine.CreateVirtualLineForInsertedToken(0, tokenText, firstOriginalToken.TokensLine.ColumnsLayout);
+
+                TokensLine tempTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstOriginalToken.TokensLine.LineIndex, tokenText, firstOriginalToken.TokensLine.ColumnsLayout);
                 var initialScanState = _scanStateTracker.GetCurrentScanState() ?? firstOriginalToken.TokensLine.InitialScanState;
                 tempTokensLine.InitializeScanState(initialScanState);
-                var tempScanner = new TypeCobol.Compiler.Scanner.Scanner(tokenText, 0, tokenText.Length - 1, tempTokensLine, CompilerOptions);
+                var tempScanner = new TypeCobol.Compiler.Scanner.Scanner(tokenText, firstOriginalToken.StartIndex, tokenText.Length - 1, tempTokensLine, CompilerOptions);
                 Token rescannedToken;
                 List<Token> tokens = new List<Token>((replacementTokens.Length / 2) + 1);
                 while ((rescannedToken = tempScanner.GetNextToken()) != null)

--- a/TypeCobol/Compiler/Preprocessor/AbstractReplaceTokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Preprocessor/AbstractReplaceTokensLinesIterator.cs
@@ -476,7 +476,7 @@ namespace TypeCobol.Compiler.Preprocessor
             }
         }
 
-        internal static Token GenerateReplacementToken(Token originalToken, string replacedTokenText, MultilineScanState scanState, TypeCobolOptions scanOptions)
+        private static Token GenerateReplacementToken(Token originalToken, string replacedTokenText, MultilineScanState scanState, TypeCobolOptions scanOptions)
         {
             var textToScan = new string(' ', originalToken.StartIndex) //Keep original spaces before first token
                              + replacedTokenText;

--- a/TypeCobol/Compiler/Preprocessor/AutoReplacePartialWordsTokensDocument.cs
+++ b/TypeCobol/Compiler/Preprocessor/AutoReplacePartialWordsTokensDocument.cs
@@ -22,15 +22,15 @@ namespace TypeCobol.Compiler.Preprocessor
             {
                 var nextToken = SourceIteratorNextToken();
 
-
                 // Reset previous replace operations
                 List<ReplaceOperation> updatedReplaceOperations = null;
                 if (nextToken.TokenType == TokenType.PartialCobolWord)
                 {
                     //TODO Don't reset replace but first try to check if it's the same than before
                     updatedReplaceOperations = new List<ReplaceOperation>();
-                    var replacementText = new string(' ', nextToken.StartIndex)  //Keep original spaces before first token
-                                          + nextToken.NormalizedText.Replace(":", string.Empty);
+                    var replacementText =
+                        new string(' ', nextToken.StartIndex) //Keep original spaces before first token
+                        + nextToken.NormalizedText.Replace(":", string.Empty);
                     TokensLine tempTokensLine = TokensLine.CreateVirtualLineForInsertedToken(nextToken.TokensLine.LineIndex, replacementText, nextToken.TokensLine.ColumnsLayout);
                     var replacementToken = new Token(TokenType.UserDefinedWord, nextToken.StartIndex, tempTokensLine.Length - 1, tempTokensLine);
 

--- a/TypeCobol/Compiler/Preprocessor/AutoReplacePartialWordsTokensDocument.cs
+++ b/TypeCobol/Compiler/Preprocessor/AutoReplacePartialWordsTokensDocument.cs
@@ -29,8 +29,8 @@ namespace TypeCobol.Compiler.Preprocessor
                 {
                     //TODO Don't reset replace but first try to check if it's the same than before
                     updatedReplaceOperations = new List<ReplaceOperation>();
-                                                //Preserve original column
-                    var replacementText = new string(' ', nextToken.StartIndex) + nextToken.NormalizedText.Replace(":", string.Empty);
+                    var replacementText = new string(' ', nextToken.StartIndex)  //Keep original spaces before first token
+                                          + nextToken.NormalizedText.Replace(":", string.Empty);
                     TokensLine tempTokensLine = TokensLine.CreateVirtualLineForInsertedToken(nextToken.TokensLine.LineIndex, replacementText, nextToken.TokensLine.ColumnsLayout);
                     var replacementToken = new Token(TokenType.UserDefinedWord, nextToken.StartIndex, tempTokensLine.Length - 1, tempTokensLine);
 

--- a/TypeCobol/Compiler/Preprocessor/AutoReplacePartialWordsTokensDocument.cs
+++ b/TypeCobol/Compiler/Preprocessor/AutoReplacePartialWordsTokensDocument.cs
@@ -12,77 +12,36 @@ namespace TypeCobol.Compiler.Preprocessor
     /// </summary>
     public class AutoReplacePartialWordsTokensDocument : ProcessedTokensDocument
     {
-        private class TokensLinesIterator : ITokensLinesIterator
+        private class TokensLinesIterator : AbstractReplaceTokensLinesIterator
         {
-            private readonly ITokensLinesIterator _sourceIterator;
-            private readonly TypeCobolOptions _compilerOptions;
-
-            public TokensLinesIterator([NotNull] ITokensLinesIterator sourceIterator, [NotNull] TypeCobolOptions compilerOptions)
+            public TokensLinesIterator([NotNull] ITokensLinesIterator sourceIterator, [NotNull] TypeCobolOptions compilerOptions) : base(sourceIterator, compilerOptions)
             {
-                System.Diagnostics.Debug.Assert(sourceIterator != null);
-                System.Diagnostics.Debug.Assert(compilerOptions != null);
-                _sourceIterator = sourceIterator;
-                _compilerOptions = compilerOptions;
             }
 
-            public Token NextToken()
+            protected override CheckTokenStatus CheckNextTokenBeforeReplace(IReadOnlyList<ReplaceOperation> currentReplaceOperations)
             {
-                var nextToken = _sourceIterator.NextToken();
+                var nextToken = SourceIteratorNextToken();
+
+
+                // Reset previous replace operations
+                List<ReplaceOperation> updatedReplaceOperations = null;
                 if (nextToken.TokenType == TokenType.PartialCobolWord)
                 {
-                    //basic replacement mechanic, remove the ':' from the tag.
-                    //NOTE: Altered token is scanned as if it was located at the beginning of the line because we only have InitialScanState here.
-                    //NOTE: Does not handle '::-item' or 'item-::' partial names as '::' will turn into empty string and will produce invalid data names.
-                    var originalToken = nextToken;
-                    string replacedTokenText = originalToken.NormalizedText.Replace(":", string.Empty);
-                    var scanState = originalToken.TokensLine.InitialScanState;
-                    var generatedReplacementToken = ReplaceTokensLinesIterator.GenerateReplacementToken(originalToken, replacedTokenText, scanState, _compilerOptions);
+                    //TODO Don't reset replace but first try to check if it's the same than before
+                    updatedReplaceOperations = new List<ReplaceOperation>();
+                                                //Preserve original column
+                    var replacementText = new string(' ', nextToken.StartIndex) + nextToken.NormalizedText.Replace(":", string.Empty);
+                    TokensLine tempTokensLine = TokensLine.CreateVirtualLineForInsertedToken(nextToken.TokensLine.LineIndex, replacementText, nextToken.TokensLine.ColumnsLayout);
+                    var replacementToken = new Token(TokenType.UserDefinedWord, nextToken.StartIndex, tempTokensLine.Length - 1, tempTokensLine);
 
-                    nextToken = new ReplacedPartialCobolWord(generatedReplacementToken, null, originalToken);
+                    updatedReplaceOperations.Add(new SingleTokenReplaceOperation(nextToken, replacementToken));
                 }
 
-                return nextToken;
-            }
-
-            // Delegate the rest of the implementation to _sourceIterator
-
-            public string DocumentPath => _sourceIterator.DocumentPath;
-
-            public int LineIndexInMainDocument => _sourceIterator.LineIndexInMainDocument;
-
-            public int ColumnIndex => _sourceIterator.ColumnIndex;
-
-            public int LineIndex => _sourceIterator.LineIndex;
-
-            public ITokensLine CurrentLine => _sourceIterator.CurrentLine;
-
-            public ITokensLine LastLine => _sourceIterator.LastLine;
-
-            public Token CurrentToken => _sourceIterator.CurrentToken;
-
-            public object GetCurrentPosition()
-            {
-                return _sourceIterator.GetCurrentPosition();
-            }
-
-            public void SeekToPosition(object iteratorPosition)
-            {
-                _sourceIterator.SeekToPosition(iteratorPosition);
-            }
-
-            public void SeekToLineInMainDocument(int line)
-            {
-                _sourceIterator.SeekToLineInMainDocument(line);
-            }
-
-            public void SaveCurrentPositionSnapshot()
-            {
-                _sourceIterator.SaveCurrentPositionSnapshot();
-            }
-
-            public void ReturnToLastPositionSnapshot()
-            {
-                _sourceIterator.ReturnToLastPositionSnapshot();
+                return new CheckTokenStatus()
+                {
+                    NextToken = nextToken,
+                    UpdatedReplaceOperations = updatedReplaceOperations
+                };
             }
         }
 

--- a/TypeCobol/Compiler/Preprocessor/ReplaceTokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Preprocessor/ReplaceTokensLinesIterator.cs
@@ -69,7 +69,6 @@ namespace TypeCobol.Compiler.Preprocessor
 
             return new CheckTokenStatus()
                    {
-                       ApplyReplace = updatedReplaceOperations != null,
                        NextToken = nextToken,
                        UpdatedReplaceOperations = updatedReplaceOperations
                    };

--- a/TypeCobol/Compiler/Preprocessor/ReplacingTokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Preprocessor/ReplacingTokensLinesIterator.cs
@@ -124,7 +124,6 @@ namespace TypeCobol.Compiler.Preprocessor
             //Replacing directive never changes
             return new CheckTokenStatus()
                    {
-                       ApplyReplace = currentReplaceOperations != null,
                        NextToken = nextToken,
                        UpdatedReplaceOperations = currentReplaceOperations
                    };

--- a/TypeCobol/Compiler/Preprocessor/ReplacingTokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Preprocessor/ReplacingTokensLinesIterator.cs
@@ -112,7 +112,7 @@ namespace TypeCobol.Compiler.Preprocessor
                     int additionalSpaceRequired = replacedText.Length - originalText.Length;
                     if (CheckTokensLineOverflow(nextToken, additionalSpaceRequired))
                     {
-                        TokensLine virtualTokensLine = TokensLine.CreateVirtualLineForInsertedToken(0, replacedText, nextToken.TokensLine.ColumnsLayout);
+                        TokensLine virtualTokensLine = TokensLine.CreateVirtualLineForInsertedToken(nextToken.TokensLine.LineIndex, replacedText, nextToken.TokensLine.ColumnsLayout);
                         Token replacementToken = new Token(TokenType.UserDefinedWord, 0, replacedText.Length - 1, virtualTokensLine);
 
                         nextToken = new ReplacedToken(replacementToken, nextToken);


### PR DESCRIPTION
WI #2218 Scan during Replace preserve original column and line

Temporary Virtual Line used to rescan replaced token:
- Always use the lineIndex of the original line
- The line preserve space characters before first token
- Keep the ColumnLayout of the original line

Rewrite AutoReplaceIterator with AbstractReplaceTokensLinesIterator.