### PR TITLE
WI #2632 Use correct default encoding for alphanumeric literals written using hex notation

### DIFF
--- a/TypeCobol.LanguageServer/Workspace.cs
+++ b/TypeCobol.LanguageServer/Workspace.cs
@@ -12,6 +12,7 @@ using TypeCobol.Logging;
 using TypeCobol.Tools;
 using System.Collections.Concurrent;
 using TypeCobol.Compiler.CodeElements;
+using TypeCobol.Compiler.File;
 using TypeCobol.Compiler.Nodes;
 #if EUROINFO_RULES
 using System.Text.RegularExpressions;
@@ -212,7 +213,7 @@ namespace TypeCobol.LanguageServer
             StopDocumentBackgroundCompilation(docContext);
             CompilationProject compilationProject = docContext.Project.Project;
             string fileName = Path.GetFileName(docContext.Uri.LocalPath);
-            ITextDocument initialTextDocumentLines = new ReadOnlyTextDocument(fileName, Configuration.Format.Encoding,
+            ITextDocument initialTextDocumentLines = new ReadOnlyTextDocument(fileName, IBMCodePages.DefaultEncodingForAlphanumericLiterals,
                 Configuration.Format.ColumnsLayout, docContext.IsCopy, sourceText);
             FileCompiler fileCompiler = null;
 

--- a/TypeCobol.Test/Parser/CodeElements/DISPLAY.CodeElements.txt
+++ b/TypeCobol.Test/Parser/CodeElements/DISPLAY.CodeElements.txt
@@ -93,7 +93,7 @@ Line 46[24,27] <27, Error, Syntax> - Syntax error : mismatched input 'Var1' expe
 - OutputDeviceName = SYSOUT
 - WithNoAdvancing
 
-[[DisplayStatement]] [12,18:display]<DISPLAY> --> [24,28+:X'40']<HexadecimalAlphanumericLiteral>(',Y,Y){@}
+[[DisplayStatement]] [12,18:display]<DISPLAY> --> [24,28+:X'40']<HexadecimalAlphanumericLiteral>(',Y,Y){ }
 - variables = X'40'
 
 [[DisplayStatement]] [12,18:display]<DISPLAY> --> [24,33:HIGH-VALUE]<HIGH_VALUE>

--- a/TypeCobol.Test/Parser/FileFormat/TestCobolFile.cs
+++ b/TypeCobol.Test/Parser/FileFormat/TestCobolFile.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using TypeCobol.Compiler;
 using TypeCobol.Compiler.File;
 using TypeCobol.Compiler.Text;
@@ -27,7 +24,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile("EbcdicRefFormat", out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormat.TXT", docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormat.TXT", IBMCodePages.DefaultEncodingForAlphanumericLiterals, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();
@@ -84,7 +81,7 @@ namespace TypeCobol.Test.Parser.FileFormat
                 try
                 {
                     // Load the CobolFile in a TextDocument;
-                    ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormatWithBadChars.TXT", docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
+                    ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("EbcdicRefFormatWithBadChars.TXT", IBMCodePages.DefaultEncodingForAlphanumericLiterals, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 }
                 catch(Exception e)
                 {
@@ -117,7 +114,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile("AsciiRefFormat", out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCOUT.cpy", docFormat.Encoding, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCOUT.cpy", IBMCodePages.DefaultEncodingForAlphanumericLiterals, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();
@@ -172,7 +169,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile("AsciiLinuxFormat.14", out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("AsciiLinuxFormat.14", docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("AsciiLinuxFormat.14", IBMCodePages.DefaultEncodingForAlphanumericLiterals, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();
@@ -227,7 +224,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile("AsciiFreeFormat", out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("AsciiFreeFormat.cpy", docFormat.Encoding, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("AsciiFreeFormat.cpy", IBMCodePages.DefaultEncodingForAlphanumericLiterals, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();
@@ -307,7 +304,7 @@ namespace TypeCobol.Test.Parser.FileFormat
             if (fileProvider.TryGetFile(filename, out cobolFile))
             {
                 // Load the CobolFile in a TextDocument
-                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument(filename, docFormat.Encoding, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
+                ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument(filename, IBMCodePages.DefaultEncodingForAlphanumericLiterals, docFormat.ColumnsLayout, false, cobolFile.ReadChars());
                 // Send all text lines in one batch to the test observer
                 textDocument.TextChanged += textSourceListener.OnTextChanged;
                 textDocument.StartSendingChangeEvents();

--- a/TypeCobol.Test/Parser/Scanner/ResultFiles/AlphanumericLiterals4-1140.txt
+++ b/TypeCobol.Test/Parser/Scanner/ResultFiles/AlphanumericLiterals4-1140.txt
@@ -1,0 +1,3 @@
+-- Line 1 --
+[1,9+:X'C085D0']<HexadecimalAlphanumericLiteral>(',Y,Y){{e}}
+

--- a/TypeCobol.Test/Parser/Scanner/ResultFiles/AlphanumericLiterals4-1147.txt
+++ b/TypeCobol.Test/Parser/Scanner/ResultFiles/AlphanumericLiterals4-1147.txt
@@ -1,0 +1,3 @@
+-- Line 1 --
+[1,9+:X'C085D0']<HexadecimalAlphanumericLiteral>(',Y,Y){éeè}
+

--- a/TypeCobol.Test/Parser/Scanner/ScannerUtils.cs
+++ b/TypeCobol.Test/Parser/Scanner/ScannerUtils.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Text;
+﻿using System.Text;
 using TypeCobol.Compiler.Concurrency;
 using TypeCobol.Compiler.Diagnostics;
 using TypeCobol.Compiler.Directives;
@@ -44,7 +42,7 @@ namespace TypeCobol.Test.Parser.Scanner
 
     internal static class ScannerUtils
     {
-        public static TextSourceInfo TextSourceInfo = new TextSourceInfo("test", IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147), ColumnsLayout.FreeTextFormat, false);//Assuming a program here, not a copy.
+        public static TextSourceInfo TextSourceInfo = new TextSourceInfo("test", IBMCodePages.DefaultEncodingForAlphanumericLiterals, ColumnsLayout.FreeTextFormat, false);//Assuming a program here, not a copy.
         public static TypeCobolOptions CompilerOptions = new TypeCobolOptions();
         public static List<RemarksDirective.TextNameVariation> CopyTextNameVariations = new List<RemarksDirective.TextNameVariation>();
 

--- a/TypeCobol.Test/Parser/Scanner/TestTokenTypes.cs
+++ b/TypeCobol.Test/Parser/Scanner/TestTokenTypes.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using TypeCobol.Compiler.Scanner;
+﻿using TypeCobol.Compiler.Scanner;
 
 namespace TypeCobol.Test.Parser.Scanner
 {
@@ -136,6 +135,15 @@ namespace TypeCobol.Test.Parser.Scanner
                 "X\"A396A3960\"",
                 "NX'74007500740075000'"
             };
+            result = ScannerUtils.ScanLines(testLines);
+            ScannerUtils.CheckWithResultFile(result, testName);
+
+#if EUROINFO_RULES
+            testName = "AlphanumericLiterals4-1147";
+#else
+            testName = "AlphanumericLiterals4-1140";
+#endif
+            testLines = new string[] { "X'C085D0'" }; // 'éeè' in EBCDIC 1147, '{e}' in EBCDIC 1140
             result = ScannerUtils.ScanLines(testLines);
             ScannerUtils.CheckWithResultFile(result, testName);
 

--- a/TypeCobol.Test/Parser/TestParserRobustness.cs
+++ b/TypeCobol.Test/Parser/TestParserRobustness.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using TypeCobol.Compiler;
+﻿using TypeCobol.Compiler;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.Diagnostics;
 using TypeCobol.Compiler.Directives;
+using TypeCobol.Compiler.File;
 using TypeCobol.Compiler.Text;
 
 namespace TypeCobol.Test.Compiler.Parser
@@ -22,7 +18,7 @@ namespace TypeCobol.Test.Compiler.Parser
         private static CodeElement[] ParseCodeElements(string cobolString, bool asPartOfACopy, out Diagnostic[] parserDiagnostics)
         {
             // Load text document from string
-            var textDocument = new ReadOnlyTextDocument("test string", Encoding.Default, ColumnsLayout.FreeTextFormat, asPartOfACopy, string.Empty);
+            var textDocument = new ReadOnlyTextDocument("test string", IBMCodePages.DefaultEncodingForAlphanumericLiterals, ColumnsLayout.FreeTextFormat, asPartOfACopy, string.Empty);
             textDocument.LoadChars(cobolString);
 
             // Create a compilation project and a compiler for this document

--- a/TypeCobol.Test/Parser/Text/TestReadOnlyTextDocument.cs
+++ b/TypeCobol.Test/Parser/Text/TestReadOnlyTextDocument.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using TypeCobol.Compiler;
 using TypeCobol.Compiler.File;
 using TypeCobol.Compiler.Text;
@@ -49,7 +46,7 @@ namespace TypeCobol.Test.Parser.Text
 
         public static void Check_EmptyDocument()
         {
-            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("empty", Encoding.Default, ColumnsLayout.CobolReferenceFormat, false, String.Empty);
+            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("empty", IBMCodePages.DefaultEncodingForAlphanumericLiterals, ColumnsLayout.CobolReferenceFormat, false, String.Empty);
 
             Exception resultException = null;
             try
@@ -176,7 +173,7 @@ namespace TypeCobol.Test.Parser.Text
             }
                 
             // Load the CobolFile in a TextDocument
-            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCOUT.cpy", docFormat.Encoding, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
+            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCOUT.cpy", IBMCodePages.DefaultEncodingForAlphanumericLiterals, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
             
             if(textDocument.CharAt(0) != '0')
             {
@@ -269,7 +266,7 @@ namespace TypeCobol.Test.Parser.Text
             }
 
             // Load the CobolFile in a TextDocument
-            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCINP free format.cpy", docFormat.Encoding, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
+            ReadOnlyTextDocument textDocument = new ReadOnlyTextDocument("MSVCINP free format.cpy", IBMCodePages.DefaultEncodingForAlphanumericLiterals, docFormat.ColumnsLayout, true, cobolFile.ReadChars());
 
             if (textDocument.CharAt(0) != '/')
             {

--- a/TypeCobol.Test/Utils/ParserUtils.cs
+++ b/TypeCobol.Test/Utils/ParserUtils.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using Antlr4.Runtime;
 using TypeCobol.Compiler;
 using TypeCobol.Compiler.AntlrUtils;
@@ -11,6 +7,7 @@ using TypeCobol.Compiler.CodeModel;
 using TypeCobol.Compiler.CupCommon;
 using TypeCobol.Compiler.Diagnostics;
 using TypeCobol.Compiler.Directives;
+using TypeCobol.Compiler.File;
 using TypeCobol.Compiler.Nodes;
 using TypeCobol.Compiler.Parser;
 using TypeCobol.Compiler.Text;
@@ -60,7 +57,7 @@ namespace TypeCobol.Test.Utils
         public static CompilationUnit ParseCobolString(string cobolString, bool asPartOfACopy)
         {
             //Prepare
-            var textDocument = new ReadOnlyTextDocument("Empty doc", Encoding.Default, ColumnsLayout.FreeTextFormat, asPartOfACopy, string.Empty);
+            var textDocument = new ReadOnlyTextDocument("Empty doc", IBMCodePages.DefaultEncodingForAlphanumericLiterals, ColumnsLayout.FreeTextFormat, asPartOfACopy, string.Empty);
             textDocument.LoadChars(cobolString);
 
             var typeCobolOptions = new TypeCobolOptions();

--- a/TypeCobol/Compiler/File/IBMCodePages.cs
+++ b/TypeCobol/Compiler/File/IBMCodePages.cs
@@ -8,6 +8,18 @@ namespace TypeCobol.Compiler.File
     public static class IBMCodePages
     {
         /// <summary>
+        /// • The default encoding of literals in the source program
+        /// • The default encoding for data items described with USAGE DISPLAY or DISPLAY-1
+        /// • The default encoding for XML parsing and XML generation
+        ///
+        /// The encoding of national and UTF-8 data is not affected by the CODEPAGE compiler option. The encoding
+        /// for national literals and data items described with usage NATIONAL is UTF-16BE (big endian), CCSID
+        /// 1200. A reference to UTF-16 in this document is a reference to UTF-16BE. The encoding for UTF-8 literals
+        /// and data items described with usage UTF-8 is UTF-8, CCSID 1208.
+        /// </summary>
+        public static readonly Encoding DefaultEncodingForAlphanumericLiterals;
+
+        /// <summary>
         /// Gets the .Net Encoding equivalent to an IBM Coded Character Set ID
         /// (or throws a NotSupportedException)
         /// </summary>
@@ -186,6 +198,13 @@ namespace TypeCobol.Compiler.File
             {
                 IBMCCSIDFromDotNetCodePage.Add(codePageEquivalence.MS_CodePage, codePageEquivalence);
             }
+
+#if EUROINFO_RULES
+            const int defaultCodePage = 1147; //IBM EBCDIC (France-Euro)
+#else
+            const int defaultCodePage = 1140; //IBM EBCDIC (EU-Canada-Euro)
+#endif
+            DefaultEncodingForAlphanumericLiterals = GetDotNetEncodingFromIBMCCSID(defaultCodePage);
         }
 
         private class CodePageEquivalence

--- a/TypeCobol/Compiler/FileCompiler.cs
+++ b/TypeCobol/Compiler/FileCompiler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using JetBrains.Annotations;
 using TypeCobol.Compiler.CodeModel;
 using TypeCobol.Compiler.Directives;
@@ -165,7 +164,7 @@ namespace TypeCobol.Compiler
             {
                 // 2.a Load it in a new text document in memory
                 Debug.Assert(sourceFile != null);
-                TextDocument = new ReadOnlyTextDocument(sourceFile.Name, sourceFile.Encoding, fileInfo.Item3, fileInfo.Item4, sourceFile.ReadChars());
+                TextDocument = new ReadOnlyTextDocument(sourceFile.Name, IBMCodePages.DefaultEncodingForAlphanumericLiterals, fileInfo.Item3, fileInfo.Item4, sourceFile.ReadChars());
             }
             else
             {

--- a/TypeCobol/Compiler/Text/CobolTextLine.cs
+++ b/TypeCobol/Compiler/Text/CobolTextLine.cs
@@ -193,7 +193,7 @@ namespace TypeCobol.Compiler.Text
                 }
             }
             TokensLine tempTokensLine = TokensLine.CreateVirtualLineForInsertedToken(0, line, layout);
-            tempTokensLine.InitializeScanState(new MultilineScanState(IBMCodePages.GetDotNetEncodingFromIBMCCSID(1147)));
+            tempTokensLine.InitializeScanState(new MultilineScanState(IBMCodePages.DefaultEncodingForAlphanumericLiterals));
 
             Scanner.Scanner scanner = new Scanner.Scanner(line, 0, line.Length - 1, tempTokensLine, scannerOptions, false);
             Token? t;


### PR DESCRIPTION
For #2632 but does not fix it fully yet as we still need a way for the client to override the default value, if need be.