### PR TITLE
WI #2599 Fix SourceText property for missing tokens

### DIFF
--- a/Codegen/test/CodegenTestUtils.cs
+++ b/Codegen/test/CodegenTestUtils.cs
@@ -74,14 +74,14 @@ namespace TypeCobol.Codegen {
 
             // compare with expected result
             string expected = File.ReadAllText(Path.Combine(ROOT, OUTPUT, path), format.Encoding);
-            TypeCobol.Test.TestUtils.compareLines(path, writer.ToString(), expected, PlatformUtils.GetPathForProjectFile(Path.Combine(ROOT, OUTPUT, path), "Codegen\\test"));
+            TypeCobol.Test.TestUtils.CompareLines(path, writer.ToString(), expected, PlatformUtils.GetPathForProjectFile(Path.Combine(ROOT, OUTPUT, path), "Codegen\\test"));
 
             if (lmStream != null)
             {
                 //compare with expected line mapping
                 string lm = System.Text.ASCIIEncoding.Default.GetString(lmStream.ToArray());
                 string expectedLm = File.ReadAllText(Path.Combine(ROOT, OUTPUT, path + ML_SUFFIX), format.Encoding);
-                TypeCobol.Test.TestUtils.compareLines(path + ML_SUFFIX, lm, expectedLm, PlatformUtils.GetPathForProjectFile(Path.Combine(ROOT, OUTPUT, path + ML_SUFFIX), "Codegen\\test"));
+                TypeCobol.Test.TestUtils.CompareLines(path + ML_SUFFIX, lm, expectedLm, PlatformUtils.GetPathForProjectFile(Path.Combine(ROOT, OUTPUT, path + ML_SUFFIX), "Codegen\\test"));
             }
         }
 

--- a/TypeCobol.Analysis.Test/CfgDfaDominatorTests.cs
+++ b/TypeCobol.Analysis.Test/CfgDfaDominatorTests.cs
@@ -26,7 +26,7 @@ namespace TypeCobol.Analysis.Test
             // compare with expected result
             string result = writer.ToString();
             string expected = File.ReadAllText(expectedDomsFile);
-            TestUtils.compareLines(path, result, expected, expectedDomsFile);
+            TestUtils.CompareLines(path, result, expected, expectedDomsFile);
         }
 
         private static void HanoiPrgCfgExtendedImmediateDominator(bool duplicate)
@@ -43,7 +43,7 @@ namespace TypeCobol.Analysis.Test
             // compare with expected result
             string result = writer.ToString();
             string expected = File.ReadAllText(expectedDomsFile);
-            TestUtils.compareLines(path, result, expected, expectedDomsFile);
+            TestUtils.CompareLines(path, result, expected, expectedDomsFile);
         }
 
         [TestMethod]

--- a/TypeCobol.Analysis.Test/CfgTestUtils.cs
+++ b/TypeCobol.Analysis.Test/CfgTestUtils.cs
@@ -80,7 +80,7 @@ namespace TypeCobol.Analysis.Test
 
                 string result = writer.ToString();
                 string expected = File.ReadAllText(expectedLivenessFilePath);
-                TestUtils.compareLines(sourceFilePath, result, expected, expectedLivenessFilePath);
+                TestUtils.CompareLines(sourceFilePath, result, expected, expectedLivenessFilePath);
             }
 
             return dfaResults;
@@ -141,7 +141,7 @@ namespace TypeCobol.Analysis.Test
                     if (File.Exists(expectedDiagnosticsFilePath))
                     {
                         string expectedResult = File.ReadAllText(expectedDiagnosticsFilePath);
-                        TestUtils.compareLines(sourceFilePath, diagnosticsText, expectedResult, expectedDiagnosticsFilePath);
+                        TestUtils.CompareLines(sourceFilePath, diagnosticsText, expectedResult, expectedDiagnosticsFilePath);
                     }
                     else
                     {
@@ -216,7 +216,7 @@ namespace TypeCobol.Analysis.Test
             // compare with expected result
             string result = writer.ToString();
             string expected = File.ReadAllText(expectedDotFile);
-            TestUtils.compareLines(testPath, result, expected, expectedDotFile);
+            TestUtils.CompareLines(testPath, result, expected, expectedDotFile);
         }
 
         /// <summary>

--- a/TypeCobol.Analysis.Test/DfaCallPgmReport.cs
+++ b/TypeCobol.Analysis.Test/DfaCallPgmReport.cs
@@ -31,7 +31,7 @@ namespace TypeCobol.Analysis.Test
                 string result = sw.ToString();
                 string output = Path.Combine(CfgTestUtils.Report, "InBulkCallPgm.csv");
                 string expected = File.ReadAllText(output, DocumentFormat.RDZReferenceFormat.Encoding);
-                TypeCobol.Test.TestUtils.compareLines(path, result, expected, output);
+                TypeCobol.Test.TestUtils.CompareLines(path, result, expected, output);
             }
         }
 
@@ -51,7 +51,7 @@ namespace TypeCobol.Analysis.Test
                 string result = sw.ToString();
                 string output = Path.Combine(CfgTestUtils.Report, "InBulkCallPgm88Set.csv");
                 string expected = File.ReadAllText(output, DocumentFormat.RDZReferenceFormat.Encoding);
-                TypeCobol.Test.TestUtils.compareLines(path, result, expected, output);
+                TypeCobol.Test.TestUtils.CompareLines(path, result, expected, output);
             }
         }
 
@@ -71,7 +71,7 @@ namespace TypeCobol.Analysis.Test
                 string result = sw.ToString();
                 string output = Path.Combine(CfgTestUtils.Report, "ProcCallPgm.csv");
                 string expected = File.ReadAllText(output, DocumentFormat.RDZReferenceFormat.Encoding);
-                TypeCobol.Test.TestUtils.compareLines(path, result, expected, output);
+                TypeCobol.Test.TestUtils.CompareLines(path, result, expected, output);
             }
         }
 

--- a/TypeCobol.Test/GrammarTest.cs
+++ b/TypeCobol.Test/GrammarTest.cs
@@ -240,7 +240,7 @@ namespace TypeCobol.Test {
             {
                 StreamReader expectedResultReader = new StreamReader(new FileStream(expectedResultFile, FileMode.Open));
                 StreamReader actualResultReader = new StreamReader(new FileStream(resultFile, FileMode.Open));
-                TestUtils.compareLines("GrammarTestCompareFiles", expectedResultReader.ReadToEnd(), actualResultReader.ReadToEnd(), expectedResultFile); //The test will fail if result files are different
+                TestUtils.CompareLines("GrammarTestCompareFiles", expectedResultReader.ReadToEnd(), actualResultReader.ReadToEnd(), expectedResultFile); //The test will fail if result files are different
 
                 expectedResultReader.Close();
                 actualResultReader.Close();

--- a/TypeCobol.Test/Misc/CopyTokenProperties.cpy
+++ b/TypeCobol.Test/Misc/CopyTokenProperties.cpy
@@ -1,0 +1,1 @@
+       01 var1-imported PIC X.

--- a/TypeCobol.Test/Misc/TestExpressions.cs
+++ b/TypeCobol.Test/Misc/TestExpressions.cs
@@ -195,7 +195,7 @@ namespace TypeCobol.Test.Misc
             var expectedPath = Path.ChangeExtension(Path.Combine("Misc", "Expressions-expected"), "txt");
             var expected = File.ReadAllText(expectedPath);
             // ensure the string and the file are the same 
-            TestUtils.compareLines("CheckExpressions", strToString.ToString(), expected, PlatformUtils.GetPathForProjectFile(expectedPath));
+            TestUtils.CompareLines("CheckExpressions", strToString.ToString(), expected, PlatformUtils.GetPathForProjectFile(expectedPath));
         }
 
         /// <summary>
@@ -264,7 +264,7 @@ namespace TypeCobol.Test.Misc
             var expectedPath = Path.ChangeExtension(Path.Combine("Misc", "ExpressionsTokens-expected"), "txt");
             var expected = File.ReadAllText(expectedPath);
             // ensure the string and the file are the same 
-            TestUtils.compareLines("CheckExpressionTokens", strToString.ToString(), expected, PlatformUtils.GetPathForProjectFile(expectedPath));
+            TestUtils.CompareLines("CheckExpressionTokens", strToString.ToString(), expected, PlatformUtils.GetPathForProjectFile(expectedPath));
         }
 
         private class TokenCollector : AbstractAstVisitor

--- a/TypeCobol.Test/Misc/TestTokenProperties.cs
+++ b/TypeCobol.Test/Misc/TestTokenProperties.cs
@@ -31,7 +31,7 @@ namespace TypeCobol.Test.Misc
             // Compare to expected
             var expectedPath = Path.Combine(folder, fileName) + $"-{propertyName}.txt";
             var expected = File.ReadAllText(expectedPath);
-            TestUtils.compareLines(testName, result.ToString(), expected, expectedPath);
+            TestUtils.CompareLines(testName, result.ToString(), expected, expectedPath);
         }
 
         /// <summary>

--- a/TypeCobol.Test/Misc/TestTokenProperties.cs
+++ b/TypeCobol.Test/Misc/TestTokenProperties.cs
@@ -1,0 +1,43 @@
+﻿using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TypeCobol.Compiler.Scanner;
+using TypeCobol.Test.Utils;
+
+namespace TypeCobol.Test.Misc
+{
+    /// <summary>
+    /// Supplementary tests on Token properties after they have been consumed by ANTLR.
+    /// </summary>
+    [TestClass]
+    public class TestTokenProperties
+    {
+        private static void TestTokenProperty(string propertyName, Func<Token, string> extractor, [CallerMemberName] string testName = null)
+        {
+            // Parse dedicated source file
+            var folder = Path.GetFullPath("Misc");
+            var fileName = "TokenProperties";
+            var compilationUnit = ParserUtils.ParseCobolFile(fileName, folder, execToStep: ExecutionStep.SemanticCrossCheck);
+
+            // Collect consumed tokens and read target property
+            var consumedTokens = compilationUnit.CodeElementsDocumentSnapshot.CodeElements.SelectMany(ce => ce.ConsumedTokens);
+            var result = new StringBuilder();
+            foreach (var consumedToken in consumedTokens)
+            {
+                result.AppendLine($"Class={consumedToken.GetType().Name}, TokenType={consumedToken.TokenType}");
+                result.AppendLine($"-{propertyName}={extractor(consumedToken)}");
+            }
+
+            // Compare to expected
+            var expectedPath = Path.Combine(folder, fileName) + $"-{propertyName}.txt";
+            var expected = File.ReadAllText(expectedPath);
+            TestUtils.compareLines(testName, result.ToString(), expected, expectedPath);
+        }
+
+        /// <summary>
+        /// Check SourceText property on various tokens
+        /// </summary>
+        [TestMethod]
+        public void TestSourceText() => TestTokenProperty(nameof(Token.SourceText), token => token.SourceText);
+    }
+}

--- a/TypeCobol.Test/Misc/TokenProperties-SourceText.txt
+++ b/TypeCobol.Test/Misc/TokenProperties-SourceText.txt
@@ -1,0 +1,134 @@
+Class=Token, TokenType=IDENTIFICATION
+-SourceText=IDENTIFICATION
+Class=Token, TokenType=DIVISION
+-SourceText=DIVISION
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=PROGRAM_ID
+-SourceText=PROGRAM-ID
+Class=Token, TokenType=PeriodSeparator
+-SourceText=. 
+Class=Token, TokenType=UserDefinedWord
+-SourceText=TokenProperties
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=DATA
+-SourceText=DATA
+Class=Token, TokenType=DIVISION
+-SourceText=DIVISION
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=WORKING_STORAGE
+-SourceText=WORKING-STORAGE
+Class=Token, TokenType=SECTION
+-SourceText=SECTION
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=ImportedToken, TokenType=LevelNumber
+-SourceText=01
+Class=ImportedToken, TokenType=UserDefinedWord
+-SourceText=var1-imported
+Class=ImportedToken, TokenType=PIC
+-SourceText=PIC
+Class=ImportedToken, TokenType=PictureCharacterString
+-SourceText=X
+Class=ImportedToken, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=LevelNumber
+-SourceText=01
+Class=Token, TokenType=UserDefinedWord
+-SourceText=var1
+Class=Token, TokenType=PIC
+-SourceText=PIC
+Class=Token, TokenType=PictureCharacterString
+-SourceText=X
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=LevelNumber
+-SourceText=01
+Class=ReplacedPartialCobolWord, TokenType=UserDefinedWord
+-SourceText=var1-:SUFFIX:
+Class=Token, TokenType=PIC
+-SourceText=PIC
+Class=Token, TokenType=PictureCharacterString
+-SourceText=X
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=LevelNumber
+-SourceText=01
+Class=Token, TokenType=UserDefinedWord
+-SourceText=exempleTab
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=LevelNumber
+-SourceText=05
+Class=Token, TokenType=UserDefinedWord
+-SourceText=item
+Class=Token, TokenType=PIC
+-SourceText=PIC
+Class=Token, TokenType=PictureCharacterString
+-SourceText=X
+Class=Token, TokenType=OCCURS
+-SourceText=OCCURS
+Class=ReplacedToken, TokenType=IntegerLiteral
+-SourceText=TabSize
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=LevelNumber
+-SourceText=01
+Class=ReplacedTokenGroup, TokenType=UserDefinedWord
+-SourceText=to create a ReplacedTokenGroup
+Class=Token, TokenType=PIC
+-SourceText=PIC
+Class=Token, TokenType=PictureCharacterString
+-SourceText=X
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=LevelNumber
+-SourceText=01
+Class=Token, TokenType=UserDefinedWord
+-SourceText=var1-continued
+Class=Token, TokenType=PIC
+-SourceText=PIC
+Class=Token, TokenType=PictureCharacterString
+-SourceText=X(1000)
+Class=Token, TokenType=VALUE
+-SourceText=VALUE
+Class=ContinuationToken, TokenType=AlphanumericLiteral
+-SourceText='This value is continued on t
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=PROCEDURE
+-SourceText=PROCEDURE
+Class=Token, TokenType=DIVISION
+-SourceText=DIVISION
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=GOBACK
+-SourceText=GOBACK
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=SectionParagraphName
+-SourceText=missingToken
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=INITIALIZE
+-SourceText=INITIALIZE
+Class=Token, TokenType=UserDefinedWord
+-SourceText=var1
+Class=Token, TokenType=WITH
+-SourceText=WITH
+Class=MissingToken, TokenType=FILLER
+-SourceText=<missing FILLER>
+Class=Token, TokenType=DEFAULT
+-SourceText=DEFAULT
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.
+Class=Token, TokenType=END
+-SourceText=END
+Class=Token, TokenType=PROGRAM
+-SourceText=PROGRAM
+Class=Token, TokenType=UserDefinedWord
+-SourceText=TokenProperties
+Class=Token, TokenType=PeriodSeparator
+-SourceText=.

--- a/TypeCobol.Test/Misc/TokenProperties.cbl
+++ b/TypeCobol.Test/Misc/TokenProperties.cbl
@@ -1,0 +1,28 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TokenProperties.
+      * Use this sample to test various tokens and their properties
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * For imported tokens
+       COPY CopyTokenProperties.
+       01 var1 PIC X.
+      * For replaced tokens
+       REPLACE ==:SUFFIX:== BY ==replaced==.
+       01 var1-:SUFFIX: PIC X.
+       REPLACE ==TabSize== BY ==80==.
+       01 exempleTab.
+          05 item PIC X OCCURS TabSize.
+       REPLACE ==to create a ReplacedTokenGroup==
+            BY ==var1-group-replaced==.
+       01 to create a ReplacedTokenGroup PIC X.
+      * For continuation token
+       01 var1-continued PIC X(1000) VALUE 'This value is continued on t
+      -    'he next line'.
+       PROCEDURE DIVISION.
+           GOBACK
+           .
+       missingToken.
+      * ANTLR will create a missing token for this statement
+           INITIALIZE var1 WITH DEFAULT
+           .
+       END PROGRAM TokenProperties.

--- a/TypeCobol.Test/Parser/Preprocessor/PreprocessorUtils.cs
+++ b/TypeCobol.Test/Parser/Preprocessor/PreprocessorUtils.cs
@@ -64,7 +64,7 @@ namespace TypeCobol.Test.Parser.Preprocessor
         {
             string path = Path.Combine(Root, "DirectiveResultFiles", testName + ".txt");
             string expected = File.ReadAllText(PlatformUtils.GetPathForProjectFile(path));
-            TestUtils.compareLines(path, result, expected, PlatformUtils.GetPathForProjectFile(path));
+            TestUtils.CompareLines(path, result, expected, PlatformUtils.GetPathForProjectFile(path));
         }
 
         private static string ProcessTokensDocument(ProcessedTokensDocument processedDoc)
@@ -126,7 +126,7 @@ namespace TypeCobol.Test.Parser.Preprocessor
         {
             string path = Path.Combine(Root, "CopyResultFiles", testName + ".txt");
             string expected = File.ReadAllText(PlatformUtils.GetPathForProjectFile(path));
-            TestUtils.compareLines(path, result, expected, PlatformUtils.GetPathForProjectFile(path));
+            TestUtils.CompareLines(path, result, expected, PlatformUtils.GetPathForProjectFile(path));
         }
 
         public static string ProcessReplaceDirectives(CompilationProject project, string name)
@@ -138,7 +138,7 @@ namespace TypeCobol.Test.Parser.Preprocessor
         {
             string path = Path.Combine(Root, "ReplaceResultFiles", testName + ".txt");
             string expected = File.ReadAllText(PlatformUtils.GetPathForProjectFile(path));
-            TestUtils.compareLines(path, result, expected, PlatformUtils.GetPathForProjectFile(path));
+            TestUtils.CompareLines(path, result, expected, PlatformUtils.GetPathForProjectFile(path));
         }
     }
 }

--- a/TypeCobol.Test/Parser/Scanner/ScannerUtils.cs
+++ b/TypeCobol.Test/Parser/Scanner/ScannerUtils.cs
@@ -114,7 +114,7 @@ namespace TypeCobol.Test.Parser.Scanner
             {
                 expectedResult = reader.ReadToEnd();
             }
-            TestUtils.compareLines(testName, result, expectedResult, PlatformUtils.GetPathForProjectFile(@"Parser\Scanner\ResultFiles\" + testName + ".txt"));
+            TestUtils.CompareLines(testName, result, expectedResult, PlatformUtils.GetPathForProjectFile(@"Parser\Scanner\ResultFiles\" + testName + ".txt"));
         }
 
         public static string ScanSqlLines(string[] lines, bool decimalPointIsComma)

--- a/TypeCobol.Test/Report/ReportTestHelper.cs
+++ b/TypeCobol.Test/Report/ReportTestHelper.cs
@@ -65,7 +65,7 @@ namespace TypeCobol.Test.Report
                         // compare with expected result
                         string result = sw.ToString();
                         string expected = File.ReadAllText(output, format.Encoding);
-                        TestUtils.compareLines(input, result, expected, PlatformUtils.GetPathForProjectFile(output));
+                        TestUtils.CompareLines(input, result, expected, PlatformUtils.GetPathForProjectFile(output));
                         return ReturnCode.Success;
                     }
                 }

--- a/TypeCobol.Test/TestCollection.cs
+++ b/TypeCobol.Test/TestCollection.cs
@@ -202,7 +202,7 @@ namespace TypeCobol.Test {
         [TestProperty("Time", "fast")]
         public void TCBLAutoReplaceSecurityTest()
         {
-            TestUtils.compareLines(string.Empty, string.Empty, string.Empty, string.Empty);
+            TestUtils.CompareLines(string.Empty, string.Empty, string.Empty, string.Empty);
         }
 
 

--- a/TypeCobol.Test/TestUtils.cs
+++ b/TypeCobol.Test/TestUtils.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using System.Text.RegularExpressions;
 using Antlr4.Runtime.Misc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -26,7 +22,7 @@ namespace TypeCobol.Test
         /// <param name="expectedResult"></param>
         /// <param name="expectedResultPath"></param>
         /// <returns></returns>
-        public static void compareLines(string testName, string result, string expectedResult, string expectedResultPath)
+        public static void CompareLines(string testName, string result, string expectedResult, string expectedResultPath)
         {
             StringBuilder errors = new StringBuilder();
 
@@ -37,7 +33,7 @@ namespace TypeCobol.Test
                 expectedResultPath == string.Empty)
             {
                 if (autoReplace)
-                    Assert.Fail("Set AutoReplace to false in TestUtils.compareLines()\n\n");
+                    Assert.Fail("Set AutoReplace to false in TestUtils.CompareLines()\n\n");
             }
 
             result = Regex.Replace(result, "(?<!\r)\n", "\r\n");
@@ -66,7 +62,7 @@ namespace TypeCobol.Test
                 {
                     errors.Append("result != expectedResult  In test:" + testName)
                         .AppendLine(" at line" + (linefaults.Count > 1 ? "s" : "") + ": " + string.Join(",", linefaults));
-                    errors.AppendLine("See TestUtils.cs compareLines method to autoreplace ExpectedResult");
+                    errors.AppendLine("See TestUtils.cs CompareLines method to autoreplace ExpectedResult");
                     errors.Append("=== RESULT ==========\n" + result + "====================");
                     throw new Exception(errors.ToString());
                 }

--- a/TypeCobol.Test/Utils/ParserUtils.cs
+++ b/TypeCobol.Test/Utils/ParserUtils.cs
@@ -348,7 +348,7 @@ namespace TypeCobol.Test.Utils
         {
             string expectedResult = reader.ReadToEnd();
             reader.Close();
-            TestUtils.compareLines(testName, result, expectedResult, expectedResultPath);
+            TestUtils.CompareLines(testName, result, expectedResult, expectedResultPath);
         }
 
 

--- a/TypeCobol/Compiler/AntlrUtils/TokensLinesTokenSource.cs
+++ b/TypeCobol/Compiler/AntlrUtils/TokensLinesTokenSource.cs
@@ -157,7 +157,7 @@ namespace TypeCobol.Compiler.AntlrUtils
         /// <summary>
         /// Returns missing token InformationText
         /// </summary>
-        public override string Text
+        public override string SourceText
         {
             get
             {


### PR DESCRIPTION
Fixes #2599.

This is a simple fix for the index out of range error happening when evaluating the `SourceText` property.
As `MissingToken` instances don't refer to actual tokens found in text lines, the `Substring` operation to compute source text will always fail for them.