### PR TITLE
2647 adjust filler may insert filler at bad location

### DIFF
--- a/TypeCobol.LanguageServer.Test/LSRTest.cs
+++ b/TypeCobol.LanguageServer.Test/LSRTest.cs
@@ -565,6 +565,7 @@ namespace TypeCobol.LanguageServer.Test
             LSRTestHelper.Test("ExecuteCommandRefactorAdjustFillers", LsrTestingOptions.NoLsrTesting);
             LSRTestHelper.Test("ExecuteCommandRefactorAdjustFillers_WithCopy", LsrTestingOptions.NoLsrTesting, copyFolder: "CopyFolder");
             LSRTestHelper.Test("ExecuteCommandRefactorAdjustFillers_BadEdits_1", LsrTestingOptions.NoLsrTesting);
+            LSRTestHelper.Test("ExecuteCommandRefactorAdjustFillers_BadLocation", LsrTestingOptions.NoLsrTesting);
         }
     }
 }

--- a/TypeCobol.LanguageServer.Test/LSRTests/ExecuteCommandRefactorAdjustFillers_BadLocation/input/ExecuteCommandRefactorAdjustFillers_BadLocation.tlsp
+++ b/TypeCobol.LanguageServer.Test/LSRTests/ExecuteCommandRefactorAdjustFillers_BadLocation/input/ExecuteCommandRefactorAdjustFillers_BadLocation.tlsp
@@ -1,0 +1,43 @@
+{
+  "name": "ExecuteCommandRefactorAdjustFillers_BadLocation.tlsp",
+  "session": "C:\\Users\\GDLRUSER\\AppData\\Roaming\\TypeCobol.LanguageServerRobot\\Repository\\Session2023_09_07_10_40_16_316\\TestSuite_2023_09_07_10_40_16_316.slsp",
+  "user": "GDLRUSER",
+  "date": "2023/09/07 10:40:16 340",
+  "uri": "file:///C:/Users/GDLRUSER/Documents/TCOB/ExecuteCommandRefactorAdjustFillers_BadLocation.tlsp",
+  "initialize": "{\"jsonrpc\":\"2.0\",\"id\":\"0\",\"method\":\"initialize\",\"params\":{\"processId\":-1,\"rootPath\":\"C:\\\\Users\\\\GDLRUSER\\\\Documents\\\\RepoGit\\\\TCOB\\\\Parser\\\\bin\\\\LS\\\\EI_Debug\",\"rootUri\":\"file:/C:/Users/GDLRUSER/Documents/RepoGit/TCOB/Parser/bin/LS/EI_Debug/\",\"capabilities\":{\"workspace\":{\"applyEdit\":true,\"didChangeConfiguration\":{\"dynamicRegistration\":true},\"didChangeWatchedFiles\":{\"dynamicRegistration\":false},\"symbol\":{\"dynamicRegistration\":true},\"executeCommand\":{\"dynamicRegistration\":true}},\"textDocument\":{\"synchronization\":{\"willSave\":true,\"willSaveWaitUntil\":true,\"didSave\":true,\"dynamicRegistration\":true},\"completion\":{\"completionItem\":{\"snippetSupport\":true},\"dynamicRegistration\":true},\"hover\":{\"dynamicRegistration\":true},\"definition\":{\"dynamicRegistration\":true}}},\"trace\":\"off\"}}",
+  "initialize_result": "{\"jsonrpc\":\"2.0\",\"id\":\"0\",\"result\":{\"capabilities\":{\"experimental\":[{\"Item1\":\"version\",\"Item2\":\"0.0.0-local\"}],\"textDocumentSync\":2,\"hoverProvider\":true,\"completionProvider\":{\"resolveProvider\":false,\"triggerCharacters\":[\"::\"]},\"signatureHelpProvider\":{\"triggerCharacters\":[]},\"definitionProvider\":true,\"referencesProvider\":false,\"documentHighlightProvider\":false,\"documentSymbolProvider\":false,\"workspaceSymbolProvider\":false,\"codeActionProvider\":false,\"documentFormattingProvider\":false,\"documentRangeFormattingProvider\":false,\"renameProvider\":false}}}",
+  "did_change_configuation": "{\"jsonrpc\":\"2.0\",\"method\":\"workspace/didChangeConfiguration\",\"params\":{\"settings\":[\"C:\\\\Users\\\\GDLRUSER\\\\Documents\\\\RepoGit\\\\TCOB\\\\Parser\\\\bin\\\\LS\\\\EI_Debug\\\\TypeCobol.CLI.exe\",\"-e\",\"rdz\",\"{-c}\",\"--autoremarks\",\"-cob\",\"-dol\",\"-c\",\"C:\\\\Users\\\\GDLRUSER\\\\AppData\\\\Local\\\\Euro-Information\\\\TCOB\\\\CobolEditorEI\\\\Copys\\\\Test\",\"-c\",\"C:\\\\Users\\\\GDLRUSER\\\\AppData\\\\Local\\\\Euro-Information\\\\TCOB\\\\CobolEditorEI\\\\Copys\\\\Test_suffixedCPY\",\"-c\",\"C:\\\\Users\\\\GDLRUSER\\\\AppData\\\\Local\\\\Euro-Information\\\\TCOB\\\\CobolEditorEI\\\\Copys\\\\UATL\",\"-c\",\"C:\\\\Users\\\\GDLRUSER\\\\AppData\\\\Local\\\\Euro-Information\\\\TCOB\\\\CobolEditorEI\\\\Copys\\\\UATL_suffixedCPY\",\"-c\",\"C:\\\\Users\\\\GDLRUSER\\\\AppData\\\\Local\\\\Euro-Information\\\\TCOB\\\\CobolEditorEI\\\\Copys\\\\UAT\",\"-c\",\"C:\\\\Users\\\\GDLRUSER\\\\AppData\\\\Local\\\\Euro-Information\\\\TCOB\\\\CobolEditorEI\\\\Copys\\\\UAT_suffixedCPY\",\"-c\",\"C:\\\\Users\\\\GDLRUSER\\\\AppData\\\\Local\\\\Euro-Information\\\\TCOB\\\\CobolEditorEI\\\\Copys\\\\Production\",\"-c\",\"C:\\\\Users\\\\GDLRUSER\\\\AppData\\\\Local\\\\Euro-Information\\\\TCOB\\\\CobolEditorEI\\\\Copys\\\\Production_suffixedCPY\",\"-dcsm\"]}}",
+  "didOpen": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didOpen\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/GDLRUSER/workspaces/runtime-CobolEditorEI/RemoteSystemsTempFiles/FttRemoteTempFiles/nitcpip.e-i.net/ZZ/ZZ.DY530.ZGEN.SOURCE.TST2.PERM/TCOZADJ1.cbl\",\"languageId\":\"__lsp4j_Cobol\",\"version\":0,\"text\":\"       IDENTIFICATION DIVISION.\\r\\n       PROGRAM-ID. TCOZADJ1.\\r\\n       DATA DIVISION.\\r\\n       WORKING-STORAGE SECTION.\\r\\n       01 group0.\\r\\n          05 target-zone PIC X(1000).\\r\\n          05 redef1 REDEFINES target-zone.\\r\\n             10 group1.\\r\\n                15 group11.\\r\\n                   20 group111.\\r\\n                      25 var1 PIC X(500).\\r\\n      * Insert here a FILLER with size 500\\r\\n          05 redef2 REDEFINES target-zone.\\r\\n             10 group2.\\r\\n                15 group22.\\r\\n                   20 group222.\\r\\n                      25 var2 PIC X(25) OCCURS 10 INDEXED BY idx2.\\r\\n      * Insert here a FILLER with size 750\\r\\n          05 redef3 REDEFINES target-zone PIC X OCCURS 100 INDEXED idx3.\\r\\n      * No crash\\r\\n\\r\\n       PROCEDURE DIVISION.\\r\\n            GOBACK\\r\\n            .\\r\\n       END PROGRAM TCOZADJ1.\"}}}",
+  "messages": [
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didSave\",\"params\":{\"textDocument\":{\"version\":0,\"uri\":\"file:/C:/Users/GDLRUSER/workspaces/runtime-CobolEditorEI/RemoteSystemsTempFiles/FttRemoteTempFiles/nitcpip.e-i.net/ZZ/ZZ.DY530.ZGEN.SOURCE.TST2.PERM/TCOZADJ1.cbl\"},\"text\":\"       IDENTIFICATION DIVISION.\\r\\n       PROGRAM-ID. TCOZADJ1.\\r\\n       DATA DIVISION.\\r\\n       WORKING-STORAGE SECTION.\\r\\n       01 group0.\\r\\n          05 target-zone PIC X(1000).\\r\\n          05 redef1 REDEFINES target-zone.\\r\\n             10 group1.\\r\\n                15 group11.\\r\\n                   20 group111.\\r\\n                      25 var1 PIC X(500).\\r\\n      * Insert here a FILLER with size 500\\r\\n          05 redef2 REDEFINES target-zone.\\r\\n             10 group2.\\r\\n                15 group22.\\r\\n                   20 group222.\\r\\n                      25 var2 PIC X(25) OCCURS 10 INDEXED BY idx2.\\r\\n      * Insert here a FILLER with size 750\\r\\n          05 redef3 REDEFINES target-zone PIC X OCCURS 100 INDEXED idx3.\\r\\n      * No crash\\r\\n\\r\\n       PROCEDURE DIVISION.\\r\\n            GOBACK\\r\\n            .\\r\\n       END PROGRAM TCOZADJ1.\"}}"
+    },
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:/C:/Users/GDLRUSER/workspaces/runtime-CobolEditorEI/RemoteSystemsTempFiles/FttRemoteTempFiles/nitcpip.e-i.net/ZZ/ZZ.DY530.ZGEN.SOURCE.TST2.PERM/TCOZADJ1.cbl\",\"diagnostics\":[]}}"
+    },
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:/C:/Users/GDLRUSER/workspaces/runtime-CobolEditorEI/RemoteSystemsTempFiles/FttRemoteTempFiles/nitcpip.e-i.net/ZZ/ZZ.DY530.ZGEN.SOURCE.TST2.PERM/TCOZADJ1.cbl\",\"diagnostics\":[]}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"workspace/executeCommand\",\"params\":{\"command\":\"refactor/adjustFillers\",\"arguments\":[{\"uri\":\"file:/C:/Users/GDLRUSER/workspaces/runtime-CobolEditorEI/RemoteSystemsTempFiles/FttRemoteTempFiles/nitcpip.e-i.net/ZZ/ZZ.DY530.ZGEN.SOURCE.TST2.PERM/TCOZADJ1.cbl\"}]}}"
+    },
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{}}"
+    },
+    {
+      "category": 1,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"workspace/applyEdit\",\"params\":{\"label\":\"Adjust FILLERs: 2 FILLER(s) modified\",\"edit\":{\"changes\":{\"file:/C:/Users/GDLRUSER/workspaces/runtime-CobolEditorEI/RemoteSystemsTempFiles/FttRemoteTempFiles/nitcpip.e-i.net/ZZ/ZZ.DY530.ZGEN.SOURCE.TST2.PERM/TCOZADJ1.cbl\":[{\"range\":{\"start\":{\"line\":11,\"character\":41},\"end\":{\"line\":11,\"character\":41}},\"newText\":\"\\r\\n             10 FILLER PIC X(500).\"},{\"range\":{\"start\":{\"line\":17,\"character\":66},\"end\":{\"line\":17,\"character\":66}},\"newText\":\"\\r\\n             10 FILLER PIC X(750).\"}]}}}}"
+    },
+    {
+      "category": 0,
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{\"applied\":true}}"
+    }
+  ],
+  "didClose": "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didClose\",\"params\":{\"textDocument\":{\"uri\":\"file:/C:/Users/GDLRUSER/workspaces/runtime-CobolEditorEI/RemoteSystemsTempFiles/FttRemoteTempFiles/nitcpip.e-i.net/ZZ/ZZ.DY530.ZGEN.SOURCE.TST2.PERM/TCOZADJ1.cbl\"}}}",
+  "IsValid": true
+}

--- a/TypeCobol.LanguageServer.Test/LSRTests/ExecuteCommandRefactorAdjustFillers_BadLocation/output_expected/ExecuteCommandRefactorAdjustFillers_BadLocation.rlsp
+++ b/TypeCobol.LanguageServer.Test/LSRTests/ExecuteCommandRefactorAdjustFillers_BadLocation/output_expected/ExecuteCommandRefactorAdjustFillers_BadLocation.rlsp
@@ -1,0 +1,6 @@
+{
+  "success": true,
+  "diff_index": [
+    -1
+  ]
+}

--- a/TypeCobol.LanguageServer/Commands/AdjustFillers.cs
+++ b/TypeCobol.LanguageServer/Commands/AdjustFillers.cs
@@ -18,7 +18,7 @@ namespace TypeCobol.LanguageServer.Commands
                     return true;
                 }
 
-                if (HasNoChildrenExcludingIndex(dataRedefines))
+                if (!dataRedefines.HasChildrenExcludingIndex())
                 {
                     // Inline REDEFINES, nothing to do
                     return true;
@@ -93,7 +93,7 @@ namespace TypeCobol.LanguageServer.Commands
                         string newText = $"{Environment.NewLine}{new string(' ', indent)}{level} FILLER PIC X({adjustedFillerSize}).";
 
                         // Look for the last node (last child itself or the last node of its descendants for a group)
-                        var lastNode = GetLastDescendant(lastChild);
+                        var lastNode = lastChild.GetLastNode();
 
                         // Insert at the end of last node line
                         Debug.Assert(lastNode.CodeElement != null);
@@ -109,17 +109,6 @@ namespace TypeCobol.LanguageServer.Commands
                     {
                         textEdits.Add(textEdit);
                     }
-
-                    DataDefinition GetLastDescendant(DataDefinition dataDefinition)
-                    {
-                        if (HasNoChildrenExcludingIndex(dataDefinition))
-                        {
-                            return dataDefinition;
-                        }
-
-                        Debug.Assert(dataDefinition.Children[^1] is DataDefinition);
-                        return GetLastDescendant((DataDefinition)dataDefinition.Children[^1]);
-                    }
                 }
 
                 void Remove()
@@ -129,11 +118,6 @@ namespace TypeCobol.LanguageServer.Commands
                     var end = new Position(lastChild.CodeElement.LineEnd, lastChild.CodeElement.StopIndex + 1);
                     var textEdit = new TextEdit(new VsCodeProtocol.Range() { start = start, end = end }, string.Empty);
                     textEdits.Add(textEdit);
-                }
-
-                bool HasNoChildrenExcludingIndex(Node node)
-                {
-                    return node.ChildrenCount == node.Children.OfType<IndexDefinition>().Count();
                 }
             }
         }

--- a/TypeCobol/Compiler/Nodes/Node.cs
+++ b/TypeCobol/Compiler/Nodes/Node.cs
@@ -941,6 +941,26 @@ namespace TypeCobol.Compiler.Nodes {
 
             return Parent.GetNextNode();
         }
+
+        /// <summary>
+        /// Return the last node (by ignoring indexes) under the current node in document order.
+        /// The result is the current node itself if it has no children.
+        /// </summary>
+        /// <returns>Non-null instance of Node.</returns>
+        public Node GetLastNode()
+        {
+            return HasChildrenExcludingIndex() ? Children[^1].GetLastNode() : this;
+        }
+
+        /// <summary>
+        /// Indicate whether this node has 'real' children (from a semantic point of view) by excluding indexes.
+        /// Note: indexes are created as children nodes for technical reasons (especially Symbol Table management).
+        /// </summary>
+        /// <returns></returns>
+        public bool HasChildrenExcludingIndex()
+        {
+            return Children.Any(child => child is not IndexDefinition);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #2647

Also ignore INDEX among children to avoid a crash when retrieving the CodeElement (which is null for an Index node)