### PR TITLE
WI #2670 Use telemetry/event to send server exceptions to client

### DIFF
--- a/TypeCobol.LanguageServer/TypeCobolServerHost.cs
+++ b/TypeCobol.LanguageServer/TypeCobolServerHost.cs
@@ -310,6 +310,10 @@ namespace TypeCobol.LanguageServer
                     httpServer.RedirectedOutpuStream = Process.StandardInput;
                 }
                 var jsonRPCServer = new JsonRPCServer(httpServer);
+
+                // Add custom logger to track server exceptions
+                LoggingSystem.RegisterLogger(new TypeCobolServerLogger(jsonRPCServer));
+
                 var typeCobolServer = new TypeCobolCustomLanguageServer(jsonRPCServer, MessagesActionQueue);
 
                 typeCobolServer.NoLogsMessageNotification = NoLogsMessageNotification;

--- a/TypeCobol.LanguageServer/TypeCobolServerLogger.cs
+++ b/TypeCobol.LanguageServer/TypeCobolServerLogger.cs
@@ -1,0 +1,38 @@
+﻿using TypeCobol.LanguageServer.JsonRPC;
+using TypeCobol.LanguageServer.VsCodeProtocol;
+using TypeCobol.LanguageServer.VsCodeProtocol.Telemetry_Notification;
+using TypeCobol.Logging;
+
+namespace TypeCobol.LanguageServer
+{
+    /// <summary>
+    /// Custom logger used to dispatch server exceptions as telemetry events to the client
+    /// </summary>
+    internal class TypeCobolServerLogger : ILogger
+    {
+        private readonly IRPCServer _rpcServer;
+
+        public TypeCobolServerLogger(IRPCServer rpcServer)
+        {
+            _rpcServer = rpcServer;
+        }
+
+        public void LogMessage(LogLevel level, string message, IDictionary<string, object> contextData)
+        {
+            // Do nothing
+        }
+
+        public void LogException(Exception exception, IDictionary<string, object> contextData)
+        {
+            // Send exception as telemetry/event, ignore context data as the event is supposed to be lightweight.
+            // Context data will still be sent through the other loggers
+            var telemetryEvent = TelemetryEvent.CreateFrom(exception);
+            _rpcServer.SendNotification(TelemetryNotification.Type, telemetryEvent);
+        }
+
+        public void LogMetric(string name, double value, string unit, IDictionary<string, object> contextData)
+        {
+            // Do nothing
+        }
+    }
+}

--- a/TypeCobol.LanguageServer/VsCodeProtocol/LanguageServer.cs
+++ b/TypeCobol.LanguageServer/VsCodeProtocol/LanguageServer.cs
@@ -72,12 +72,15 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
         /// <param name="e">Tne Exception event argument</param>
         private void UnhandledExceptionHandler(object sender, UnhandledExceptionEventArgs e)
         {
-            NotifyException(e.ExceptionObject as Exception);
+            var exception = (Exception)e.ExceptionObject;
+            NotifyException(exception);
+
+            // Display message on client interface to notify server crash !
+            this.RemoteWindow.ShowErrorMessage(exception.Message + "\n" + exception.StackTrace);
         }
 
         public virtual void NotifyException(Exception e)
         {
-            this.RemoteWindow.ShowErrorMessage(e.Message + "\n" + e.StackTrace);
             LoggingSystem.LogException(e);
         }
 

--- a/TypeCobol.LanguageServer/VsCodeProtocol/Telemetry Notification/TelemetryEvent.cs
+++ b/TypeCobol.LanguageServer/VsCodeProtocol/Telemetry Notification/TelemetryEvent.cs
@@ -1,0 +1,57 @@
+﻿using System.Text;
+
+namespace TypeCobol.LanguageServer.VsCodeProtocol
+{
+    /// <summary>
+    /// Class used to describe an event that occured on this server.
+    /// </summary>
+    public class TelemetryEvent
+    {
+        /// <summary>
+        /// Extract data from an exception to produce a meaningful TelemetryEvent.
+        /// The event will contain :
+        /// - the exception's .NET type
+        /// - the exception's message
+        /// - the exception's target site (which is the method that threw the exception, top of the StackTrace)
+        /// </summary>
+        /// <param name="exception">Non-null exception instance to describe.</param>
+        /// <returns>Non-null instance of TelemetryEvent.</returns>
+        public static TelemetryEvent CreateFrom(Exception exception)
+        {
+            string exceptionType = exception.GetType().FullName;
+            string exceptionMessage = exception.Message;
+            var exceptionTargetSite = new StringBuilder();
+            if (exception.TargetSite != null)
+            {
+                var targetSite = exception.TargetSite;
+                exceptionTargetSite.Append(targetSite.DeclaringType?.FullName); // Fullname of the type declaring the method
+                exceptionTargetSite.Append('.');
+                exceptionTargetSite.Append(targetSite.Name);
+                exceptionTargetSite.Append('(');
+                exceptionTargetSite.AppendJoin(", ", targetSite.GetParameters().Select(p => p.ParameterType.Name)); // For each param, simple name of its type
+                exceptionTargetSite.Append(')');
+            }
+
+            return new TelemetryEvent()
+            {
+                Type = "exception",
+                Data = new Dictionary<string, string>()
+                {
+                    { "Type", exceptionType },
+                    { nameof(Exception.Message), exceptionMessage },
+                    { nameof(Exception.TargetSite), exceptionTargetSite.ToString() }
+                }
+            };
+        }
+
+        /// <summary>
+        /// String identifier for the type of the event.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Name-value collection to hold descriptive data of the event.
+        /// </summary>
+        public Dictionary<string, string> Data { get; set; }
+    }
+}

--- a/TypeCobol.LanguageServer/VsCodeProtocol/Telemetry Notification/TelemetryEvent.cs
+++ b/TypeCobol.LanguageServer/VsCodeProtocol/Telemetry Notification/TelemetryEvent.cs
@@ -20,6 +20,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
         {
             string exceptionType = exception.GetType().FullName;
             string exceptionMessage = exception.Message;
+            string exceptionSource = exception.Source;
             var exceptionTargetSite = new StringBuilder();
             if (exception.TargetSite != null)
             {
@@ -39,6 +40,7 @@ namespace TypeCobol.LanguageServer.VsCodeProtocol
                 {
                     { "Type", exceptionType },
                     { nameof(Exception.Message), exceptionMessage },
+                    { nameof(Exception.Source), exceptionSource },
                     { nameof(Exception.TargetSite), exceptionTargetSite.ToString() }
                 }
             };

--- a/TypeCobol.LanguageServer/VsCodeProtocol/Telemetry Notification/TelemetryNotification.cs
+++ b/TypeCobol.LanguageServer/VsCodeProtocol/Telemetry Notification/TelemetryNotification.cs
@@ -1,0 +1,17 @@
+﻿using TypeCobol.LanguageServer.JsonRPC;
+
+namespace TypeCobol.LanguageServer.VsCodeProtocol.Telemetry_Notification
+{
+    /// <summary>
+    /// The telemetry notification is sent from the server to the client to ask the client
+    /// to log a telemetry event. The protocol doesn't specify the payload since no interpretation
+    /// of the data happens in the protocol.
+    /// 
+    /// Most clients even don’t handle the event directly but forward them to the extensions
+    /// owing the corresponding server issuing the event.
+    /// </summary>
+    class TelemetryNotification
+    {
+        public static readonly NotificationType Type = new NotificationType("telemetry/event", typeof(object));
+    }
+}


### PR DESCRIPTION
Fixes #2670

No new LSP tests:
- since `telemetry/event` is not tied to any document, I suspect LSR will drop the message
- the send happens on the logger thread so the message order is not guaranteed

I manually tested on our private client and the event is correctly sent and received.
![Capture](https://github.com/user-attachments/assets/64767640-e57e-49f7-b727-28c3a7fca8d1)
