### PR TITLE
WI #2664 Ignore change notifications for closed projects

### DIFF
--- a/TypeCobol.LanguageServer/Workspace.cs
+++ b/TypeCobol.LanguageServer/Workspace.cs
@@ -788,7 +788,8 @@ namespace TypeCobol.LanguageServer
                 else if (!WorkspaceProjectStore.IsKnownProject(changedCopy.OwnerProject))
                 {
                     // Inconsistent notification from client, the target project is unknown
-                    LoggingSystem.LogMessage(LogLevel.Error, $"Copy to WorkspaceProject mismatch: project '{changedCopy.OwnerProject}' is unknown.");
+                    var contextData = new Dictionary<string, object>() { { "WorkspaceProjectId", changedCopy.OwnerProject } };
+                    LoggingSystem.LogMessage(LogLevel.Error, "Copy to WorkspaceProject mismatch: unknown project.", contextData);
                 }
                 // else this is a known project but already closed: ignore
             }

--- a/TypeCobol.LanguageServer/Workspace.cs
+++ b/TypeCobol.LanguageServer/Workspace.cs
@@ -785,11 +785,12 @@ namespace TypeCobol.LanguageServer
                     // Evict from target project cache only
                     evictions[workspaceProject.Project.CopyCache].Add(changedCopy.CopyName);
                 }
-                else
+                else if (!WorkspaceProjectStore.IsKnownProject(changedCopy.OwnerProject))
                 {
-                    // Inconsistent notification from client, the target project could not be found
-                    LoggingSystem.LogMessage(LogLevel.Warning, $"Copy to WorkspaceProject mismatch: could not find project '{changedCopy.OwnerProject}'.");
+                    // Inconsistent notification from client, the target project is unknown
+                    LoggingSystem.LogMessage(LogLevel.Error, $"Copy to WorkspaceProject mismatch: project '{changedCopy.OwnerProject}' is unknown.");
                 }
+                // else this is a known project but already closed: ignore
             }
 
             // Remove obsolete data from caches


### PR DESCRIPTION
Fixes #2664

- Keep names of all opened `WorkspaceProject` instances
- Remove useless `TryAdd` call when creating neww `WorkspaceProject`