### PR TITLE
WI #2731 Add option for mixed debug check, remove option for END PROGRAM

### DIFF
--- a/TypeCobol.Test/Parser/Incremental/BasicEdits/AddEmptyLineInTheMiddleThenRemove/DebugLinesWithDebugging.0.Nodes.txt
+++ b/TypeCobol.Test/Parser/Incremental/BasicEdits/AddEmptyLineInTheMiddleThenRemove/DebugLinesWithDebugging.0.Nodes.txt
@@ -1,12 +1,12 @@
 Line 5[38,46] <37, Warning, General> - Warning: Debugging mode is active
-Range (14, 12) -> (15, 20) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (22, 12) -> (24, 19) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (27, 12) -> (29, 19) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (33, 12) -> (36, 19) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (39, 12) -> (41, 18) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (44, 12) -> (47, 17) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (54, 12) -> (55, 25) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (59, 12) -> (60, 20) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (14, 12) -> (15, 20) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (22, 12) -> (24, 19) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (27, 12) -> (29, 19) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (33, 12) -> (36, 19) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (39, 12) -> (41, 18) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (44, 12) -> (47, 17) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (54, 12) -> (55, 25) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (59, 12) -> (60, 20) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
 --- Nodes ---
 ?
   Pgm

--- a/TypeCobol.Test/Parser/Incremental/BasicEdits/AddEmptyLineInTheMiddleThenRemove/DebugLinesWithDebugging.1.Nodes.txt
+++ b/TypeCobol.Test/Parser/Incremental/BasicEdits/AddEmptyLineInTheMiddleThenRemove/DebugLinesWithDebugging.1.Nodes.txt
@@ -1,12 +1,12 @@
 Line 5[38,46] <37, Warning, General> - Warning: Debugging mode is active
-Range (14, 12) -> (15, 20) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (22, 12) -> (24, 19) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (27, 12) -> (29, 19) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (32, 12) -> (35, 19) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (38, 12) -> (40, 18) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (43, 12) -> (46, 17) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (53, 12) -> (54, 25) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (58, 12) -> (59, 20) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (14, 12) -> (15, 20) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (22, 12) -> (24, 19) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (27, 12) -> (29, 19) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (32, 12) -> (35, 19) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (38, 12) -> (40, 18) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (43, 12) -> (46, 17) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (53, 12) -> (54, 25) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (58, 12) -> (59, 20) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
 --- Nodes ---
 ?
   Pgm

--- a/TypeCobol.Test/Parser/Incremental/BasicEdits/AddEmptyLineInTheMiddleThenRemove/DebugLinesWithDebugging.Nodes.txt
+++ b/TypeCobol.Test/Parser/Incremental/BasicEdits/AddEmptyLineInTheMiddleThenRemove/DebugLinesWithDebugging.Nodes.txt
@@ -1,12 +1,12 @@
 Line 5[38,46] <37, Warning, General> - Warning: Debugging mode is active
-Range (14, 12) -> (15, 20) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (22, 12) -> (24, 19) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (27, 12) -> (29, 19) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (32, 12) -> (35, 19) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (38, 12) -> (40, 18) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (43, 12) -> (46, 17) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (53, 12) -> (54, 25) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (58, 12) -> (59, 20) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (14, 12) -> (15, 20) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (22, 12) -> (24, 19) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (27, 12) -> (29, 19) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (32, 12) -> (35, 19) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (38, 12) -> (40, 18) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (43, 12) -> (46, 17) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (53, 12) -> (54, 25) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (58, 12) -> (59, 20) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
 --- Nodes ---
 ?
   Pgm

--- a/TypeCobol.Test/Parser/Programs/Cobol85/DebugLinesWithDebugging.Nodes.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/DebugLinesWithDebugging.Nodes.txt
@@ -1,12 +1,12 @@
 Line 5[38,46] <37, Warning, General> - Warning: Debugging mode is active
-Range (14, 12) -> (15, 20) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (22, 12) -> (24, 19) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (27, 12) -> (29, 19) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (32, 12) -> (35, 19) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (38, 12) -> (40, 18) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (43, 12) -> (46, 17) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (53, 12) -> (54, 25) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
-Range (58, 12) -> (59, 20) <27, Error, Syntax> - Syntax error : In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (14, 12) -> (15, 20) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (22, 12) -> (24, 19) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (27, 12) -> (29, 19) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (32, 12) -> (35, 19) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (38, 12) -> (40, 18) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (43, 12) -> (46, 17) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (53, 12) -> (54, 25) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
+Range (58, 12) -> (59, 20) <37, Warning, General> - Warning: In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.
 --- Nodes ---
 ?
   Pgm

--- a/TypeCobol/Compiler/Diagnostics/CodeElementCheckers.cs
+++ b/TypeCobol/Compiler/Diagnostics/CodeElementCheckers.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Antlr4.Runtime;
+﻿using Antlr4.Runtime;
 using Antlr4.Runtime.Tree;
 using JetBrains.Annotations;
 using TypeCobol.Compiler.AntlrUtils;
 using TypeCobol.Compiler.CodeElements;
+using TypeCobol.Compiler.Directives;
 using TypeCobol.Compiler.Parser;
 using TypeCobol.Compiler.Parser.Generated;
 using TypeCobol.Compiler.Scanner;
@@ -431,13 +429,15 @@ namespace TypeCobol.Compiler.Diagnostics
     {
         private const int MAX_NAME_LENGTH = 30;
 
-        public static void OnCodeElement(CodeElement codeElement, bool isDebuggingModeEnabled)
+        public static void OnCodeElement(CodeElement codeElement, TypeCobolOptions compilerOptions, bool isDebuggingModeEnabled)
         {
-            if (isDebuggingModeEnabled)
+            // Check code element debug type
+            if (compilerOptions.CheckCodeElementMixedDebugType.IsActive && isDebuggingModeEnabled)
             {
                 if (codeElement.DebugMode == CodeElement.DebugType.Mix)
                 {
-                    DiagnosticUtils.AddError(codeElement, "In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.");
+                    var messageCode = compilerOptions.CheckCodeElementMixedDebugType.GetMessageCode();
+                    DiagnosticUtils.AddError(codeElement, "In debugging mode, a statement cannot span across lines marked with debug and lines not marked debug.", messageCode);
                 }
             }
 

--- a/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/CrossChecker.cs
@@ -1446,18 +1446,18 @@ namespace TypeCobol.Compiler.Diagnostics
             {
                 // END PROGRAM is present
                 node.SetFlag(Node.Flag.MissingEndProgram, false);
-                var programEnd = (ProgramEnd)end.CodeElement;
-                if (programEnd.ProgramName?.Name == null)
+                string programEndName = ((ProgramEnd)end.CodeElement).ProgramName?.Name;
+                if (programEndName == null)
                 {
                     // No name is specified after END PROGRAM
                     DiagnosticUtils.AddError(end, $"\"PROGRAM END\" should have a program name. \"{node.Name}\" was assumed.");
                 }
                 else
                 {
-                    if (!node.Name.Equals(programEnd.ProgramName.Name, StringComparison.OrdinalIgnoreCase))
+                    if (!node.Name.Equals(programEndName, StringComparison.OrdinalIgnoreCase))
                     {
                         // Wrong name is specified after END PROGRAM
-                        DiagnosticUtils.AddError(end, $"Program name \"{programEnd.ProgramName.Name}\" did not match the name of any open program. The \"END PROGRAM\" marker was assumed to have ended program \"{node.Name}\".");
+                        DiagnosticUtils.AddError(end, $"Program name \"{programEndName}\" did not match the name of any open program. The \"END PROGRAM\" marker was assumed to have ended program \"{node.Name}\".");
                     }
                 }
             }

--- a/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
+++ b/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
@@ -78,11 +78,6 @@ namespace TypeCobol.Compiler.Directives
         public TypeCobolCheckOption CheckEndAlignment { get; set; }
 
         /// <summary>
-        /// Check if END PROGRAM have a program name associated and this name exists
-        /// </summary>
-        public TypeCobolCheckOption CheckEndProgram { get; set; }
-
-        /// <summary>
         /// Check that perform statements always return to caller, requires CFG.
         /// </summary>
         public TypeCobolCheckOption CheckPerformPrematureExits { get; set; }
@@ -118,7 +113,6 @@ namespace TypeCobol.Compiler.Directives
             IsCobolLanguage = config.IsCobolLanguage;
 
             CheckEndAlignment = config.CheckEndAlignment;
-            CheckEndProgram = config.CheckEndProgram;
             CheckPerformPrematureExits = config.CheckPerformPrematureExits;
             CheckPerformThruOrder = config.CheckPerformThruOrder;
             CheckRecursivePerforms = config.CheckRecursivePerforms;
@@ -129,7 +123,6 @@ namespace TypeCobol.Compiler.Directives
         {
             // default values for checks
             CheckEndAlignment = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckEndAlignmentSeverity);
-            CheckEndProgram = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckEndProgramSeverity);
             CheckPerformPrematureExits = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckPerformPrematureExitsSeverity);
             CheckPerformThruOrder = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckPerformThruOrderSeverity);
             CheckRecursivePerforms = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckRecursivePerformsSeverity);

--- a/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
+++ b/TypeCobol/Compiler/Directives/TypeCobolOptions.cs
@@ -97,6 +97,11 @@ namespace TypeCobol.Compiler.Directives
         /// </summary>
         public TypeCobolCheckOption CheckRecursivePerforms { get; set; }
 
+        /// <summary>
+        /// Check that CodeElement do not mix debug and non-debug lines.
+        /// </summary>
+        public TypeCobolCheckOption CheckCodeElementMixedDebugType { get; set; }
+
         public TypeCobolOptions(TypeCobolConfiguration config)
         {
             HaltOnMissingCopy = config.HaltOnMissingCopyFilePath != null;
@@ -117,6 +122,7 @@ namespace TypeCobol.Compiler.Directives
             CheckPerformPrematureExits = config.CheckPerformPrematureExits;
             CheckPerformThruOrder = config.CheckPerformThruOrder;
             CheckRecursivePerforms = config.CheckRecursivePerforms;
+            CheckCodeElementMixedDebugType = config.CheckCodeElementMixedDebugType;
         }
 
         public TypeCobolOptions()
@@ -127,6 +133,7 @@ namespace TypeCobol.Compiler.Directives
             CheckPerformPrematureExits = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckPerformPrematureExitsSeverity);
             CheckPerformThruOrder = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckPerformThruOrderSeverity);
             CheckRecursivePerforms = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckRecursivePerformsSeverity);
+            CheckCodeElementMixedDebugType = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckCodeElementMixedDebugTypeSeverity);
         }
     }
 }

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Antlr4.Runtime;
+﻿using Antlr4.Runtime;
 using Antlr4.Runtime.Tree;
 using TypeCobol.Compiler.AntlrUtils;
 using TypeCobol.Compiler.CodeElements;
@@ -21,6 +18,8 @@ namespace TypeCobol.Compiler.Parser
         private ParserRuleContext Context;
         /// <summary>CodeElement object resulting of the visit the parse tree</summary>
         public CodeElement CodeElement { get; set; }
+
+        private readonly TypeCobolOptions _compilerOptions;
         private readonly CobolWordsBuilder _cobolWordsBuilder;
         private readonly CobolExpressionsBuilder _cobolExpressionsBuilder;
         private readonly CobolStatementsBuilder _cobolStatementsBuilder;
@@ -29,7 +28,8 @@ namespace TypeCobol.Compiler.Parser
 
         public CodeElementBuilder(TypeCobolOptions compilerOptions, bool isDebuggingModeEnabled)
         {
-            var targetLevel = compilerOptions.IsCobolLanguage ? CobolLanguageLevel.Cobol85 : CobolLanguageLevel.TypeCobol;
+            _compilerOptions = compilerOptions;
+            var targetLevel = _compilerOptions.IsCobolLanguage ? CobolLanguageLevel.Cobol85 : CobolLanguageLevel.TypeCobol;
             _languageLevelChecker = new UnsupportedLanguageLevelFeaturesChecker(targetLevel);
             _cobolWordsBuilder = new CobolWordsBuilder();
             _cobolExpressionsBuilder = new CobolExpressionsBuilder(_cobolWordsBuilder, _languageLevelChecker);
@@ -74,7 +74,7 @@ namespace TypeCobol.Compiler.Parser
                 // Attach all tokens consumed by the parser for this code element
                 // Collect all error messages encountered while parsing this code element
                 AddTokensConsumedAndDiagnosticsAttachedInContext(CodeElement, Context);
-                CodeElementChecker.OnCodeElement(CodeElement, IsDebuggingModeEnabled);
+                CodeElementChecker.OnCodeElement(CodeElement, _compilerOptions, IsDebuggingModeEnabled);
             }
             // If the errors can't be attached to a CodeElement object, attach it to the parent codeElements rule context
             else if (CodeElement == null && context.Diagnostics != null)

--- a/TypeCobol/Tools/Options-Config/TypeCobolConfiguration.cs
+++ b/TypeCobol/Tools/Options-Config/TypeCobolConfiguration.cs
@@ -42,7 +42,6 @@ namespace TypeCobol.Tools.Options_Config
 #endif
         // Checks
         public TypeCobolCheckOption CheckEndAlignment { get; set; }
-        public TypeCobolCheckOption CheckEndProgram { get; set; }
         public TypeCobolCheckOption CheckPerformPrematureExits { get; set; }
         public TypeCobolCheckOption CheckPerformThruOrder { get; set; }
         public TypeCobolCheckOption CheckRecursivePerforms { get; set; }
@@ -131,7 +130,6 @@ namespace TypeCobol.Tools.Options_Config
         {
             // default values for checks
             CheckEndAlignment = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckEndAlignmentSeverity);
-            CheckEndProgram = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckEndProgramSeverity);
             CheckPerformPrematureExits = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckPerformPrematureExitsSeverity);
             CheckPerformThruOrder = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckPerformThruOrderSeverity);
             CheckRecursivePerforms = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckRecursivePerformsSeverity);
@@ -247,14 +245,12 @@ namespace TypeCobol.Tools.Options_Config
     public interface ITypeCobolCheckOptions
     {
         const Severity DefaultCheckEndAlignmentSeverity = Severity.Warning;
-        const Severity DefaultCheckEndProgramSeverity = Severity.Error;
         const Severity DefaultCheckPerformPrematureExitsSeverity = Severity.Warning;
         const Severity DefaultCheckPerformThruOrderSeverity = Severity.Warning;
         const Severity DefaultCheckRecursivePerformsSeverity = Severity.Warning;
         const Severity DefaultCheckCodeElementMixedDebugTypeSeverity = Severity.Warning;
 
         TypeCobolCheckOption CheckEndAlignment { get; set; }
-        TypeCobolCheckOption CheckEndProgram { get; set; }
         TypeCobolCheckOption CheckPerformPrematureExits { get; set; }
         TypeCobolCheckOption CheckPerformThruOrder { get; set; }
         TypeCobolCheckOption CheckRecursivePerforms { get; set; }
@@ -292,7 +288,6 @@ namespace TypeCobol.Tools.Options_Config
                 { "dcsm|disablecopysuffixingmechanism", "Disable EI Legacy automatic suffixing of data names from CPY copies.", v => typeCobolConfig.EILegacy_ApplyCopySuffixing = false },
                 { "glm|genlinemap=", "{PATH} to an output file where line mapping will be generated.", v => typeCobolConfig.LineMapFiles.Add(v) },
                 { "diag.cea|diagnostic.checkEndAlignment=", "Indicate level of check end aligment: warning, error, info, ignore.", v => typeCobolConfig.CheckEndAlignment = TypeCobolCheckOption.Parse(v) },
-                { "diag.cep|diagnostic.checkEndProgram=", "Indicate level of check end program: warning, error, info, ignore.", v => typeCobolConfig.CheckEndProgram = TypeCobolCheckOption.Parse(v) },
                 { "diag.cppe|diagnostic.checkPerformPrematureExits=", "Indicate level of check perform premature exits: warning, error, info, ignore.", v => typeCobolConfig.CheckPerformPrematureExits = TypeCobolCheckOption.Parse(v) },
                 { "diag.cpto|diagnostic.checkPerformThruOrder=", "Indicate level of check perform thru procedure order: warning, error, info, ignore.", v => typeCobolConfig.CheckPerformThruOrder = TypeCobolCheckOption.Parse(v) },
                 { "diag.crp|diagnostic.checkRecursivePerforms=", "Indicate level of check recursive performs: warning, error, info, ignore.", v => typeCobolConfig.CheckRecursivePerforms = TypeCobolCheckOption.Parse(v) },

--- a/TypeCobol/Tools/Options-Config/TypeCobolConfiguration.cs
+++ b/TypeCobol/Tools/Options-Config/TypeCobolConfiguration.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+﻿using System.Text;
 using Mono.Options;
 using TypeCobol.Analysis;
 using TypeCobol.Compiler;
@@ -49,6 +46,7 @@ namespace TypeCobol.Tools.Options_Config
         public TypeCobolCheckOption CheckPerformPrematureExits { get; set; }
         public TypeCobolCheckOption CheckPerformThruOrder { get; set; }
         public TypeCobolCheckOption CheckRecursivePerforms { get; set; }
+        public TypeCobolCheckOption CheckCodeElementMixedDebugType { get; set; }
 
         public List<string> Copies = new List<string>();
         public List<string> Dependencies = new List<string>();
@@ -137,6 +135,7 @@ namespace TypeCobol.Tools.Options_Config
             CheckPerformPrematureExits = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckPerformPrematureExitsSeverity);
             CheckPerformThruOrder = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckPerformThruOrderSeverity);
             CheckRecursivePerforms = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckRecursivePerformsSeverity);
+            CheckCodeElementMixedDebugType = new TypeCobolCheckOption(ITypeCobolCheckOptions.DefaultCheckCodeElementMixedDebugTypeSeverity);
         }
     }
 
@@ -252,12 +251,14 @@ namespace TypeCobol.Tools.Options_Config
         const Severity DefaultCheckPerformPrematureExitsSeverity = Severity.Warning;
         const Severity DefaultCheckPerformThruOrderSeverity = Severity.Warning;
         const Severity DefaultCheckRecursivePerformsSeverity = Severity.Warning;
+        const Severity DefaultCheckCodeElementMixedDebugTypeSeverity = Severity.Warning;
 
         TypeCobolCheckOption CheckEndAlignment { get; set; }
         TypeCobolCheckOption CheckEndProgram { get; set; }
         TypeCobolCheckOption CheckPerformPrematureExits { get; set; }
         TypeCobolCheckOption CheckPerformThruOrder { get; set; }
         TypeCobolCheckOption CheckRecursivePerforms { get; set; }
+        TypeCobolCheckOption CheckCodeElementMixedDebugType { get; set; }
     }
 
     public static class TypeCobolOptionSet
@@ -295,6 +296,7 @@ namespace TypeCobol.Tools.Options_Config
                 { "diag.cppe|diagnostic.checkPerformPrematureExits=", "Indicate level of check perform premature exits: warning, error, info, ignore.", v => typeCobolConfig.CheckPerformPrematureExits = TypeCobolCheckOption.Parse(v) },
                 { "diag.cpto|diagnostic.checkPerformThruOrder=", "Indicate level of check perform thru procedure order: warning, error, info, ignore.", v => typeCobolConfig.CheckPerformThruOrder = TypeCobolCheckOption.Parse(v) },
                 { "diag.crp|diagnostic.checkRecursivePerforms=", "Indicate level of check recursive performs: warning, error, info, ignore.", v => typeCobolConfig.CheckRecursivePerforms = TypeCobolCheckOption.Parse(v) },
+                { "diag.ccemdt|diagnostic.checkCodeElementMixedDebugType=", "Indicate level of check for code elements mixing debug and non-debug lines: warning, error, info, ignore.", v => typeCobolConfig.CheckCodeElementMixedDebugType = TypeCobolCheckOption.Parse(v) },
                 { "log|logfilepath=", "{PATH} to TypeCobol.CLI.log log file", v => typeCobolConfig.LogFile = Path.Combine(v, TypeCobolConfiguration.DefaultLogFileName)},
                 { "cfg|cfgbuild=", "CFG build option, recognized values are: None/0, Standard/1, Extended/2, WithDfa/3.", v => typeCobolConfig.RawCfgBuildingMode = v },
                 { "cob|cobol", "Indicate that it's a pure Cobol85 input file.", v => typeCobolConfig.IsCobolLanguage = true },


### PR DESCRIPTION
Fixes #2731

Two changes in this PR:
- WI #2731 Add option for checking debug mix in CodeElement
  - a new option is available to control the severity, and possibly disable, the check of CodeElements mixing debug and non-debug lines
- WI #2731 Remove option to check END PROGRAM
  - remove the `diag.cep` option as the performed checks always resolve to an error on IBM compiler

Note that the second change is breaking so I am thonking of creating a v2.8.0 to release this.
