### PR TITLE
WI #2600 Fix NullReferenceException in Workspace.CollectDataLayoutNodes

### DIFF
--- a/TypeCobol.LanguageServer/Workspace.cs
+++ b/TypeCobol.LanguageServer/Workspace.cs
@@ -1100,7 +1100,7 @@ namespace TypeCobol.LanguageServer
         private List<Tuple<int, DataDefinition, int>> CollectDataLayoutNodes(CompilationUnit compilationUnit)
         {
             var dataLayoutNodes = new List<Tuple<int, DataDefinition, int>>();
-            Node dataDivision = compilationUnit.TemporaryProgramClassDocumentSnapshot.Root.MainProgram.GetChildren<DataDivision>().FirstOrDefault();
+            Node dataDivision = compilationUnit?.TemporaryProgramClassDocumentSnapshot?.Root?.MainProgram?.GetChildren<DataDivision>()?.FirstOrDefault();
             if (dataDivision != null)
             {
                 // Consider data declared in the Working storage


### PR DESCRIPTION
Fixes #2600

To reproduce the crash in a Cobol program: remove the . after IDENTIFICATION DIVISION