### PR TITLE
WI #2357 Preserve original column of virtual concatenated line

### DIFF
--- a/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine.Mix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine.Mix.txt
@@ -1,4 +1,4 @@
-﻿       IDENTIFICATION DIVISION.
+       IDENTIFICATION DIVISION.
        PROGRAM-ID. DVZF0OSM.
        data division.
        working-storage section.
@@ -30,11 +30,11 @@ Line 10[19,21] <30, Error, Semantics> - Semantic error: Symbol foo is not refere
 
       
       *    KO
-Line 32[13,75] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 32[20,82] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 33[19,20] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -            ' er zer '
-Line 34[13,74] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 34[20,81] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 35[19,20] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -            " er zer '
@@ -42,11 +42,11 @@ Line 35[19,20] <21, Error, Tokens> - The delimiter character of this continuatio
 Line 37[19,20] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -            ' er zer "
       
-Line 39[13,75] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 39[20,82] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 40[19,20] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -            " er zer "
-Line 41[13,74] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 41[20,81] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 42[19,20] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -            ' er zer "
@@ -70,7 +70,7 @@ Line 52[19,20] <21, Error, Tokens> - The delimiter character of this continuatio
            display "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 57[21,22] <27, Error, Syntax> - Syntax error : Starting delimiter of the continuation line is missing.
       -              er zer "
-Line 58[13,72] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 58[20,79] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 59[20,21] <27, Error, Syntax> - Syntax error : Closing delimiter of the continuation line is missing.
       -             " er zer

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine2.Mix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine2.Mix.txt
@@ -2,7 +2,7 @@
        PROGRAM-ID. MyPGM2.
        procedure division.
       * KO
-Line 5[13,75] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 5[20,82] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
            display "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 6[17,18] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -          ' er zer '

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine4.Mix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine4.Mix.txt
@@ -1,8 +1,8 @@
-﻿       IDENTIFICATION division.
+       IDENTIFICATION division.
        PROGRAM-ID. MyPGM4.
        procedure division.
       * KO
-Line 5[14,75] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 5[21,82] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
             display 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 6[17,18] <21, Error, Tokens> - The delimiter character of this continuation line is different from the initial delimiter of the alphanumeric literal
       -          " er zer "

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine6.Mix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine6.Mix.txt
@@ -1,8 +1,8 @@
-﻿       IDENTIFICATION division.
+       IDENTIFICATION division.
        PROGRAM-ID. MyPGM6.
        procedure division.
       * KO
-Line 5[18,73] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 5[25,80] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
                 display "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 6[18,19] <27, Error, Syntax> - Syntax error : Starting delimiter of the continuation line is missing.
       -           er zer '

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine8.Mix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ContinuationLine/ContinuationLine8.Mix.txt
@@ -1,8 +1,8 @@
-﻿       IDENTIFICATION division.
+       IDENTIFICATION division.
        PROGRAM-ID. MyPGM8.
        procedure division.
       * KO
-Line 5[18,73] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
+Line 5[25,80] <27, Error, Syntax> - Syntax error : Literal is not correctly delimited.
                 display 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Line 6[18,19] <27, Error, Syntax> - Syntax error : Starting delimiter of the continuation line is missing.
       -           er zer "

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -381,7 +381,7 @@ namespace TypeCobol.Compiler.Scanner
                 if (concatenatedLine.Length > 0)
                 {
                     // Scan the continuation text, and get its last token so far
-                    TokensLine temporaryTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstSourceLine.LineIndex, concatenatedLine, firstSourceLine.ColumnsLayout == ColumnsLayout.FreeTextFormat ? ColumnsLayout.FreeTextFormat : ColumnsLayout.CobolReferenceFormatWithoutCommentText);
+                    TokensLine temporaryTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstSourceLine.LineIndex, concatenatedLine, firstSourceLine.ColumnsLayout == ColumnsLayout.FreeTextFormat ? ColumnsLayout.FreeTextFormat : ColumnsLayout.CobolReferenceFormatUnlimitedLength);
                     Scanner.ScanTokensLine(temporaryTokensLine, initialScanState, compilerOptions, copyTextNameVariations);
                     Token lastTokenOfConcatenatedLineSoFar = temporaryTokensLine.SourceTokens[temporaryTokensLine.SourceTokens.Count - 1];
 
@@ -546,7 +546,7 @@ namespace TypeCobol.Compiler.Scanner
             }
 
             // Scan the complete continuation text as a whole
-            TokensLine virtualContinuationTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstSourceLine.LineIndex, concatenatedLine, firstSourceLine.ColumnsLayout == ColumnsLayout.FreeTextFormat ? ColumnsLayout.FreeTextFormat : ColumnsLayout.CobolReferenceFormatWithoutCommentText);
+            TokensLine virtualContinuationTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstSourceLine.LineIndex, concatenatedLine, firstSourceLine.ColumnsLayout == ColumnsLayout.FreeTextFormat ? ColumnsLayout.FreeTextFormat : ColumnsLayout.CobolReferenceFormatUnlimitedLength);
             // Create a BitArray of Multi String Positions based on the length of the concatenated line.
             BitArray? multiStringConcatBitPosition = null;
             if (multiStringConcatPositions.Count > 0)

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -303,8 +303,11 @@ namespace TypeCobol.Compiler.Scanner
             // Initialize the continuation text with the complete source text of the first source line
             int firstSourceLineIndex = i;
             TokensLine firstSourceLine = continuationLinesGroup[firstSourceLineIndex];
-            //Take the line without Comment TextArea
-            string concatenatedLine = (firstSourceLine.SequenceNumberText ?? "") + (firstSourceLine.Indicator.IsMissing ? "" : firstSourceLine.IndicatorChar) + firstSourceLine.SourceText;
+            var concatenatedLineLayout = firstSourceLine.ColumnsLayout == ColumnsLayout.FreeTextFormat ? ColumnsLayout.FreeTextFormat : ColumnsLayout.CobolReferenceFormatUnlimitedLength;
+            // Take the line without Comment TextArea
+            string concatenatedLine =   (firstSourceLine.SequenceNumberText ?? string.Empty)
+                                      + (firstSourceLine.Indicator.IsMissing ? string.Empty : firstSourceLine.IndicatorChar)
+                                      + firstSourceLine.SourceText;
             textAreasForOriginalLinesInConcatenatedLine[firstSourceLineIndex] = new TextArea(0, concatenatedLine.Length -1);
             startIndexForTextAreasInOriginalLines[firstSourceLineIndex] = 0;
             offsetForLiteralContinuationInOriginalLines[firstSourceLineIndex] = 0;
@@ -381,7 +384,7 @@ namespace TypeCobol.Compiler.Scanner
                 if (concatenatedLine.Length > 0)
                 {
                     // Scan the continuation text, and get its last token so far
-                    TokensLine temporaryTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstSourceLine.LineIndex, concatenatedLine, firstSourceLine.ColumnsLayout == ColumnsLayout.FreeTextFormat ? ColumnsLayout.FreeTextFormat : ColumnsLayout.CobolReferenceFormatUnlimitedLength);
+                    TokensLine temporaryTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstSourceLine.LineIndex, concatenatedLine, concatenatedLineLayout);
                     Scanner.ScanTokensLine(temporaryTokensLine, initialScanState, compilerOptions, copyTextNameVariations);
                     Token lastTokenOfConcatenatedLineSoFar = temporaryTokensLine.SourceTokens[temporaryTokensLine.SourceTokens.Count - 1];
 
@@ -546,7 +549,7 @@ namespace TypeCobol.Compiler.Scanner
             }
 
             // Scan the complete continuation text as a whole
-            TokensLine virtualContinuationTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstSourceLine.LineIndex, concatenatedLine, firstSourceLine.ColumnsLayout == ColumnsLayout.FreeTextFormat ? ColumnsLayout.FreeTextFormat : ColumnsLayout.CobolReferenceFormatUnlimitedLength);
+            TokensLine virtualContinuationTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstSourceLine.LineIndex, concatenatedLine, concatenatedLineLayout);
             // Create a BitArray of Multi String Positions based on the length of the concatenated line.
             BitArray? multiStringConcatBitPosition = null;
             if (multiStringConcatPositions.Count > 0)

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -303,9 +303,10 @@ namespace TypeCobol.Compiler.Scanner
             // Initialize the continuation text with the complete source text of the first source line
             int firstSourceLineIndex = i;
             TokensLine firstSourceLine = continuationLinesGroup[firstSourceLineIndex];
-            string concatenatedLine = firstSourceLine.SourceText;
+            //Take the line without Comment TextArea
+            string concatenatedLine = (firstSourceLine.SequenceNumberText ?? "") + (firstSourceLine.Indicator.IsMissing ? "" : firstSourceLine.IndicatorChar) + firstSourceLine.SourceText;
             textAreasForOriginalLinesInConcatenatedLine[firstSourceLineIndex] = new TextArea(0, concatenatedLine.Length -1);
-            startIndexForTextAreasInOriginalLines[firstSourceLineIndex] = firstSourceLine.Source.StartIndex;
+            startIndexForTextAreasInOriginalLines[firstSourceLineIndex] = 0;
             offsetForLiteralContinuationInOriginalLines[firstSourceLineIndex] = 0;
 
             // Find the index of the last ContinuationLine in the group
@@ -380,7 +381,7 @@ namespace TypeCobol.Compiler.Scanner
                 if (concatenatedLine.Length > 0)
                 {
                     // Scan the continuation text, and get its last token so far
-                    TokensLine temporaryTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstSourceLine.LineIndex, concatenatedLine, ColumnsLayout.FreeTextFormat);
+                    TokensLine temporaryTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstSourceLine.LineIndex, concatenatedLine, firstSourceLine.ColumnsLayout == ColumnsLayout.FreeTextFormat ? ColumnsLayout.FreeTextFormat : ColumnsLayout.CobolReferenceFormatWithoutCommentText);
                     Scanner.ScanTokensLine(temporaryTokensLine, initialScanState, compilerOptions, copyTextNameVariations);
                     Token lastTokenOfConcatenatedLineSoFar = temporaryTokensLine.SourceTokens[temporaryTokensLine.SourceTokens.Count - 1];
 
@@ -470,7 +471,7 @@ namespace TypeCobol.Compiler.Scanner
                             if (lastTokenOfConcatenatedLineSoFar.HasClosingDelimiter)
                             {
                                 bool continuationStartsWithTwoDelimiters = ((startOfContinuationIndex + 1) <= lastIndex && line[startOfContinuationIndex + 1] == lastTokenOfConcatenatedLineSoFar.ExpectedClosingDelimiter);
-                                bool previousDelimiterIsNotAtEnd = (lastTokenOfConcatenatedLineSoFar.EndColumn + CobolFormatAreas.Indicator) != CobolFormatAreas.End_B;
+                                bool previousDelimiterIsNotAtEnd = lastTokenOfConcatenatedLineSoFar.EndColumn != (int) CobolFormatAreas.End_B;
 
                                 if (format == ColumnsLayout.CobolReferenceFormat ? continuationStartsWithTwoDelimiters && previousDelimiterIsNotAtEnd : !continuationStartsWithTwoDelimiters)
                                 {
@@ -545,7 +546,7 @@ namespace TypeCobol.Compiler.Scanner
             }
 
             // Scan the complete continuation text as a whole
-            TokensLine virtualContinuationTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstSourceLine.LineIndex, concatenatedLine, ColumnsLayout.FreeTextFormat);
+            TokensLine virtualContinuationTokensLine = TokensLine.CreateVirtualLineForInsertedToken(firstSourceLine.LineIndex, concatenatedLine, firstSourceLine.ColumnsLayout == ColumnsLayout.FreeTextFormat ? ColumnsLayout.FreeTextFormat : ColumnsLayout.CobolReferenceFormatWithoutCommentText);
             // Create a BitArray of Multi String Positions based on the length of the concatenated line.
             BitArray? multiStringConcatBitPosition = null;
             if (multiStringConcatPositions.Count > 0)

--- a/TypeCobol/Compiler/Text/CobolTextLine.cs
+++ b/TypeCobol/Compiler/Text/CobolTextLine.cs
@@ -63,6 +63,10 @@ namespace TypeCobol.Compiler.Text
             {
                 MapVariableLengthLineWithReferenceFormat(out indicator, out source);
             }
+            else if (columnsLayout == ColumnsLayout.CobolReferenceFormatWithoutCommentText)
+            {
+                MapVariableLengthLineWithReferenceFormatWithoutCommentText(out indicator, out source);
+            }
             // - free format and unlimited line length
             else
             {
@@ -249,6 +253,39 @@ namespace TypeCobol.Compiler.Text
                 {
                     indicator = new TextArea(6, 6);
                     source = new TextArea(7, lastIndexOfLine > 71 ? 71 : lastIndexOfLine);
+                }
+                else if (lastIndexOfLine == 6)
+                {
+                    indicator = new TextArea(6, 6);
+                    source = new TextArea(7, 6);
+                }
+                else
+                {
+                    indicator = new TextArea(lastIndexOfLine + 1, lastIndexOfLine);
+                    source = new TextArea(lastIndexOfLine + 1, lastIndexOfLine);
+                }
+            }
+        }
+        private void MapVariableLengthLineWithReferenceFormatWithoutCommentText(out TextArea indicator, out TextArea source)
+        {
+            string line = textLine.Text;
+            int lastIndexOfLine = line.Length - 1;
+
+            // Test for free format compiler directives embedded in a reference format file
+            int compilerDirectiveIndex = FindFirstCharOfCompilerDirectiveBeforeColumn8(line);
+            if (compilerDirectiveIndex >= 0)
+            {
+                // Free text format line embedded in reference format file
+                indicator = new TextArea(compilerDirectiveIndex, compilerDirectiveIndex - 1);
+                source = new TextArea(compilerDirectiveIndex, lastIndexOfLine);
+            }
+            else
+            {
+                // Cobol reference format
+                if (lastIndexOfLine >= 7)
+                {
+                    indicator = new TextArea(6, 6);
+                    source = new TextArea(7, lastIndexOfLine);
                 }
                 else if (lastIndexOfLine == 6)
                 {

--- a/TypeCobol/Compiler/Text/CobolTextLine.cs
+++ b/TypeCobol/Compiler/Text/CobolTextLine.cs
@@ -237,7 +237,7 @@ namespace TypeCobol.Compiler.Text
         {
             string line = textLine.Text;
             int lastIndexOfLine = line.Length - 1;
-            int endIndex = !unlimitedLength && lastIndexOfLine > 71 ? 71 : lastIndexOfLine;
+            int maxEndIndex = !unlimitedLength && lastIndexOfLine > 71 ? 71 : lastIndexOfLine;
 
             // Test for free format compiler directives embedded in a reference format file
             int compilerDirectiveIndex = FindFirstCharOfCompilerDirectiveBeforeColumn8(line);
@@ -245,7 +245,7 @@ namespace TypeCobol.Compiler.Text
             {
                 // Free text format line embedded in reference format file
                 indicator = new TextArea(compilerDirectiveIndex, compilerDirectiveIndex - 1);
-                source = new TextArea(compilerDirectiveIndex, endIndex);
+                source = new TextArea(compilerDirectiveIndex, maxEndIndex);
             }
             else
             {
@@ -253,7 +253,7 @@ namespace TypeCobol.Compiler.Text
                 if (lastIndexOfLine >= 7)
                 {
                     indicator = new TextArea(6, 6);
-                    source = new TextArea(7, endIndex);
+                    source = new TextArea(7, maxEndIndex);
                 }
                 else if (lastIndexOfLine == 6)
                 {

--- a/TypeCobol/Compiler/Text/CobolTextLine.cs
+++ b/TypeCobol/Compiler/Text/CobolTextLine.cs
@@ -61,11 +61,11 @@ namespace TypeCobol.Compiler.Text
             TextArea source;
             if (columnsLayout == ColumnsLayout.CobolReferenceFormat)
             {
-                MapVariableLengthLineWithReferenceFormat(out indicator, out source);
+                MapVariableLengthLineWithReferenceFormat(false, out indicator, out source);
             }
-            else if (columnsLayout == ColumnsLayout.CobolReferenceFormatWithoutCommentText)
+            else if (columnsLayout == ColumnsLayout.CobolReferenceFormatUnlimitedLength)
             {
-                MapVariableLengthLineWithReferenceFormatWithoutCommentText(out indicator, out source);
+                MapVariableLengthLineWithReferenceFormat(true, out indicator, out source);
             }
             // - free format and unlimited line length
             else
@@ -233,10 +233,11 @@ namespace TypeCobol.Compiler.Text
 
         // --- Cobol text line scanner
 
-        private void MapVariableLengthLineWithReferenceFormat(out TextArea indicator, out TextArea source)
+        private void MapVariableLengthLineWithReferenceFormat(bool unlimitedLength, out TextArea indicator, out TextArea source)
         {
             string line = textLine.Text;
             int lastIndexOfLine = line.Length - 1;
+            int endIndex = !unlimitedLength && lastIndexOfLine > 71 ? 71 : lastIndexOfLine;
 
             // Test for free format compiler directives embedded in a reference format file
             int compilerDirectiveIndex = FindFirstCharOfCompilerDirectiveBeforeColumn8(line);
@@ -244,7 +245,7 @@ namespace TypeCobol.Compiler.Text
             {
                 // Free text format line embedded in reference format file
                 indicator = new TextArea(compilerDirectiveIndex, compilerDirectiveIndex - 1);
-                source = new TextArea(compilerDirectiveIndex, lastIndexOfLine > 71 ? 71 : lastIndexOfLine);
+                source = new TextArea(compilerDirectiveIndex, endIndex);
             }
             else
             {
@@ -252,40 +253,7 @@ namespace TypeCobol.Compiler.Text
                 if (lastIndexOfLine >= 7)
                 {
                     indicator = new TextArea(6, 6);
-                    source = new TextArea(7, lastIndexOfLine > 71 ? 71 : lastIndexOfLine);
-                }
-                else if (lastIndexOfLine == 6)
-                {
-                    indicator = new TextArea(6, 6);
-                    source = new TextArea(7, 6);
-                }
-                else
-                {
-                    indicator = new TextArea(lastIndexOfLine + 1, lastIndexOfLine);
-                    source = new TextArea(lastIndexOfLine + 1, lastIndexOfLine);
-                }
-            }
-        }
-        private void MapVariableLengthLineWithReferenceFormatWithoutCommentText(out TextArea indicator, out TextArea source)
-        {
-            string line = textLine.Text;
-            int lastIndexOfLine = line.Length - 1;
-
-            // Test for free format compiler directives embedded in a reference format file
-            int compilerDirectiveIndex = FindFirstCharOfCompilerDirectiveBeforeColumn8(line);
-            if (compilerDirectiveIndex >= 0)
-            {
-                // Free text format line embedded in reference format file
-                indicator = new TextArea(compilerDirectiveIndex, compilerDirectiveIndex - 1);
-                source = new TextArea(compilerDirectiveIndex, lastIndexOfLine);
-            }
-            else
-            {
-                // Cobol reference format
-                if (lastIndexOfLine >= 7)
-                {
-                    indicator = new TextArea(6, 6);
-                    source = new TextArea(7, lastIndexOfLine);
+                    source = new TextArea(7, endIndex);
                 }
                 else if (lastIndexOfLine == 6)
                 {

--- a/TypeCobol/Compiler/Text/ColumnsLayout.cs
+++ b/TypeCobol/Compiler/Text/ColumnsLayout.cs
@@ -15,7 +15,12 @@ namespace TypeCobol.Compiler.Text
         /// Columns 73-> : Comment
         /// </summary>
         CobolReferenceFormat,
-        CobolReferenceFormatWithoutCommentText,
+        /// <summary>
+        /// Like CobolReferenceFormat but with unlimited line length.
+        /// This column layout should only be used by continuation line.
+        /// 
+        /// </summary>
+        CobolReferenceFormatUnlimitedLength,
         /// <summary>
         /// Free-form format
         /// There is not limit on the size a source line.

--- a/TypeCobol/Compiler/Text/ColumnsLayout.cs
+++ b/TypeCobol/Compiler/Text/ColumnsLayout.cs
@@ -15,6 +15,7 @@ namespace TypeCobol.Compiler.Text
         /// Columns 73-> : Comment
         /// </summary>
         CobolReferenceFormat,
+        CobolReferenceFormatWithoutCommentText,
         /// <summary>
         /// Free-form format
         /// There is not limit on the size a source line.

--- a/TypeCobol/Compiler/Text/ColumnsLayout.cs
+++ b/TypeCobol/Compiler/Text/ColumnsLayout.cs
@@ -17,8 +17,7 @@ namespace TypeCobol.Compiler.Text
         CobolReferenceFormat,
         /// <summary>
         /// Like CobolReferenceFormat but with unlimited line length.
-        /// This column layout should only be used by continuation line.
-        /// 
+        /// This column layout should only be used by continuation line
         /// </summary>
         CobolReferenceFormatUnlimitedLength,
         /// <summary>


### PR DESCRIPTION
WI #2357 Virtual line used by continuation line preserve original column of the first line

Fix column of diagnostics on continued lines.
Introduce new ColumnLayout CobolReferenceFormatWithoutComment which is like CobolReferenceFormat but with unlimited line length. 
This column layout should only be used by continuation line.