### PR TITLE
v2.8.2

### DIFF
--- a/TypeCobol.LanguageServer.Test/LSRTests/AmbiguousVariablesCompletion/input/AmbiguousVariablesCompletion.tlsp
+++ b/TypeCobol.LanguageServer.Test/LSRTests/AmbiguousVariablesCompletion/input/AmbiguousVariablesCompletion.tlsp
@@ -75,7 +75,7 @@
     },
     {
       "category": 1,
-      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"4\",\"result\":{\"isIncomplete\":false,\"items\":[{\"label\":\"ambiguous (Alphanumeric) (Group1::Level1::ambiguous)\",\"kind\":6,\"insertText\":\"Group1::Level1::ambiguous\",\"data\":{\"start\":{\"line\":12,\"character\":19},\"end\":{\"line\":12,\"character\":22}}},{\"label\":\"ambiguous (Alphanumeric) (Group1::Level2::ambiguous)\",\"kind\":6,\"insertText\":\"Group1::Level2::ambiguous\",\"data\":{\"start\":{\"line\":12,\"character\":19},\"end\":{\"line\":12,\"character\":22}}}]}}"
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"4\",\"result\":{\"isIncomplete\":false,\"items\":[{\"label\":\"ambiguous (Alphanumeric) (Group1::Level1::ambiguous)\",\"kind\":6,\"insertText\":\"Group1::Level1::ambiguous\",\"data\":{\"start\":{\"line\":12,\"character\":19},\"end\":{\"line\":12,\"character\":22}}},{\"label\":\"ambiguous (Alphanumeric) (Group1::Level2::ambiguous)\",\"kind\":6,\"insertText\":\"Group1::Level2::ambiguous\",\"data\":{\"start\":{\"line\":12,\"character\":19},\"end\":{\"line\":12,\"character\":22}}},{\"label\":\"non-ambiguous-1 (Alphanumeric) (Group1::Level1::non-ambiguous-1)\",\"kind\":6,\"insertText\":\"Group1::Level1::non-ambiguous-1\",\"data\":{\"start\":{\"line\":12,\"character\":19},\"end\":{\"line\":12,\"character\":22}}},{\"label\":\"non-ambiguous-2 (Alphanumeric) (Group1::Level2::non-ambiguous-2)\",\"kind\":6,\"insertText\":\"Group1::Level2::non-ambiguous-2\",\"data\":{\"start\":{\"line\":12,\"character\":19},\"end\":{\"line\":12,\"character\":22}}}]}}"
     },
     {
       "category": 0,

--- a/TypeCobol.LanguageServer.Test/LSRTests/AmbiguousVariablesCompletionNoTC/input/AmbiguousVariablesCompletionNoTC.tlsp
+++ b/TypeCobol.LanguageServer.Test/LSRTests/AmbiguousVariablesCompletionNoTC/input/AmbiguousVariablesCompletionNoTC.tlsp
@@ -75,7 +75,7 @@
     },
     {
       "category": 1,
-      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"4\",\"result\":{\"isIncomplete\":false,\"items\":[{\"label\":\"ambiguous (Alphanumeric) (ambiguous OF Level1 OF Group1)\",\"kind\":6,\"insertText\":\"ambiguous OF Level1 OF Group1\",\"data\":{\"start\":{\"line\":12,\"character\":19},\"end\":{\"line\":12,\"character\":22}}},{\"label\":\"ambiguous (Alphanumeric) (ambiguous OF Level2 OF Group1)\",\"kind\":6,\"insertText\":\"ambiguous OF Level2 OF Group1\",\"data\":{\"start\":{\"line\":12,\"character\":19},\"end\":{\"line\":12,\"character\":22}}}]}}"
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"4\",\"result\":{\"isIncomplete\":false,\"items\":[{\"label\":\"ambiguous (Alphanumeric) (ambiguous OF Level1 OF Group1)\",\"kind\":6,\"insertText\":\"ambiguous OF Level1 OF Group1\",\"data\":{\"start\":{\"line\":12,\"character\":19},\"end\":{\"line\":12,\"character\":22}}},{\"label\":\"ambiguous (Alphanumeric) (ambiguous OF Level2 OF Group1)\",\"kind\":6,\"insertText\":\"ambiguous OF Level2 OF Group1\",\"data\":{\"start\":{\"line\":12,\"character\":19},\"end\":{\"line\":12,\"character\":22}}},{\"label\":\"non-ambiguous-1 (Alphanumeric) (non-ambiguous-1)\",\"kind\":6,\"insertText\":\"non-ambiguous-1\",\"data\":{\"start\":{\"line\":12,\"character\":19},\"end\":{\"line\":12,\"character\":22}}},{\"label\":\"non-ambiguous-2 (Alphanumeric) (non-ambiguous-2)\",\"kind\":6,\"insertText\":\"non-ambiguous-2\",\"data\":{\"start\":{\"line\":12,\"character\":19},\"end\":{\"line\":12,\"character\":22}}}]}}"
     },
     {
       "category": 0,

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterCall/WithUserFilterText.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterCall/WithUserFilterText.txt
@@ -1,0 +1,70 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       PROCEDURE DIVISION.
+       main.
+           CALL proc
+           GOBACK
+           .
+       DECLARE PROCEDURE proc1 PRIVATE.
+       END-DECLARE.
+       
+       DECLARE PROCEDURE another-proc1 PRIVATE.
+       END-DECLARE.
+       
+       DECLARE PROCEDURE func1 PRIVATE.
+       END-DECLARE.
+       
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ProcNested1.
+       END PROGRAM ProcNested1.
+       
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. NestedProc1.
+       END PROGRAM NestedProc1.
+       
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. AnotherNested.
+       END PROGRAM AnotherNested.
+       
+       END PROGRAM TCOMFL06.
+---------------------------------------------------------------------------------
+{"line":4,"character":20}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "proc1   ",
+    "kind": 3,
+    "insertText": "proc1",
+    "data": [
+      {
+        "start": {
+          "line": 4,
+          "character": 16
+        },
+        "end": {
+          "line": 4,
+          "character": 20
+        }
+      },
+      {
+        "label": "TCOMFL06.proc1",
+        "parameters": []
+      },
+      null
+    ]
+  },
+  {
+    "label": "ProcNested1",
+    "kind": 9,
+    "data": {
+      "start": {
+        "line": 4,
+        "character": 16
+      },
+      "end": {
+        "line": 4,
+        "character": 20
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterCall/WithoutUserFilterText.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterCall/WithoutUserFilterText.txt
@@ -1,0 +1,89 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       PROCEDURE DIVISION.
+       main.
+           CALL 
+           GOBACK
+           .
+       DECLARE PROCEDURE proc1 PRIVATE.
+       END-DECLARE.
+       
+       DECLARE PROCEDURE another-proc1 PRIVATE.
+       END-DECLARE.
+       
+       DECLARE PROCEDURE func1 PRIVATE.
+       END-DECLARE.
+       
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ProcNested1.
+       END PROGRAM ProcNested1.
+       
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. NestedProc1.
+       END PROGRAM NestedProc1.
+       
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. AnotherNested.
+       END PROGRAM AnotherNested.
+       
+       END PROGRAM TCOMFL06.
+---------------------------------------------------------------------------------
+{"line":4,"character":16}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "proc1   ",
+    "kind": 3,
+    "insertText": "proc1",
+    "data": [
+      null,
+      {
+        "label": "TCOMFL06.proc1",
+        "parameters": []
+      },
+      null
+    ]
+  },
+  {
+    "label": "another-proc1   ",
+    "kind": 3,
+    "insertText": "another-proc1",
+    "data": [
+      null,
+      {
+        "label": "TCOMFL06.another-proc1",
+        "parameters": []
+      },
+      null
+    ]
+  },
+  {
+    "label": "func1   ",
+    "kind": 3,
+    "insertText": "func1",
+    "data": [
+      null,
+      {
+        "label": "TCOMFL06.func1",
+        "parameters": []
+      },
+      null
+    ]
+  },
+  {
+    "label": "TCOMFL06",
+    "kind": 9
+  },
+  {
+    "label": "ProcNested1",
+    "kind": 9
+  },
+  {
+    "label": "NestedProc1",
+    "kind": 9
+  },
+  {
+    "label": "AnotherNested",
+    "kind": 9
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterDisplay/NamesUsingHyphens.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterDisplay/NamesUsingHyphens.txt
@@ -1,0 +1,168 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+      * should suggest: matching variables
+       01 SAY-VAR1               PIC 9.
+       01 REDEF-SAY-VAR1 REDEFINES SAY-VAR1
+                                 PIC 9.
+       01 GROUP1-SAY.
+          05 VAR2-SAY            PIC X.
+          66 SAY66 RENAMES VAR2-SAY.
+       01 VAR3-SAY-VAR3          PIC 9.
+       01 SAY-POINTER USAGE POINTER.
+       77 SAY77                  PIC X.
+
+      * should not suggest: not matching, invalid usage, 88
+       01 VAR4                   PIC 9.
+       01 NOTSAY                 PIC 9.
+       01 SAY-PROCEDURE-POINTER USAGE PROCEDURE-POINTER.
+       01 SAY-FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 GROUP2 OCCURS 10 INDEXED BY SAY-INDEX
+                                 PIC X.
+       01 GROUP3.
+          05 VAR5                PIC X.
+             88 SAY88-YES              VALUE 'Y'.
+             88 SAY88-NO               VALUE 'N'.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           DISPLAY SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P-SAY-HELLO.
+           DISPLAY "HELlO"
+           .
+      * should not suggest: section
+       S-SAY-CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":30,"character":22}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-VAR1 (Numeric) (SAY-VAR1)",
+    "kind": 6,
+    "insertText": "SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "REDEF-SAY-VAR1 (Numeric) (REDEF-SAY-VAR1)",
+    "kind": 6,
+    "insertText": "REDEF-SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "GROUP1-SAY (Alphanumeric) (GROUP1-SAY)",
+    "kind": 6,
+    "insertText": "GROUP1-SAY",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "VAR2-SAY (Alphanumeric) (GROUP1-SAY::VAR2-SAY)",
+    "kind": 6,
+    "insertText": "GROUP1-SAY::VAR2-SAY",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "SAY66 (?) (GROUP1-SAY::SAY66)",
+    "kind": 6,
+    "insertText": "GROUP1-SAY::SAY66",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "VAR3-SAY-VAR3 (Numeric) (VAR3-SAY-VAR3)",
+    "kind": 6,
+    "insertText": "VAR3-SAY-VAR3",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "SAY-POINTER (Alphanumeric) (SAY-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-POINTER",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "SAY77 (Alphanumeric) (SAY77)",
+    "kind": 6,
+    "insertText": "SAY77",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterDisplay/NamesUsingUnderscores.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterDisplay/NamesUsingUnderscores.txt
@@ -1,0 +1,168 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+      * should suggest: matching variables
+       01 SAY_VAR1               PIC 9.
+       01 REDEF_SAY_VAR1 REDEFINES SAY_VAR1
+                                 PIC 9.
+       01 GROUP1_SAY.
+          05 VAR2_SAY            PIC X.
+          66 SAY66 RENAMES VAR2_SAY.
+       01 VAR3_SAY_VAR3          PIC 9.
+       01 SAY_POINTER USAGE POINTER.
+       77 SAY77                  PIC X.
+
+      * should not suggest: not matching, invalid usage, 88
+       01 VAR4                   PIC 9.
+       01 NOTSAY                 PIC 9.
+       01 SAY_PROCEDURE-POINTER USAGE PROCEDURE-POINTER.
+       01 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 GROUP2 OCCURS 10 INDEXED BY SAY_INDEX
+                                 PIC X.
+       01 GROUP3.
+          05 VAR5                PIC X.
+             88 SAY88-YES              VALUE 'Y'.
+             88 SAY88-NO               VALUE 'N'.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           DISPLAY SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "HELlO"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":30,"character":22}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY_VAR1 (Numeric) (SAY_VAR1)",
+    "kind": 6,
+    "insertText": "SAY_VAR1",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "REDEF_SAY_VAR1 (Numeric) (REDEF_SAY_VAR1)",
+    "kind": 6,
+    "insertText": "REDEF_SAY_VAR1",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "GROUP1_SAY (Alphanumeric) (GROUP1_SAY)",
+    "kind": 6,
+    "insertText": "GROUP1_SAY",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (Alphanumeric) (GROUP1_SAY::VAR2_SAY)",
+    "kind": 6,
+    "insertText": "GROUP1_SAY::VAR2_SAY",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "SAY66 (?) (GROUP1_SAY::SAY66)",
+    "kind": 6,
+    "insertText": "GROUP1_SAY::SAY66",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Numeric) (VAR3_SAY_VAR3)",
+    "kind": 6,
+    "insertText": "VAR3_SAY_VAR3",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "SAY_POINTER (Alphanumeric) (SAY_POINTER)",
+    "kind": 6,
+    "insertText": "SAY_POINTER",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "SAY77 (Alphanumeric) (SAY77)",
+    "kind": 6,
+    "insertText": "SAY77",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 19
+      },
+      "end": {
+        "line": 30,
+        "character": 22
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterInto/String.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterInto/String.txt
@@ -1,0 +1,115 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching alpha variables
+       01 SAY-VAR1              PIC X.
+       01 GROUP1-SAY.
+          05 VAR2-SAY           PIC BX.
+       01 VAR3-SAY-VAR3         PIC A.
+       01 SAY-FUNCTION-POINTER USAGE FUNCTION-POINTER.
+      * should not suggest: not matching, not alpha
+       01 VAR4                  PIC X.
+       01 VAR5-SAY              PIC 9.
+       01 GROUP2 OCCURS 10 INDEXED BY SAY-INDEX
+                                PIC X.
+       01 GROUP3.
+          05 VAR6               PIC X.
+             88 SAY88-YES              VALUE 'Y'.
+             88 SAY88-NO               VALUE 'N'.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           STRING VAR4 DELIMITED BY SPACE INTO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P-SAY-HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S-SAY-CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":22,"character":50}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-VAR1 (Alphanumeric) (SAY-VAR1)",
+    "kind": 6,
+    "insertText": "SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 47
+      },
+      "end": {
+        "line": 22,
+        "character": 50
+      }
+    }
+  },
+  {
+    "label": "GROUP1-SAY (Alphanumeric) (GROUP1-SAY)",
+    "kind": 6,
+    "insertText": "GROUP1-SAY",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 47
+      },
+      "end": {
+        "line": 22,
+        "character": 50
+      }
+    }
+  },
+  {
+    "label": "VAR2-SAY (AlphanumericEdited) (GROUP1-SAY::VAR2-SAY)",
+    "kind": 6,
+    "insertText": "GROUP1-SAY::VAR2-SAY",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 47
+      },
+      "end": {
+        "line": 22,
+        "character": 50
+      }
+    }
+  },
+  {
+    "label": "VAR3-SAY-VAR3 (Alphabetic) (VAR3-SAY-VAR3)",
+    "kind": 6,
+    "insertText": "VAR3-SAY-VAR3",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 47
+      },
+      "end": {
+        "line": 22,
+        "character": 50
+      }
+    }
+  },
+  {
+    "label": "SAY-FUNCTION-POINTER (Alphanumeric) (SAY-FUNCTION-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-FUNCTION-POINTER",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 47
+      },
+      "end": {
+        "line": 22,
+        "character": 50
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterInto/Unstring.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterInto/Unstring.txt
@@ -1,0 +1,115 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching alpha variables
+       01 SAY_VAR1              PIC X.
+       01 GROUP1_SAY.
+          05 VAR2_SAY           PIC BX.
+       01 VAR3_SAY_VAR3         PIC A.
+       01 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+      * should not suggest: not matching, not alpha
+       01 VAR4                  PIC X.
+       01 VAR5_SAY              PIC 9.
+       01 GROUP2 OCCURS 10 INDEXED BY SAY_INDEX
+                                PIC X.
+       01 GROUP3.
+          05 VAR6               PIC X.
+             88 SAY88-YES              VALUE 'Y'.
+             88 SAY88-NO               VALUE 'N'.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           UNSTRING VAR4 DELIMITED BY SPACE INTO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":22,"character":52}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY_VAR1 (Alphanumeric) (SAY_VAR1)",
+    "kind": 6,
+    "insertText": "SAY_VAR1",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 49
+      },
+      "end": {
+        "line": 22,
+        "character": 52
+      }
+    }
+  },
+  {
+    "label": "GROUP1_SAY (Alphanumeric) (GROUP1_SAY)",
+    "kind": 6,
+    "insertText": "GROUP1_SAY",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 49
+      },
+      "end": {
+        "line": 22,
+        "character": 52
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (AlphanumericEdited) (GROUP1_SAY::VAR2_SAY)",
+    "kind": 6,
+    "insertText": "GROUP1_SAY::VAR2_SAY",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 49
+      },
+      "end": {
+        "line": 22,
+        "character": 52
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Alphabetic) (VAR3_SAY_VAR3)",
+    "kind": 6,
+    "insertText": "VAR3_SAY_VAR3",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 49
+      },
+      "end": {
+        "line": 22,
+        "character": 52
+      }
+    }
+  },
+  {
+    "label": "SAY_FUNCTION-POINTER (Alphanumeric) (SAY_FUNCTION-POINTER)",
+    "kind": 6,
+    "insertText": "SAY_FUNCTION-POINTER",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 49
+      },
+      "end": {
+        "line": 22,
+        "character": 52
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterMove/NamesUsingHyphens.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterMove/NamesUsingHyphens.txt
@@ -1,0 +1,213 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+      * should suggest: matching variables
+       01 SAY-VAR1               PIC 9.
+       01 REDEF-SAY-VAR1 REDEFINES SAY-VAR1
+                                 PIC 9.
+       01 GROUP1-SAY.
+          05 VAR2-SAY            PIC X.
+          66 SAY66 RENAMES VAR2-SAY.
+       01 VAR3-SAY-VAR3          PIC 9.
+       01 SAY-POINTER USAGE POINTER.
+       01 SAY-PROCEDURE-POINTER USAGE PROCEDURE-POINTER.
+       01 SAY-FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 GROUP2 OCCURS 10 INDEXED BY SAY-INDEX
+                                 PIC X.
+       77 SAY77                  PIC X.
+
+      * should not suggest: not matching, 88
+       01 VAR4                   PIC 9.
+       01 NOTSAY                 PIC 9.
+       01 GROUP3.
+          05 VAR5                PIC X.
+             88 SAY88-YES              VALUE 'Y'.
+             88 SAY88-NO               VALUE 'N'.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           MOVE SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P-SAY-HELLO.
+           DISPLAY "HELlO"
+           .
+      * should not suggest: section
+       S-SAY-CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":30,"character":19}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-VAR1 (Numeric) (SAY-VAR1)",
+    "kind": 6,
+    "insertText": "SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "REDEF-SAY-VAR1 (Numeric) (REDEF-SAY-VAR1)",
+    "kind": 6,
+    "insertText": "REDEF-SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "GROUP1-SAY (Alphanumeric) (GROUP1-SAY)",
+    "kind": 6,
+    "insertText": "GROUP1-SAY",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "VAR2-SAY (Alphanumeric) (GROUP1-SAY::VAR2-SAY)",
+    "kind": 6,
+    "insertText": "GROUP1-SAY::VAR2-SAY",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY66 (?) (GROUP1-SAY::SAY66)",
+    "kind": 6,
+    "insertText": "GROUP1-SAY::SAY66",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "VAR3-SAY-VAR3 (Numeric) (VAR3-SAY-VAR3)",
+    "kind": 6,
+    "insertText": "VAR3-SAY-VAR3",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY-POINTER (Alphanumeric) (SAY-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-POINTER",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY-PROCEDURE-POINTER (Alphanumeric) (SAY-PROCEDURE-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-PROCEDURE-POINTER",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY-FUNCTION-POINTER (Alphanumeric) (SAY-FUNCTION-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-FUNCTION-POINTER",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY-INDEX (Numeric) (GROUP2::SAY-INDEX)",
+    "kind": 6,
+    "insertText": "GROUP2::SAY-INDEX",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY77 (Alphanumeric) (SAY77)",
+    "kind": 6,
+    "insertText": "SAY77",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterMove/NamesUsingUnderscores.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterMove/NamesUsingUnderscores.txt
@@ -1,0 +1,213 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+      * should suggest: matching variables
+       01 SAY_VAR1               PIC 9.
+       01 REDEF_SAY_VAR1 REDEFINES SAY_VAR1
+                                 PIC 9.
+       01 GROUP1_SAY.
+          05 VAR2_SAY            PIC X.
+          66 SAY66 RENAMES VAR2_SAY.
+       01 VAR3_SAY_VAR3          PIC 9.
+       01 SAY_POINTER USAGE POINTER.
+       01 SAY_PROCEDURE-POINTER USAGE PROCEDURE-POINTER.
+       01 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 GROUP2 OCCURS 10 INDEXED BY SAY_INDEX
+                                 PIC X.
+       77 SAY77                  PIC X.
+
+      * should not suggest: not matching, 88
+       01 VAR4                   PIC 9.
+       01 NOTSAY                 PIC 9.
+       01 GROUP3.
+          05 VAR5                PIC X.
+             88 SAY88-YES              VALUE 'Y'.
+             88 SAY88-NO               VALUE 'N'.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           MOVE SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "HELlO"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":30,"character":19}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY_VAR1 (Numeric) (SAY_VAR1)",
+    "kind": 6,
+    "insertText": "SAY_VAR1",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "REDEF_SAY_VAR1 (Numeric) (REDEF_SAY_VAR1)",
+    "kind": 6,
+    "insertText": "REDEF_SAY_VAR1",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "GROUP1_SAY (Alphanumeric) (GROUP1_SAY)",
+    "kind": 6,
+    "insertText": "GROUP1_SAY",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (Alphanumeric) (GROUP1_SAY::VAR2_SAY)",
+    "kind": 6,
+    "insertText": "GROUP1_SAY::VAR2_SAY",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY66 (?) (GROUP1_SAY::SAY66)",
+    "kind": 6,
+    "insertText": "GROUP1_SAY::SAY66",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Numeric) (VAR3_SAY_VAR3)",
+    "kind": 6,
+    "insertText": "VAR3_SAY_VAR3",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY_POINTER (Alphanumeric) (SAY_POINTER)",
+    "kind": 6,
+    "insertText": "SAY_POINTER",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY_PROCEDURE-POINTER (Alphanumeric) (SAY_PROCEDURE-POINTER)",
+    "kind": 6,
+    "insertText": "SAY_PROCEDURE-POINTER",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY_FUNCTION-POINTER (Alphanumeric) (SAY_FUNCTION-POINTER)",
+    "kind": 6,
+    "insertText": "SAY_FUNCTION-POINTER",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY_INDEX (Numeric) (GROUP2::SAY_INDEX)",
+    "kind": 6,
+    "insertText": "GROUP2::SAY_INDEX",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY77 (Alphanumeric) (SAY77)",
+    "kind": 6,
+    "insertText": "SAY77",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 19
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/IfAddress.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/IfAddress.txt
@@ -1,0 +1,142 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables 01/77
+       01 WS-SAY-VAR1              PIC 9.
+       77 WS-SAY-VAR2              PIC 9.
+      * should not suggest: not matching, not 01/77
+       01 WS-VAR3                  PIC 9.
+       66 WS-SAY-RENAME RENAMES WS-VAR3.
+       77 WS-VAR4                  PIC 9.
+       LOCAL-STORAGE SECTION.
+      * should suggest: matching variables 01/77
+       01 LS-SAY-VAR1              PIC 9.
+       77 LS-SAY-VAR2              PIC 9.
+      * should not suggest: not matching, not 01/77
+       01 LS-VAR3                  PIC 9.
+       01 LS-GROUP.
+          05 LS-SAY-VAR3           PIC 9.
+             88 LS-SAY-88-VAL0        VALUE 0.
+             88 LS-SAY-88-VAL1        VALUE 1.
+       77 LS-VAR4                  PIC 9.
+       LINKAGE SECTION.
+      * should suggest: matching variables 01/77
+       01 LK-SAY-VAR1              PIC 9.
+       77 LK-SAY-VAR2              PIC 9.
+      * should not suggest: not matching, not 01/77
+       01 LK-VAR3                  PIC 9.
+       01 LK-GROUP.
+          05 LK-SAY-VAR3           PIC 9.
+       77 LK-VAR4                  PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           IF ADDRESS OF SAY = NULL
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":34,"character":28}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "WS-SAY-VAR1 (Numeric) (WS-SAY-VAR1)",
+    "kind": 6,
+    "insertText": "WS-SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 34,
+        "character": 25
+      },
+      "end": {
+        "line": 34,
+        "character": 28
+      }
+    }
+  },
+  {
+    "label": "WS-SAY-VAR2 (Numeric) (WS-SAY-VAR2)",
+    "kind": 6,
+    "insertText": "WS-SAY-VAR2",
+    "data": {
+      "start": {
+        "line": 34,
+        "character": 25
+      },
+      "end": {
+        "line": 34,
+        "character": 28
+      }
+    }
+  },
+  {
+    "label": "LS-SAY-VAR1 (Numeric) (LS-SAY-VAR1)",
+    "kind": 6,
+    "insertText": "LS-SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 34,
+        "character": 25
+      },
+      "end": {
+        "line": 34,
+        "character": 28
+      }
+    }
+  },
+  {
+    "label": "LS-SAY-VAR2 (Numeric) (LS-SAY-VAR2)",
+    "kind": 6,
+    "insertText": "LS-SAY-VAR2",
+    "data": {
+      "start": {
+        "line": 34,
+        "character": 25
+      },
+      "end": {
+        "line": 34,
+        "character": 28
+      }
+    }
+  },
+  {
+    "label": "LK-SAY-VAR1 (Numeric) (LK-SAY-VAR1)",
+    "kind": 6,
+    "insertText": "LK-SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 34,
+        "character": 25
+      },
+      "end": {
+        "line": 34,
+        "character": 28
+      }
+    }
+  },
+  {
+    "label": "LK-SAY-VAR2 (Numeric) (LK-SAY-VAR2)",
+    "kind": 6,
+    "insertText": "LK-SAY-VAR2",
+    "data": {
+      "start": {
+        "line": 34,
+        "character": 25
+      },
+      "end": {
+        "line": 34,
+        "character": 28
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/Multiple.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/Multiple.txt
@@ -1,0 +1,59 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching parent
+       01 SAY-GROUP1.
+          05 GROUP11.
+             10 GROUP111.
+                15 VAR1         PIC 9.
+      * should suggest but does not (see #2717)
+       01 SAY-GROUP2.
+          05 GROUP11.
+             10 GROUP111.
+                15 VAR1         PIC 9.
+       01 SAY-GROUP3.
+          05 GROUP11.
+             10 GROUP111.
+                15 VAR1         PIC 9.
+      * should not suggest: not matching parent
+       01 GROUP4.
+          05 GROUP44.
+             10 GROUP444.
+          05 VAR1               PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           DISPLAY VAR1 OF GROUP111 OF GROUP11 OF SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":26,"character":53}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-GROUP1 (Alphanumeric) (SAY-GROUP1)",
+    "kind": 6,
+    "insertText": "SAY-GROUP1",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 50
+      },
+      "end": {
+        "line": 26,
+        "character": 53
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/NoResult.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/NoResult.txt
@@ -1,0 +1,31 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest nothing!
+       01 SAY-GROUP1.
+          05 VAR1               PIC 9.
+       01 GROUP2-SAY.
+          05 VAR1               PIC 9.
+       01 GROUP3-SAY-GROUP3.
+          05 VAR1               PIC 9.
+       01 GROUP4.
+          05 VAR1               PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           CALL 'OTHERPGM' USING VALUE LENGTH OF SAY
+           GOBACK
+           .
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":16,"character":52}
+---------------------------------------------------------------------------------
+[]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/SetAddress.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/SetAddress.txt
@@ -1,0 +1,78 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should not suggest: matching variables but not in LINKAGE
+       01 WS-SAY-VAR1     PIC 9.
+       01 WS-SAY-POINTER USAGE POINTER.
+       01 WS-GROUP.
+          05 WS-SAY-VAR2  PIC 9.
+       77 WS-SAY-VAR3     PIC 9.
+       LOCAL-STORAGE SECTION.
+      * should not suggest: matching variables but not in LINKAGE
+       01 LS-SAY-VAR1     PIC 9.
+       01 LS-GROUP.
+          05 LS-SAY-VAR2  PIC 9.
+       77 LS-SAY-VAR3     PIC 9.
+       LINKAGE SECTION.
+      * should suggest: matching variables 01 in LINKAGE
+       01 LK-SAY-VAR1     PIC 9.
+      * should not suggest: not matching, not 01
+       01 LK-VAR3         PIC 9.
+       01 LK-GROUP.
+          05 LK-SAY-VAR3  PIC 9.
+      * should suggest: matching variables 77 in LINKAGE
+       77 LK-SAY-VAR2     PIC 9.
+      * should not suggest: not matching 77 in LINKAGE
+       77 LK-VAR4         PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           SET ADDRESS OF SAY TO WS-SAY-POINTER
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":30,"character":29}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "LK-SAY-VAR1 (Numeric) (LK-SAY-VAR1)",
+    "kind": 6,
+    "insertText": "LK-SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 26
+      },
+      "end": {
+        "line": 30,
+        "character": 29
+      }
+    }
+  },
+  {
+    "label": "LK-SAY-VAR2 (Numeric) (LK-SAY-VAR2)",
+    "kind": 6,
+    "insertText": "LK-SAY-VAR2",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 26
+      },
+      "end": {
+        "line": 30,
+        "character": 29
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/Variable.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/Variable.txt
@@ -1,0 +1,51 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching parent
+       01 SAY-GROUP1.
+          05 VAR1               PIC 9.
+      * should suggest but does not (see #2717)
+       01 GROUP2-SAY.
+          05 VAR1               PIC 9.
+       01 GROUP3-SAY-GROUP3.
+          05 VAR1               PIC 9.
+      * should not suggest: not matching parent
+       01 GROUP4.
+          05 VAR1               PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           DISPLAY VAR1 OF SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":18,"character":30}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-GROUP1 (Alphanumeric) (SAY-GROUP1)",
+    "kind": 6,
+    "insertText": "SAY-GROUP1",
+    "data": {
+      "start": {
+        "line": 18,
+        "character": 27
+      },
+      "end": {
+        "line": 18,
+        "character": 30
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterPerform/NamesUsingHyphens.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterPerform/NamesUsingHyphens.txt
@@ -1,0 +1,207 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should be suggested
+       01 say-var1      PIC 9.
+       01 var2-say      PIC 9.
+       01 var3-say-var3 PIC 9.
+      * should not (does not contain 'say', not numeric)
+       01 item-numeric  PIC 9.
+       01 item-text-1   PIC X.
+       01 item-text-2   PIC X.
+       PROCEDURE DIVISION.
+       main.
+           PERFORM say
+           GOBACK
+           .
+       s1-say-hello-world SECTION.
+       p1-say-hello.
+           DISPLAY "hello"
+           .
+       p2-say-world.
+           DISPLAY "world"
+           .
+       s2-say-goodbye-end SECTION.
+       p1-say-goodbye.
+           DISPLAY "goodbye"
+           .
+       p2-say-end.
+           DISPLAY "end of PGM"
+           .
+       say-something.
+           DISPLAY "something"
+           .
+       say-nothing SECTION.
+           CONTINUE
+           .
+       do-something SECTION.
+       one-way.
+           MOVE item-text-1 TO item-text-2
+           .
+       and-the-other.
+           MOVE item-text-2 TO item-text-1
+           .
+       END PROGRAM TCOMFL06.
+---------------------------------------------------------------------------------
+{"line":14,"character":22}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "p1-say-hello",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "p2-say-world",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "p1-say-goodbye",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "p2-say-end",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "say-something",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "s1-say-hello-world",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "s2-say-goodbye-end",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "say-nothing",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "say-var1 PIC9",
+    "kind": 6,
+    "insertText": "say-var1",
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "var2-say PIC9",
+    "kind": 6,
+    "insertText": "var2-say",
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "var3-say-var3 PIC9",
+    "kind": 6,
+    "insertText": "var3-say-var3",
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterPerform/NamesUsingUnderscores.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterPerform/NamesUsingUnderscores.txt
@@ -1,0 +1,207 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should be suggested
+       01 say_var1      PIC 9.
+       01 var2_say      PIC 9.
+       01 var3_say_var3 PIC 9.
+      * should not (does not contain 'say', not numeric)
+       01 item_numeric  PIC 9.
+       01 item_text_1   PIC X.
+       01 item_text_2   PIC X.
+       PROCEDURE DIVISION.
+       main.
+           PERFORM say
+           GOBACK
+           .
+       s1_say_hello_world SECTION.
+       p1_say_hello.
+           DISPLAY "hello"
+           .
+       p2_say_world.
+           DISPLAY "world"
+           .
+       s2_say_goodbye_end SECTION.
+       p1_say_goodbye.
+           DISPLAY "goodbye"
+           .
+       p2_say_end.
+           DISPLAY "end of PGM"
+           .
+       say_something.
+           DISPLAY "something"
+           .
+       say_nothing SECTION.
+           CONTINUE
+           .
+       do_something SECTION.
+       one_way.
+           MOVE item-text-1 TO item-text-2
+           .
+       and_the_other.
+           MOVE item-text-2 TO item-text-1
+           .
+       END PROGRAM TCOMFL06.
+---------------------------------------------------------------------------------
+{"line":14,"character":22}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "p1_say_hello",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "p2_say_world",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "p1_say_goodbye",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "p2_say_end",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "say_something",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "s1_say_hello_world",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "s2_say_goodbye_end",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "say_nothing",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "say_var1 PIC9",
+    "kind": 6,
+    "insertText": "say_var1",
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "var2_say PIC9",
+    "kind": 6,
+    "insertText": "var2_say",
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "var3_say_var3 PIC9",
+    "kind": 6,
+    "insertText": "var3_say_var3",
+    "data": {
+      "start": {
+        "line": 14,
+        "character": 19
+      },
+      "end": {
+        "line": 14,
+        "character": 22
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterSet/NamesUsingHyphens.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterSet/NamesUsingHyphens.txt
@@ -1,0 +1,162 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables + numeric and valid usage
+       01 SAY-VAR1              PIC 9.
+       01 GROUP1.
+          05 VAR2-SAY           PIC 99.
+       01 VAR3-SAY-VAR3         PIC 9(2).
+       01 SAY-POINTER USAGE POINTER.
+       01 SAY-POINTER-32 USAGE POINTER-32.
+       01 GROUP2.
+          05 VAR4               PIC 9.
+             88 SAY88-YES              VALUE 1.
+             88 SAY88-NO               VALUE 0.
+       01 GROUP2 OCCURS 10 INDEXED BY SAY-INDEX
+                                PIC X.
+      * should not suggest: not matching, not numeric, invalid usage
+       01 VAR5                  PIC 9.
+       01 VAR6-SAY              PIC X.
+       01 SAY-FUNCTION-POINTER USAGE FUNCTION-POINTER.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           SET SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P-SAY-HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S-SAY-CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":24,"character":18}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-VAR1 (Numeric) (SAY-VAR1)",
+    "kind": 6,
+    "insertText": "SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "VAR2-SAY (Numeric) (GROUP1::VAR2-SAY)",
+    "kind": 6,
+    "insertText": "GROUP1::VAR2-SAY",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "VAR3-SAY-VAR3 (Numeric) (VAR3-SAY-VAR3)",
+    "kind": 6,
+    "insertText": "VAR3-SAY-VAR3",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY-POINTER (Alphanumeric) (SAY-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-POINTER",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY-POINTER-32 (Alphanumeric) (SAY-POINTER-32)",
+    "kind": 6,
+    "insertText": "SAY-POINTER-32",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY88-YES (Level88) (GROUP2::VAR4::SAY88-YES)",
+    "kind": 6,
+    "insertText": "GROUP2::VAR4::SAY88-YES",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY88-NO (Level88) (GROUP2::VAR4::SAY88-NO)",
+    "kind": 6,
+    "insertText": "GROUP2::VAR4::SAY88-NO",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY-INDEX (Numeric) (GROUP2::SAY-INDEX)",
+    "kind": 6,
+    "insertText": "GROUP2::SAY-INDEX",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterSet/NamesUsingUnderscores.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterSet/NamesUsingUnderscores.txt
@@ -1,0 +1,162 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables + numeric and valid usage
+       01 SAY_VAR1              PIC 9.
+       01 GROUP1.
+          05 VAR2_SAY           PIC 99.
+       01 VAR3_SAY_VAR3         PIC 9(2).
+       01 SAY_POINTER USAGE POINTER.
+       01 SAY_POINTER-32 USAGE POINTER-32.
+       01 GROUP2.
+          05 VAR4               PIC 9.
+             88 SAY88-YES              VALUE 1.
+             88 SAY88-NO               VALUE 0.
+       01 GROUP2 OCCURS 10 INDEXED BY SAY_INDEX
+                                PIC X.
+      * should not suggest: not matching, not numeric, invalid usage
+       01 VAR5                  PIC 9.
+       01 VAR6_SAY              PIC X.
+       01 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           SET SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":24,"character":18}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY_VAR1 (Numeric) (SAY_VAR1)",
+    "kind": 6,
+    "insertText": "SAY_VAR1",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (Numeric) (GROUP1::VAR2_SAY)",
+    "kind": 6,
+    "insertText": "GROUP1::VAR2_SAY",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Numeric) (VAR3_SAY_VAR3)",
+    "kind": 6,
+    "insertText": "VAR3_SAY_VAR3",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY_POINTER (Alphanumeric) (SAY_POINTER)",
+    "kind": 6,
+    "insertText": "SAY_POINTER",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY_POINTER-32 (Alphanumeric) (SAY_POINTER-32)",
+    "kind": 6,
+    "insertText": "SAY_POINTER-32",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY88-YES (Level88) (GROUP2::VAR4::SAY88-YES)",
+    "kind": 6,
+    "insertText": "GROUP2::VAR4::SAY88-YES",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY88-NO (Level88) (GROUP2::VAR4::SAY88-NO)",
+    "kind": 6,
+    "insertText": "GROUP2::VAR4::SAY88-NO",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY_INDEX (Numeric) (GROUP2::SAY_INDEX)",
+    "kind": 6,
+    "insertText": "GROUP2::SAY_INDEX",
+    "data": {
+      "start": {
+        "line": 24,
+        "character": 15
+      },
+      "end": {
+        "line": 24,
+        "character": 18
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/AddLiteral.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/AddLiteral.txt
@@ -1,0 +1,195 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables and literal type
+       01 SAY-VAR1              PIC 9.
+       01 VAR2-SAY              PIC 99.
+       01 VAR3-SAY-VAR3         PIC 9(2).
+       01 SAY-POINTER USAGE POINTER.
+       01 SAY-POINTER-32 USAGE POINTER-32.
+       01 VAR4-SAY              PIC X.
+       01 GROUP1 OCCURS 10 INDEXED BY SAY-INDEX
+                                PIC X.
+       01 SAY-FUNCTION-POINTER USAGE FUNCTION-POINTER.
+      * should not suggest (not literal type) but does
+       01 VAR5-SAY              PIC X.
+       01 GROUP2-SAY.
+          05 VAR6               PIC 9
+      * should not suggest: not matching, 88
+       01 VAR7SAY               PIC 9.
+       01 GROUP3.
+          05 VAR8               PIC 9.
+             88 SAY88-YES              VALUE 1.
+             88 SAY88-NO               VALUE 0.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           ADD 1 TO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P-SAY-HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S-SAY-CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":27,"character":23}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-VAR1 (Numeric) (SAY-VAR1)",
+    "kind": 6,
+    "insertText": "SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 20
+      },
+      "end": {
+        "line": 27,
+        "character": 23
+      }
+    }
+  },
+  {
+    "label": "VAR2-SAY (Numeric) (VAR2-SAY)",
+    "kind": 6,
+    "insertText": "VAR2-SAY",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 20
+      },
+      "end": {
+        "line": 27,
+        "character": 23
+      }
+    }
+  },
+  {
+    "label": "VAR3-SAY-VAR3 (Numeric) (VAR3-SAY-VAR3)",
+    "kind": 6,
+    "insertText": "VAR3-SAY-VAR3",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 20
+      },
+      "end": {
+        "line": 27,
+        "character": 23
+      }
+    }
+  },
+  {
+    "label": "SAY-POINTER (Alphanumeric) (SAY-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-POINTER",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 20
+      },
+      "end": {
+        "line": 27,
+        "character": 23
+      }
+    }
+  },
+  {
+    "label": "SAY-POINTER-32 (Alphanumeric) (SAY-POINTER-32)",
+    "kind": 6,
+    "insertText": "SAY-POINTER-32",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 20
+      },
+      "end": {
+        "line": 27,
+        "character": 23
+      }
+    }
+  },
+  {
+    "label": "VAR4-SAY (Alphanumeric) (VAR4-SAY)",
+    "kind": 6,
+    "insertText": "VAR4-SAY",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 20
+      },
+      "end": {
+        "line": 27,
+        "character": 23
+      }
+    }
+  },
+  {
+    "label": "SAY-INDEX (Numeric) (GROUP1::SAY-INDEX)",
+    "kind": 6,
+    "insertText": "GROUP1::SAY-INDEX",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 20
+      },
+      "end": {
+        "line": 27,
+        "character": 23
+      }
+    }
+  },
+  {
+    "label": "SAY-FUNCTION-POINTER (Alphanumeric) (SAY-FUNCTION-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-FUNCTION-POINTER",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 20
+      },
+      "end": {
+        "line": 27,
+        "character": 23
+      }
+    }
+  },
+  {
+    "label": "VAR5-SAY (Alphanumeric) (VAR5-SAY)",
+    "kind": 6,
+    "insertText": "VAR5-SAY",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 20
+      },
+      "end": {
+        "line": 27,
+        "character": 23
+      }
+    }
+  },
+  {
+    "label": "GROUP2-SAY (Alphanumeric) (GROUP2-SAY)",
+    "kind": 6,
+    "insertText": "GROUP2-SAY",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 20
+      },
+      "end": {
+        "line": 27,
+        "character": 23
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/AddVariable.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/AddVariable.txt
@@ -1,0 +1,104 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables and sender type
+       01 SAY_VAR1              PIC 9.
+       01 GROUP1.
+          05 VAR2_SAY           PIC 99.
+       01 VAR3_SAY_VAR3         PIC 9(2).
+       01 GROUP2 OCCURS 10 INDEXED BY SAY_INDEX
+                                PIC X.
+      * should not suggest: not matching variables, 88, not sender type
+       01 VAR5                  PIC 9.
+       01 VAR6SAY               PIC 9.
+       01 GROUP3.
+          05 VAR7               PIC 9.
+             88 SAY88-YES              VALUE 1.
+             88 SAY88-NO               VALUE 0.
+       01 SAY_POINTER USAGE POINTER.
+       01 SAY_POINTER-32 USAGE POINTER-32.
+       01 VAR4_SAY              PIC X.
+       01 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 SAY_SENDER            PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           ADD SAY_SENDER TO SAY
+           GOBACK
+           .
+      * should not suggest (paragraph)
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest (section)
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":26,"character":32}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY_VAR1 (Numeric) (SAY_VAR1)",
+    "kind": 6,
+    "insertText": "SAY_VAR1",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 29
+      },
+      "end": {
+        "line": 26,
+        "character": 32
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (Numeric) (GROUP1::VAR2_SAY)",
+    "kind": 6,
+    "insertText": "GROUP1::VAR2_SAY",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 29
+      },
+      "end": {
+        "line": 26,
+        "character": 32
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Numeric) (VAR3_SAY_VAR3)",
+    "kind": 6,
+    "insertText": "VAR3_SAY_VAR3",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 29
+      },
+      "end": {
+        "line": 26,
+        "character": 32
+      }
+    }
+  },
+  {
+    "label": "SAY_INDEX (Numeric) (GROUP2::SAY_INDEX)",
+    "kind": 6,
+    "insertText": "GROUP2::SAY_INDEX",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 29
+      },
+      "end": {
+        "line": 26,
+        "character": 32
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/Inspect.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/Inspect.txt
@@ -1,0 +1,104 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables and sender type
+       01 SAY_VAR1              PIC 9.
+       01 GROUP1.
+          05 VAR2_SAY           PIC 99.
+       01 VAR3_SAY_VAR3         PIC 9(2).
+       01 GROUP2 OCCURS 10 INDEXED BY SAY_INDEX
+                                PIC X.
+      * should not suggest: not matching variables, 88, not sender type
+       01 VAR5                  PIC 9.
+       01 VAR6SAY               PIC 9.
+       01 GROUP3.
+          05 VAR7               PIC 9.
+             88 SAY88-YES              VALUE 1.
+             88 SAY88-NO               VALUE 0.
+       01 SAY_POINTER USAGE POINTER.
+       01 SAY_POINTER-32 USAGE POINTER-32.
+       01 VAR4_SAY              PIC X.
+       01 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 SAY_SENDER            PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           INSPECT VAR5 CONVERTING SAY_SENDER TO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":26,"character":52}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY_VAR1 (Numeric) (SAY_VAR1)",
+    "kind": 6,
+    "insertText": "SAY_VAR1",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 49
+      },
+      "end": {
+        "line": 26,
+        "character": 52
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (Numeric) (GROUP1::VAR2_SAY)",
+    "kind": 6,
+    "insertText": "GROUP1::VAR2_SAY",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 49
+      },
+      "end": {
+        "line": 26,
+        "character": 52
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Numeric) (VAR3_SAY_VAR3)",
+    "kind": 6,
+    "insertText": "VAR3_SAY_VAR3",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 49
+      },
+      "end": {
+        "line": 26,
+        "character": 52
+      }
+    }
+  },
+  {
+    "label": "SAY_INDEX (Numeric) (GROUP2::SAY_INDEX)",
+    "kind": 6,
+    "insertText": "GROUP2::SAY_INDEX",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 49
+      },
+      "end": {
+        "line": 26,
+        "character": 52
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/MoveLiteral.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/MoveLiteral.txt
@@ -1,0 +1,103 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables and literal type
+       01 SAY-VAR1              PIC 9.
+       01 GROUP1.
+          05 VAR2-SAY           PIC 99.
+       01 VAR3-SAY-VAR3         PIC 9(2).
+       01 GROUP2 OCCURS 10 INDEXED BY SAY-INDEX
+                                PIC X.
+      * should not suggest: not matching, not literal type, 88
+       01 VAR5                  PIC 9.
+       01 VAR6SAY               PIC 9.
+       01 SAY-FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 SAY-POINTER USAGE POINTER.
+       01 VAR7-SAY              PIC X.
+       01 VAR8-SAY              PIC N.
+       01 GROUP3.
+          05 VAR9               PIC 9.
+             88 SAY88-YES              VALUE 1.
+             88 SAY88-NO               VALUE 0.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           MOVE 1 TO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P-SAY-HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S-SAY-CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":25,"character":24}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-VAR1 (Numeric) (SAY-VAR1)",
+    "kind": 6,
+    "insertText": "SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 21
+      },
+      "end": {
+        "line": 25,
+        "character": 24
+      }
+    }
+  },
+  {
+    "label": "VAR2-SAY (Numeric) (GROUP1::VAR2-SAY)",
+    "kind": 6,
+    "insertText": "GROUP1::VAR2-SAY",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 21
+      },
+      "end": {
+        "line": 25,
+        "character": 24
+      }
+    }
+  },
+  {
+    "label": "VAR3-SAY-VAR3 (Numeric) (VAR3-SAY-VAR3)",
+    "kind": 6,
+    "insertText": "VAR3-SAY-VAR3",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 21
+      },
+      "end": {
+        "line": 25,
+        "character": 24
+      }
+    }
+  },
+  {
+    "label": "SAY-INDEX (Numeric) (GROUP2::SAY-INDEX)",
+    "kind": 6,
+    "insertText": "GROUP2::SAY-INDEX",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 21
+      },
+      "end": {
+        "line": 25,
+        "character": 24
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/MoveSpaces.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/MoveSpaces.txt
@@ -1,0 +1,133 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables and SPACES type
+       01 SAY-VAR1              PIC x.
+       01 GROUP1-SAY.
+          05 VAR2-SAY           PIC AA.
+       01 VAR3-SAY-VAR3         PIC X(2).
+       01 SAY-FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 SAY-POINTER USAGE POINTER.
+      * should not suggest: not matching variables, not SPACES type, 88
+       01 VAR5                  PIC X.
+       01 VAR6SAY               PIC A.
+       01 GROUP2 OCCURS 10 INDEXED BY SAY-INDEX
+                                PIC X.
+       01 VAR7-SAY              PIC 9.
+       01 VAR8-SAY              PIC N.
+       01 GROUP3.
+          05 VAR9               PIC 9.
+             88 SAY88-YES              VALUE 1.
+             88 SAY88-NO               VALUE 0.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           MOVE SPACES TO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P-SAY-HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S-SAY-CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":25,"character":29}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-VAR1 (Alphanumeric) (SAY-VAR1)",
+    "kind": 6,
+    "insertText": "SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 26
+      },
+      "end": {
+        "line": 25,
+        "character": 29
+      }
+    }
+  },
+  {
+    "label": "GROUP1-SAY (Alphanumeric) (GROUP1-SAY)",
+    "kind": 6,
+    "insertText": "GROUP1-SAY",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 26
+      },
+      "end": {
+        "line": 25,
+        "character": 29
+      }
+    }
+  },
+  {
+    "label": "VAR3-SAY-VAR3 (Alphanumeric) (VAR3-SAY-VAR3)",
+    "kind": 6,
+    "insertText": "VAR3-SAY-VAR3",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 26
+      },
+      "end": {
+        "line": 25,
+        "character": 29
+      }
+    }
+  },
+  {
+    "label": "SAY-FUNCTION-POINTER (Alphanumeric) (SAY-FUNCTION-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-FUNCTION-POINTER",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 26
+      },
+      "end": {
+        "line": 25,
+        "character": 29
+      }
+    }
+  },
+  {
+    "label": "SAY-POINTER (Alphanumeric) (SAY-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-POINTER",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 26
+      },
+      "end": {
+        "line": 25,
+        "character": 29
+      }
+    }
+  },
+  {
+    "label": "VAR2-SAY (Alphabetic) (GROUP1-SAY::VAR2-SAY)",
+    "kind": 6,
+    "insertText": "GROUP1-SAY::VAR2-SAY",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 26
+      },
+      "end": {
+        "line": 25,
+        "character": 29
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/MoveVariable.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/MoveVariable.txt
@@ -1,0 +1,104 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables and sender type
+       01 SAY_VAR1              PIC 9.
+       01 GROUP1.
+          05 VAR2_SAY           PIC 99.
+       01 VAR3_SAY_VAR3         PIC 9(2).
+       01 GROUP2 OCCURS 10 INDEXED BY SAY_INDEX
+                                PIC X.
+      * should not suggest: not matching variables, 88, sender type
+       01 VAR5                  PIC 9.
+       01 VAR6SAY               PIC 9.
+       01 GROUP3.
+          05 VAR7               PIC 9.
+             88 SAY88-YES              VALUE 1.
+             88 SAY88-NO               VALUE 0.
+       01 SAY_POINTER USAGE POINTER.
+       01 SAY_POINTER-32 USAGE POINTER-32.
+       01 VAR4_SAY              PIC X.
+       01 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 SAY_SENDER            PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           MOVE SAY_SENDER TO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":26,"character":33}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY_VAR1 (Numeric) (SAY_VAR1)",
+    "kind": 6,
+    "insertText": "SAY_VAR1",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 30
+      },
+      "end": {
+        "line": 26,
+        "character": 33
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (Numeric) (GROUP1::VAR2_SAY)",
+    "kind": 6,
+    "insertText": "GROUP1::VAR2_SAY",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 30
+      },
+      "end": {
+        "line": 26,
+        "character": 33
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Numeric) (VAR3_SAY_VAR3)",
+    "kind": 6,
+    "insertText": "VAR3_SAY_VAR3",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 30
+      },
+      "end": {
+        "line": 26,
+        "character": 33
+      }
+    }
+  },
+  {
+    "label": "SAY_INDEX (Numeric) (GROUP2::SAY_INDEX)",
+    "kind": 6,
+    "insertText": "GROUP2::SAY_INDEX",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 30
+      },
+      "end": {
+        "line": 26,
+        "character": 33
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/MoveZero.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/MoveZero.txt
@@ -1,0 +1,163 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables and ZERO type
+       01 SAY-VAR1              PIC x.
+       01 GROUP1-SAY.
+          05 VAR2-SAY           PIC AA.
+       01 VAR3-SAY-VAR3         PIC X(2).
+       01 VAR4-SAY              PIC 9.
+       01 GROUP2 OCCURS 10 INDEXED BY SAY-INDEX
+                                PIC X.
+       01 SAY-FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 SAY-POINTER USAGE POINTER.
+      * should not suggest: not matching variables, not ZERO type, 88
+       01 VAR5                  PIC X.
+       01 VAR6SAY               PIC A.
+       01 VAR7-SAY              PIC N.
+       01 GROUP3.
+          05 VAR8               PIC 9.
+             88 SAY88-YES              VALUE 1.
+             88 SAY88-NO               VALUE 0.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           MOVE ZERO TO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P-SAY-HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S-SAY-CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":25,"character":27}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "VAR4-SAY (Numeric) (VAR4-SAY)",
+    "kind": 6,
+    "insertText": "VAR4-SAY",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 24
+      },
+      "end": {
+        "line": 25,
+        "character": 27
+      }
+    }
+  },
+  {
+    "label": "SAY-INDEX (Numeric) (GROUP2::SAY-INDEX)",
+    "kind": 6,
+    "insertText": "GROUP2::SAY-INDEX",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 24
+      },
+      "end": {
+        "line": 25,
+        "character": 27
+      }
+    }
+  },
+  {
+    "label": "SAY-VAR1 (Alphanumeric) (SAY-VAR1)",
+    "kind": 6,
+    "insertText": "SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 24
+      },
+      "end": {
+        "line": 25,
+        "character": 27
+      }
+    }
+  },
+  {
+    "label": "GROUP1-SAY (Alphanumeric) (GROUP1-SAY)",
+    "kind": 6,
+    "insertText": "GROUP1-SAY",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 24
+      },
+      "end": {
+        "line": 25,
+        "character": 27
+      }
+    }
+  },
+  {
+    "label": "VAR3-SAY-VAR3 (Alphanumeric) (VAR3-SAY-VAR3)",
+    "kind": 6,
+    "insertText": "VAR3-SAY-VAR3",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 24
+      },
+      "end": {
+        "line": 25,
+        "character": 27
+      }
+    }
+  },
+  {
+    "label": "SAY-FUNCTION-POINTER (Alphanumeric) (SAY-FUNCTION-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-FUNCTION-POINTER",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 24
+      },
+      "end": {
+        "line": 25,
+        "character": 27
+      }
+    }
+  },
+  {
+    "label": "SAY-POINTER (Alphanumeric) (SAY-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-POINTER",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 24
+      },
+      "end": {
+        "line": 25,
+        "character": 27
+      }
+    }
+  },
+  {
+    "label": "VAR2-SAY (Alphabetic) (GROUP1-SAY::VAR2-SAY)",
+    "kind": 6,
+    "insertText": "GROUP1-SAY::VAR2-SAY",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 24
+      },
+      "end": {
+        "line": 25,
+        "character": 27
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/Set.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/Set.txt
@@ -1,0 +1,104 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables and sender type
+       01 SAY_VAR1              PIC 9.
+       01 GROUP1.
+          05 VAR2_SAY           PIC 99.
+       01 VAR3_SAY_VAR3         PIC 9(2).
+       01 GROUP2 OCCURS 10 INDEXED BY SAY_INDEX
+                                PIC X.
+      * should not suggest: not matching variables, 88, not sender type
+       01 VAR5                  PIC 9.
+       01 VAR6SAY               PIC 9.
+       01 GROUP3.
+          05 VAR7               PIC 9.
+             88 SAY88-YES              VALUE 1.
+             88 SAY88-NO               VALUE 0.
+       01 SAY_POINTER USAGE POINTER.
+       01 SAY_POINTER-32 USAGE POINTER-32.
+       01 VAR4_SAY              PIC X.
+       01 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 SAY_SENDER            PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           SET SAY_SENDER TO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":26,"character":32}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY_VAR1 (Numeric) (SAY_VAR1)",
+    "kind": 6,
+    "insertText": "SAY_VAR1",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 29
+      },
+      "end": {
+        "line": 26,
+        "character": 32
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (Numeric) (GROUP1::VAR2_SAY)",
+    "kind": 6,
+    "insertText": "GROUP1::VAR2_SAY",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 29
+      },
+      "end": {
+        "line": 26,
+        "character": 32
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Numeric) (VAR3_SAY_VAR3)",
+    "kind": 6,
+    "insertText": "VAR3_SAY_VAR3",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 29
+      },
+      "end": {
+        "line": 26,
+        "character": 32
+      }
+    }
+  },
+  {
+    "label": "SAY_INDEX (Numeric) (GROUP2::SAY_INDEX)",
+    "kind": 6,
+    "insertText": "GROUP2::SAY_INDEX",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 29
+      },
+      "end": {
+        "line": 26,
+        "character": 32
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/SetNothingAfterTo.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/SetNothingAfterTo.txt
@@ -1,0 +1,62 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables and sender type
+       01 VAR1                  PIC 9.
+       01 GROUP1.
+          05 VAR2               PIC 99.
+       01 VAR3                  PIC 9(2).
+       01 GROUP2 OCCURS 10 INDEXED BY VAR_INDEX
+                                PIC X.
+      * should not suggest: not matching variables, 88, not sender type
+       01 GROUP3.
+          05 VAR4               PIC X.
+             88 VAR88-YES              VALUE 1.
+             88 VAR88-NO               VALUE 0.
+       01 SAY_POINTER USAGE POINTER.
+       01 SAY_POINTER-32 USAGE POINTER-32.
+       01 VAR5                  PIC X.
+       01 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 SENDER                PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           SET SENDER TO 
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":24,"character":25}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "VAR1 (Numeric) (VAR1)",
+    "kind": 6,
+    "insertText": "VAR1"
+  },
+  {
+    "label": "VAR2 (Numeric) (GROUP1::VAR2)",
+    "kind": 6,
+    "insertText": "GROUP1::VAR2"
+  },
+  {
+    "label": "VAR3 (Numeric) (VAR3)",
+    "kind": 6,
+    "insertText": "VAR3"
+  },
+  {
+    "label": "VAR_INDEX (Numeric) (GROUP2::VAR_INDEX)",
+    "kind": 6,
+    "insertText": "GROUP2::VAR_INDEX"
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/SetOf.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/SetOf.txt
@@ -1,0 +1,65 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching variables and sender type
+       01 VAR1                  PIC 9.
+       01 GROUP1.
+          05 VAR2               PIC 99.
+       01 VAR3                  PIC 9(2).
+       01 GROUP2 OCCURS 10 INDEXED BY VAR_INDEX
+                                PIC X.
+      * should not suggest: not matching variables, 88, not sender type
+       01 GROUP3.
+          05 VAR4               PIC X.
+             88 VAR88-YES              VALUE 1.
+             88 VAR88-NO               VALUE 0.
+       01 SAY_POINTER USAGE POINTER.
+       01 SAY_POINTER-32 USAGE POINTER-32.
+       01 VAR5                  PIC X.
+       01 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+       01 GROUP4.
+          05 SENDER                PIC 9.
+       01 GROUP5.
+          05 SENDER                PIC X.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           SET SENDER OF GROUP4 TO 
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":27,"character":35}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "VAR1 (Numeric) (VAR1)",
+    "kind": 6,
+    "insertText": "VAR1"
+  },
+  {
+    "label": "VAR2 (Numeric) (GROUP1::VAR2)",
+    "kind": 6,
+    "insertText": "GROUP1::VAR2"
+  },
+  {
+    "label": "VAR3 (Numeric) (VAR3)",
+    "kind": 6,
+    "insertText": "VAR3"
+  },
+  {
+    "label": "VAR_INDEX (Numeric) (GROUP2::VAR_INDEX)",
+    "kind": 6,
+    "insertText": "GROUP2::VAR_INDEX"
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/CompletionProcessorTest.cs
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/CompletionProcessorTest.cs
@@ -31,7 +31,8 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
 
             // Parse test data file
             var folder = PlatformUtils.GetPathForProjectFile(RELATIVE_PATH, Path.GetFullPath(ROOT_PATH));
-            var testDataFilePath = $"{Path.Combine(folder, sourceFileName)}.txt";
+            var sourceFilePath = Path.Combine(sourceFileName.Split('_'));
+            var testDataFilePath = $"{Path.Combine(folder, sourceFilePath)}.txt";
             var testData = LanguageServerTestUtils.ParseMultiplePartsContent(testDataFilePath);
             Debug.Assert(testData.Count == 3);
             string cobolString = testData[0];
@@ -54,7 +55,7 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
             var completionItems = _processor.ComputeProposals(compilationUnit, position);
             string actualProposals = JToken.FromObject(completionItems, new JsonSerializer() { NullValueHandling = NullValueHandling.Ignore })
                 .ToString(Formatting.Indented)
-                + Environment.NewLine;
+            + Environment.NewLine;
 
             // Compare to expected
             TestUtils.CompareContent(sourceFileName, actualProposals, expectedProposals);
@@ -65,5 +66,86 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
 
         [TestMethod]
         public void CompletionAfterUnsupportedKeyword() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterCall_WithoutUserFilterText() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterCall_WithUserFilterText() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterDisplay_NamesUsingHyphens() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterDisplay_NamesUsingUnderscores() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterInto_String() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterInto_Unstring() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterMove_NamesUsingHyphens() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterMove_NamesUsingUnderscores() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterOf_IfAddress() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterOf_Multiple() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterOf_NoResult() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterOf_SetAddress() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterOf_Variable() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterPerform_NamesUsingHyphens() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterPerform_NamesUsingUnderscores() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterSet_NamesUsingHyphens() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterSet_NamesUsingUnderscores() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_AddLiteral() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_AddVariable() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_Inspect() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_MoveLiteral() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_MoveSpaces() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_MoveVariable() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_MoveZero() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_Set() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_SetNothingAfterTo() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_SetOf() => ExecuteTest();
     }
 }

--- a/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/CommentLines/IndexFromPreviousGeneration.cbl
+++ b/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/CommentLines/IndexFromPreviousGeneration.cbl
@@ -1,0 +1,76 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER.
+           IBM-370 WITH DEBUGGING MODE.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 group1.
+          05 tab1 OCCURS 10.
+             10 var1 PIC X.
+      *<DBG> Another index from previous generation
+      D77 Idx-a1b2c3d4-1 PIC 9(4) COMP-5.
+      *</DBG>
+       PROCEDURE DIVISION.
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.
+-------------------------------------------------------------------------------------------------
+TypeCobol.LanguageServer.Commands.InsertVariableDisplay.InsertVariableDisplayRefactoringProcessor
+-------------------------------------------------------------------------------------------------
+[
+    {
+        "textDocument": { "uri": "file:/test.expected.cbl" },
+        "position": { "line": 14, "character": 26 }
+    },
+    false,
+    {
+        "vm": 1, "idx": 0, "ch": [
+            {
+                "vm": 1, "name": "group1", "ch": [
+                    {
+                        "vm": 1, "name": "tab1", "ch": [
+                            {
+                                "vm": 0, "name": "var1"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]
+-------------------------------------------------------------------------------------------------
+refactoring.label=Debug instructions successfully generated.
+refactoring.source=
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER.
+           IBM-370 WITH DEBUGGING MODE.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 group1.
+          05 tab1 OCCURS 10.
+             10 var1 PIC X.
+      *<DBG> Another index from previous generation
+      D77 Idx-a1b2c3d4-1 PIC 9(4) COMP-5.
+      *</DBG>
+      *<DBG>InsertVariableDisplay 1959/09/18 11:09 TESTUSER
+      D77 Idx-d4df4249-1 PIC 9(4) COMP-5.
+      *</DBG>
+
+       PROCEDURE DIVISION.
+      *<DBG>InsertVariableDisplay 1959/09/18 11:09 TESTUSER
+      D    PERFORM VARYING Idx-d4df4249-1 FROM 1 BY 1 UNTIL
+      D    Idx-d4df4249-1 > 10
+      D      DISPLAY '    var1 (' Idx-d4df4249-1 ') <' var1
+      D      (Idx-d4df4249-1) '>'
+      D    END-PERFORM
+      *</DBG>
+
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.

--- a/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/CommentLines/InsertAfterStatementFollowedByMultipleComments.cbl
+++ b/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/CommentLines/InsertAfterStatementFollowedByMultipleComments.cbl
@@ -1,0 +1,50 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 PIC X.
+       PROCEDURE DIVISION.
+           DISPLAY "This statement is followed by comments"
+      * First line of comments
+      * Second line of comments
+      * Third line of comments
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.
+-------------------------------------------------------------------------------------------------
+TypeCobol.LanguageServer.Commands.InsertVariableDisplay.InsertVariableDisplayRefactoringProcessor
+-------------------------------------------------------------------------------------------------
+[
+    {
+        "textDocument": { "uri": "file:/test.expected.cbl" },
+        "position": { "line": 6, "character": 18 }
+    },
+    false,
+    {
+        "vm": 1, "idx": 0, "ch": [
+            {
+                "vm": 0, "name": "var1"
+            }
+        ]
+    }
+]
+-------------------------------------------------------------------------------------------------
+refactoring.label=Debug instructions successfully generated.
+refactoring.source=
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 PIC X.
+       PROCEDURE DIVISION.
+           DISPLAY "This statement is followed by comments"
+      * First line of comments
+      * Second line of comments
+      * Third line of comments
+      *<DBG>InsertVariableDisplay 1959/09/18 11:09 TESTUSER
+      D    DISPLAY 'var1 <' var1 '>'
+      *</DBG>
+
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.

--- a/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/CommentLines/InsertAfterStatementFollowedByMultipleCommentsEndOfDocument.cbl
+++ b/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/CommentLines/InsertAfterStatementFollowedByMultipleCommentsEndOfDocument.cbl
@@ -1,0 +1,44 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 PIC X.
+       PROCEDURE DIVISION.
+           DISPLAY "This statement is followed by comments"
+      * First line of comments
+      * Second line of comments
+      * Third line of comments
+-------------------------------------------------------------------------------------------------
+TypeCobol.LanguageServer.Commands.InsertVariableDisplay.InsertVariableDisplayRefactoringProcessor
+-------------------------------------------------------------------------------------------------
+[
+    {
+        "textDocument": { "uri": "file:/test.expected.cbl" },
+        "position": { "line": 6, "character": 18 }
+    },
+    false,
+    {
+        "vm": 1, "idx": 0, "ch": [
+            {
+                "vm": 0, "name": "var1"
+            }
+        ]
+    }
+]
+-------------------------------------------------------------------------------------------------
+refactoring.label=Debug instructions successfully generated.
+refactoring.source=
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 PIC X.
+       PROCEDURE DIVISION.
+           DISPLAY "This statement is followed by comments"
+      * First line of comments
+      * Second line of comments
+      * Third line of comments
+      *<DBG>InsertVariableDisplay 1959/09/18 11:09 TESTUSER
+      D    DISPLAY 'var1 <' var1 '>'
+      *</DBG>
+

--- a/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/CommentLines/InsertAfterStatementFollowedByOneComment.cbl
+++ b/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/CommentLines/InsertAfterStatementFollowedByOneComment.cbl
@@ -1,0 +1,46 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 PIC X.
+       PROCEDURE DIVISION.
+           DISPLAY "This statement is followed by a comment"
+      * Line of comments
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.
+-------------------------------------------------------------------------------------------------
+TypeCobol.LanguageServer.Commands.InsertVariableDisplay.InsertVariableDisplayRefactoringProcessor
+-------------------------------------------------------------------------------------------------
+[
+    {
+        "textDocument": { "uri": "file:/test.expected.cbl" },
+        "position": { "line": 6, "character": 18 }
+    },
+    false,
+    {
+        "vm": 1, "idx": 0, "ch": [
+            {
+                "vm": 0, "name": "var1"
+            }
+        ]
+    }
+]
+-------------------------------------------------------------------------------------------------
+refactoring.label=Debug instructions successfully generated.
+refactoring.source=
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 PIC X.
+       PROCEDURE DIVISION.
+           DISPLAY "This statement is followed by a comment"
+      * Line of comments
+      *<DBG>InsertVariableDisplay 1959/09/18 11:09 TESTUSER
+      D    DISPLAY 'var1 <' var1 '>'
+      *</DBG>
+
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.

--- a/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/CommentLines/InsertBeforeStatementPrecededByMultipleComments.cbl
+++ b/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/CommentLines/InsertBeforeStatementPrecededByMultipleComments.cbl
@@ -1,0 +1,50 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 PIC X.
+       PROCEDURE DIVISION.
+      * First line of comments
+      * Second line of comments
+      * Third line of comments
+           DISPLAY "This statement is preceded by comments"
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.
+-------------------------------------------------------------------------------------------------
+TypeCobol.LanguageServer.Commands.InsertVariableDisplay.InsertVariableDisplayRefactoringProcessor
+-------------------------------------------------------------------------------------------------
+[
+    {
+        "textDocument": { "uri": "file:/test.expected.cbl" },
+        "position": { "line": 9, "character": 18 }
+    },
+    true,
+    {
+        "vm": 1, "idx": 0, "ch": [
+            {
+                "vm": 0, "name": "var1"
+            }
+        ]
+    }
+]
+-------------------------------------------------------------------------------------------------
+refactoring.label=Debug instructions successfully generated.
+refactoring.source=
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 PIC X.
+       PROCEDURE DIVISION.
+      *<DBG>InsertVariableDisplay 1959/09/18 11:09 TESTUSER
+      D    DISPLAY 'var1 <' var1 '>'
+      *</DBG>
+
+      * First line of comments
+      * Second line of comments
+      * Third line of comments
+           DISPLAY "This statement is preceded by comments"
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.

--- a/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/CommentLines/InsertBeforeStatementPrecededByOneComment.cbl
+++ b/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/CommentLines/InsertBeforeStatementPrecededByOneComment.cbl
@@ -1,0 +1,46 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 PIC X.
+       PROCEDURE DIVISION.
+      * Line of comment
+           DISPLAY "This statement is preceded by a comment"
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.
+-------------------------------------------------------------------------------------------------
+TypeCobol.LanguageServer.Commands.InsertVariableDisplay.InsertVariableDisplayRefactoringProcessor
+-------------------------------------------------------------------------------------------------
+[
+    {
+        "textDocument": { "uri": "file:/test.expected.cbl" },
+        "position": { "line": 7, "character": 18 }
+    },
+    true,
+    {
+        "vm": 1, "idx": 0, "ch": [
+            {
+                "vm": 0, "name": "var1"
+            }
+        ]
+    }
+]
+-------------------------------------------------------------------------------------------------
+refactoring.label=Debug instructions successfully generated.
+refactoring.source=
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 PIC X.
+       PROCEDURE DIVISION.
+      *<DBG>InsertVariableDisplay 1959/09/18 11:09 TESTUSER
+      D    DISPLAY 'var1 <' var1 '>'
+      *</DBG>
+
+      * Line of comment
+           DISPLAY "This statement is preceded by a comment"
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionAfterPerform.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionAfterPerform.cs
@@ -25,9 +25,9 @@ namespace TypeCobol.LanguageServer
 
             if (performNode?.SymbolTable != null)
             {
-                paragraphs = performNode.SymbolTable.GetParagraphs(StartsWithUserFilter);
-                sections = performNode.SymbolTable.GetSections(StartsWithUserFilter);
-                variables = performNode.SymbolTable.GetVariables(da => StartsWithUserFilter(da) && da.Picture != null && da.DataType == DataType.Numeric, SymbolTable.Scope.Program);
+                paragraphs = performNode.SymbolTable.GetParagraphs(MatchesWithUserFilter);
+                sections = performNode.SymbolTable.GetSections(MatchesWithUserFilter);
+                variables = performNode.SymbolTable.GetVariables(da => MatchesWithUserFilter(da) && da.Picture != null && da.DataType == DataType.Numeric, SymbolTable.Scope.Program);
             }
 
             if (paragraphs != null)

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionContext.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionContext.cs
@@ -46,14 +46,20 @@ namespace TypeCobol.LanguageServer
 
         protected bool MatchesWithUserFilter(Node symbol)
         {
+            string symbolName = symbol?.Name;
+            if (string.IsNullOrEmpty(symbolName))
+            {
+                return false;
+            }
+
             string userFilterText = UserFilterText;
             if (userFilterText.Length == 0)
             {
                 return true;
             }
 
-            string symbolName = symbol?.Name;
-            return !string.IsNullOrEmpty(symbolName) && Regex.IsMatch(symbolName, $"(^{userFilterText})|((-|_){userFilterText})", RegexOptions.IgnoreCase);
+            // Starts with userFilterText or contains -userFilterText or contains _userFilterText
+            return Regex.IsMatch(symbolName, $"(^{userFilterText})|((-|_){userFilterText})", RegexOptions.IgnoreCase);
         }
 
         public abstract List<CompletionItem> ComputeProposals(CompilationUnit compilationUnit, CodeElement codeElement);

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionForOf.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionForOf.cs
@@ -57,10 +57,7 @@ namespace TypeCobol.LanguageServer
             //Detect what's before the OF token
             var tokenBeforeOf = tokensUntilCursor?.Skip(1).FirstOrDefault(); //Skip(1) will skip the OF token
 
-            if (tokenBeforeOf == null || !(tokenBeforeOf.TokenType == TokenType.ADDRESS || tokenBeforeOf.TokenType == TokenType.UserDefinedWord))
-                return completionItems;
-
-            switch (tokenBeforeOf.TokenType) //In the future, this will allow to switch between different token declared before OF. 
+            switch (tokenBeforeOf?.TokenType) //In the future, this will allow to switch between different token declared before OF. 
             {
                 case TokenType.ADDRESS:
                 {
@@ -99,7 +96,7 @@ namespace TypeCobol.LanguageServer
                 potentialVariables = node.SymbolTable.GetVariables(v => v != null
                                                 && v.IsFlagSet(Node.Flag.LinkageSectionNode)
                                                 && IsRootDataItem(v)
-                                                && StartsWithUserFilter(v),
+                                                && MatchesWithUserFilter(v),
                                                 SymbolTable.Scope.Program);
             }
             else
@@ -108,7 +105,7 @@ namespace TypeCobol.LanguageServer
                 potentialVariables = node.SymbolTable.GetVariables(
                     v => v != null
                          && IsRootDataItem(v)
-                         && StartsWithUserFilter(v),
+                         && MatchesWithUserFilter(v),
                         SymbolTable.Scope.Program);
             }
 

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionForProcedure.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionForProcedure.cs
@@ -29,7 +29,7 @@ namespace TypeCobol.LanguageServer
             if (node.SymbolTable != null)
             {
                 procedures = node.SymbolTable.GetFunctions(StartsWithUserFilter, SymbolTable.Scope.Intrinsic);
-                variables = node.SymbolTable.GetVariables(da => StartsWithUserFilter(da) && da.Picture != null && da.DataType == DataType.Alphanumeric, SymbolTable.Scope.Program);
+                variables = node.SymbolTable.GetVariables(da => MatchesWithUserFilter(da) && da.Picture != null && da.DataType == DataType.Alphanumeric, SymbolTable.Scope.Program);
             }
             else
             {

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionForProcedureParameter.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionForProcedureParameter.cs
@@ -165,7 +165,7 @@ namespace TypeCobol.LanguageServer
 
             //Convert potential variables into actual CompletionItems
             var variables = potentialVariablesForCompletion
-                .Where(StartsWithUserFilter) //Filter on user text
+                .Where(MatchesWithUserFilter) //Filter on user text
                 .Distinct()
                 .SelectMany(d => node.SymbolTable.GetVariablesExplicitWithQualifiedName(new URI(d.Name)));
             var items = CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, compilationUnit.CompilerOptions);

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionForQualifiedName.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionForQualifiedName.cs
@@ -170,7 +170,7 @@ namespace TypeCobol.LanguageServer
                     {
                         System.Diagnostics.Debug.Assert(child is DataDefinition);
                         var data = (DataDefinition)child;
-                        if (StartsWithUserFilter(data))
+                        if (MatchesWithUserFilter(data))
                         {
                             childrenCandidates.Add(data);
                         }

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionForVariable.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionForVariable.cs
@@ -25,7 +25,7 @@ namespace TypeCobol.LanguageServer
                 return completionItems;
 
             var variables = node.SymbolTable
-                .GetVariables(d => StartsWithUserFilter(d) && _dataDefinitionFilter(d), SymbolTable.Scope.Program)
+                .GetVariables(d => MatchesWithUserFilter(d) && _dataDefinitionFilter(d), SymbolTable.Scope.Program)
                 .Select(v => new KeyValuePair<DataDefinitionPath, DataDefinition>(null, v));
             completionItems.AddRange(CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, compilationUnit.CompilerOptions));
 

--- a/TypeCobol.LanguageServer/Processor/CompletionProcessor.cs
+++ b/TypeCobol.LanguageServer/Processor/CompletionProcessor.cs
@@ -82,6 +82,7 @@ namespace TypeCobol.LanguageServer.Processor
                         items = new CompletionForTo(userFilterToken, lastSignificantToken).ComputeProposals(compilationUnit, matchingCodeElement);
                         break;
                     case TokenType.INTO:
+                        // We only target uses with STRING/UNSTRING => filtering on alpha dataDefinitions (note: all pointer USAGE will be also included)
                         Predicate<DataDefinition> onlyAlpha = dataDefinition => dataDefinition.CodeElement != null &&
                                                                    (dataDefinition.DataType == DataType.Alphabetic ||
                                                                     dataDefinition.DataType == DataType.Alphanumeric ||


### PR DESCRIPTION
This release improves completion by proposing variables containing user input preceded by '_' or '-' along with variables starting with user input like originally. This also contains a fix for InsertVariableDisplay to preserve comments while inserting generated indices or statements.

## Completion
- WI #2724 Improve proposal filtering using name separators (#2752)

## Fix for InsertVariableDisplay
- WI #2754 In InsertVariableDisplay look for comment lines before inserting (#2756)
