### PR TITLE
v2.9.1

### DIFF
--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/Chain1.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/Chain1.txt
@@ -1,0 +1,88 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching parents
+       01 SAY-GROUP1.
+          05 GROUP11.
+             10 GROUP111.
+                15 VAR1         PIC 9.
+       01 SAY-GROUP2.
+          05 GROUP11.
+             10 GROUP111.
+                15 VAR1         PIC 9.
+       01 SAY-GROUP3.
+          05 GROUP11.
+             10 GROUP111.
+                15 VAR1         PIC 9.
+      * should not suggest: not matching parent
+       01 GROUP4.
+          05 GROUP44.
+             10 GROUP444.
+          05 VAR1               PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           DISPLAY VAR1 IN GROUP111 OF GROUP11 IN SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":25,"character":53}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-GROUP1 (Alphanumeric) (SAY-GROUP1)",
+    "kind": 6,
+    "insertText": "SAY-GROUP1",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 50
+      },
+      "end": {
+        "line": 25,
+        "character": 53
+      }
+    }
+  },
+  {
+    "label": "SAY-GROUP2 (Alphanumeric) (SAY-GROUP2)",
+    "kind": 6,
+    "insertText": "SAY-GROUP2",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 50
+      },
+      "end": {
+        "line": 25,
+        "character": 53
+      }
+    }
+  },
+  {
+    "label": "SAY-GROUP3 (Alphanumeric) (SAY-GROUP3)",
+    "kind": 6,
+    "insertText": "SAY-GROUP3",
+    "data": {
+      "start": {
+        "line": 25,
+        "character": 50
+      },
+      "end": {
+        "line": 25,
+        "character": 53
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/Chain2.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/Chain2.txt
@@ -19,23 +19,26 @@
                 15 SUB-GROUP1.
                    20 NOT-SUB-GROUP.
                       25 VAR1        PIC X.
-      * should not suggest: not matching chain
+      * should not suggest: not matching chains
        01 NOT-MAIN-GROUP1.
           05 NOT-SUB-GLOUP1.
              10 VAR1                 PIC X.
        01 NOT-MAIN-GROUP2.
           05 SUB-GROUP1.
              10 VAR2                 PIC X.
+       01 FILLER.
+          05 SUB-GROUP1.
+             10 VAR2                 PIC X.
 
        PROCEDURE DIVISION.
        MAIN.
-           MOVE 1 TO VAR1 OF SUB-GROUP1 OF GR
+           MOVE 1 TO VAR1 IN SUB-GROUP1 IN GR
            GOBACK
            .
 
        END PROGRAM TCOBCOMP.
 ---------------------------------------------------------------------------------
-{"line":31,"character":45}
+{"line":34,"character":45}
 ---------------------------------------------------------------------------------
 [
   {
@@ -44,26 +47,26 @@
     "insertText": "SAY-MAIN-GROUP1",
     "data": {
       "start": {
-        "line": 31,
+        "line": 34,
         "character": 43
       },
       "end": {
-        "line": 31,
+        "line": 34,
         "character": 45
       }
     }
   },
   {
-    "label": "SAY-GROUP2 (Alphanumeric) (SAY-GROUP2 OF SAY-MAIN-GROUP2)",
+    "label": "SAY-GROUP2 (Alphanumeric) (SAY-GROUP2 IN SAY-MAIN-GROUP2)",
     "kind": 6,
-    "insertText": "SAY-GROUP2 OF SAY-MAIN-GROUP2",
+    "insertText": "SAY-GROUP2 IN SAY-MAIN-GROUP2",
     "data": {
       "start": {
-        "line": 31,
+        "line": 34,
         "character": 43
       },
       "end": {
-        "line": 31,
+        "line": 34,
         "character": 45
       }
     }
@@ -74,26 +77,26 @@
     "insertText": "SAY-MAIN-GROUP2",
     "data": {
       "start": {
-        "line": 31,
+        "line": 34,
         "character": 43
       },
       "end": {
-        "line": 31,
+        "line": 34,
         "character": 45
       }
     }
   },
   {
-    "label": "SAY-GROUP3 (Alphanumeric) (SAY-GROUP3 OF NOT-MAIN-GLOUP)",
+    "label": "SAY-GROUP3 (Alphanumeric) (SAY-GROUP3 IN NOT-MAIN-GLOUP)",
     "kind": 6,
-    "insertText": "SAY-GROUP3 OF NOT-MAIN-GLOUP",
+    "insertText": "SAY-GROUP3 IN NOT-MAIN-GLOUP",
     "data": {
       "start": {
-        "line": 31,
+        "line": 34,
         "character": 43
       },
       "end": {
-        "line": 31,
+        "line": 34,
         "character": 45
       }
     }

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/Filler.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/Filler.txt
@@ -1,0 +1,38 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+      * should suggest: named parent
+       01 GROUP-WITH-FILLER.
+      * should not suggest: FILLER
+          05 FILLER.
+             10 VAR1           PIC X.
+      * should suggest: named parent
+       01 GROUP-WITH-ANONYMOUS.
+      * should not suggest: anonymous
+          05 .
+             10 VAR1           PIC X.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           DISPLAY VAR1 IN 
+           GOBACK
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":18,"character":27}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "GROUP-WITH-FILLER (Alphanumeric) (GROUP-WITH-FILLER)",
+    "kind": 6,
+    "insertText": "GROUP-WITH-FILLER"
+  },
+  {
+    "label": "GROUP-WITH-ANONYMOUS (Alphanumeric) (GROUP-WITH-ANONYMOUS)",
+    "kind": 6,
+    "insertText": "GROUP-WITH-ANONYMOUS"
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/NotImplemented.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/NotImplemented.txt
@@ -1,0 +1,20 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * suggest nothing: usage of IN not implemented
+       01 GROUP1.
+          05 VAR1               PIC X.
+          05 VAR2               PIC X.
+          05 SAY-VAR3           PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           XML GENERATE VAR1 FROM VAR2 COUNT IN SAY
+           GOBACK
+           .
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":12,"character":51}
+---------------------------------------------------------------------------------
+[]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/SeveralParents.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/SeveralParents.txt
@@ -13,7 +13,7 @@
 
        PROCEDURE DIVISION.
        MAIN.
-           MOVE 1 TO VAR1 OF GR
+           MOVE 1 TO VAR1 IN GR
            GOBACK
            .
 
@@ -23,9 +23,9 @@
 ---------------------------------------------------------------------------------
 [
   {
-    "label": "SUB-GROUP1 (Alphanumeric) (SUB-GROUP1 OF MAIN-GROUP1)",
+    "label": "SUB-GROUP1 (Alphanumeric) (SUB-GROUP1 IN MAIN-GROUP1)",
     "kind": 6,
-    "insertText": "SUB-GROUP1 OF MAIN-GROUP1",
+    "insertText": "SUB-GROUP1 IN MAIN-GROUP1",
     "data": {
       "start": {
         "line": 15,

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/Variable.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/Variable.txt
@@ -5,7 +5,7 @@
       * should suggest: matching parent
        01 SAY-GROUP1.
           05 VAR1               PIC 9.
-       01 GROUP2-SAY.
+       01 GROUP2-SAY REDEFINES SAY-GROUP1.
           05 VAR1               PIC 9.
        01 GROUP3-SAY-GROUP3.
           05 VAR1               PIC 9.
@@ -18,10 +18,14 @@
       * should not suggest: not matching parent
        01 GROUP4.
           05 VAR1               PIC 9.
+       01 FILLER.
+          05 VAR1               PIC 9.
+       01 .
+          05 VAR1               PIC 9.
 
        PROCEDURE DIVISION.
        MAIN.
-           DISPLAY VAR1 OF SAY
+           DISPLAY VAR1 IN SAY
            GOBACK
            .
       * should not suggest: paragraph
@@ -35,7 +39,7 @@
 
        END PROGRAM TCOBCOMP.
 ---------------------------------------------------------------------------------
-{"line":23,"character":30}
+{"line":27,"character":30}
 ---------------------------------------------------------------------------------
 [
   {
@@ -44,11 +48,11 @@
     "insertText": "SAY-GROUP1",
     "data": {
       "start": {
-        "line": 23,
+        "line": 27,
         "character": 27
       },
       "end": {
-        "line": 23,
+        "line": 27,
         "character": 30
       }
     }
@@ -59,11 +63,11 @@
     "insertText": "GROUP2-SAY",
     "data": {
       "start": {
-        "line": 23,
+        "line": 27,
         "character": 27
       },
       "end": {
-        "line": 23,
+        "line": 27,
         "character": 30
       }
     }
@@ -74,41 +78,41 @@
     "insertText": "GROUP3-SAY-GROUP3",
     "data": {
       "start": {
-        "line": 23,
+        "line": 27,
         "character": 27
       },
       "end": {
-        "line": 23,
+        "line": 27,
         "character": 30
       }
     }
   },
   {
-    "label": "SAY-GROUP-QUALIF (Alphanumeric) (SAY-GROUP-QUALIF OF GROUP-QUALIF-1)",
+    "label": "SAY-GROUP-QUALIF (Alphanumeric) (SAY-GROUP-QUALIF IN GROUP-QUALIF-1)",
     "kind": 6,
-    "insertText": "SAY-GROUP-QUALIF OF GROUP-QUALIF-1",
+    "insertText": "SAY-GROUP-QUALIF IN GROUP-QUALIF-1",
     "data": {
       "start": {
-        "line": 23,
+        "line": 27,
         "character": 27
       },
       "end": {
-        "line": 23,
+        "line": 27,
         "character": 30
       }
     }
   },
   {
-    "label": "SAY-GROUP-QUALIF (Alphanumeric) (SAY-GROUP-QUALIF OF GROUP-QUALIF-2)",
+    "label": "SAY-GROUP-QUALIF (Alphanumeric) (SAY-GROUP-QUALIF IN GROUP-QUALIF-2)",
     "kind": 6,
-    "insertText": "SAY-GROUP-QUALIF OF GROUP-QUALIF-2",
+    "insertText": "SAY-GROUP-QUALIF IN GROUP-QUALIF-2",
     "data": {
       "start": {
-        "line": 23,
+        "line": 27,
         "character": 27
       },
       "end": {
-        "line": 23,
+        "line": 27,
         "character": 30
       }
     }

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterMove/NamesUsingHyphens.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterMove/NamesUsingHyphens.txt
@@ -16,6 +16,12 @@
        01 SAY-FUNCTION-POINTER USAGE FUNCTION-POINTER.
        01 GROUP2 OCCURS 10 INDEXED BY SAY-INDEX
                                  PIC X.
+       01 GROUP-QUALIF-1.
+          05 SUB-GROUP-QUALIF-1.
+             10 SAY-VAR-QUALIF   PIC X.
+       01 GROUP-QUALIF-2.
+          05 SUB-GROUP-QUALIF-2.
+             10 SAY-VAR-QUALIF   PIC X.
        77 SAY77                  PIC X.
 
       * should not suggest: not matching, 88
@@ -42,7 +48,7 @@
 
        END PROGRAM TCOBCOMP.
 ---------------------------------------------------------------------------------
-{"line":30,"character":19}
+{"line":36,"character":19}
 ---------------------------------------------------------------------------------
 [
   {
@@ -51,11 +57,11 @@
     "insertText": "SAY-VAR1",
     "data": {
       "start": {
-        "line": 30,
+        "line": 36,
         "character": 16
       },
       "end": {
-        "line": 30,
+        "line": 36,
         "character": 19
       }
     }
@@ -66,11 +72,11 @@
     "insertText": "REDEF-SAY-VAR1",
     "data": {
       "start": {
-        "line": 30,
+        "line": 36,
         "character": 16
       },
       "end": {
-        "line": 30,
+        "line": 36,
         "character": 19
       }
     }
@@ -81,41 +87,41 @@
     "insertText": "GROUP1-SAY",
     "data": {
       "start": {
-        "line": 30,
+        "line": 36,
         "character": 16
       },
       "end": {
-        "line": 30,
+        "line": 36,
         "character": 19
       }
     }
   },
   {
-    "label": "VAR2-SAY (Alphanumeric) (GROUP1-SAY::VAR2-SAY)",
+    "label": "VAR2-SAY (Alphanumeric) (VAR2-SAY)",
     "kind": 6,
-    "insertText": "GROUP1-SAY::VAR2-SAY",
+    "insertText": "VAR2-SAY",
     "data": {
       "start": {
-        "line": 30,
+        "line": 36,
         "character": 16
       },
       "end": {
-        "line": 30,
+        "line": 36,
         "character": 19
       }
     }
   },
   {
-    "label": "SAY66 (?) (GROUP1-SAY::SAY66)",
+    "label": "SAY66 (?) (SAY66)",
     "kind": 6,
-    "insertText": "GROUP1-SAY::SAY66",
+    "insertText": "SAY66",
     "data": {
       "start": {
-        "line": 30,
+        "line": 36,
         "character": 16
       },
       "end": {
-        "line": 30,
+        "line": 36,
         "character": 19
       }
     }
@@ -126,11 +132,11 @@
     "insertText": "VAR3-SAY-VAR3",
     "data": {
       "start": {
-        "line": 30,
+        "line": 36,
         "character": 16
       },
       "end": {
-        "line": 30,
+        "line": 36,
         "character": 19
       }
     }
@@ -141,11 +147,11 @@
     "insertText": "SAY-POINTER",
     "data": {
       "start": {
-        "line": 30,
+        "line": 36,
         "character": 16
       },
       "end": {
-        "line": 30,
+        "line": 36,
         "character": 19
       }
     }
@@ -156,11 +162,11 @@
     "insertText": "SAY-PROCEDURE-POINTER",
     "data": {
       "start": {
-        "line": 30,
+        "line": 36,
         "character": 16
       },
       "end": {
-        "line": 30,
+        "line": 36,
         "character": 19
       }
     }
@@ -171,26 +177,56 @@
     "insertText": "SAY-FUNCTION-POINTER",
     "data": {
       "start": {
-        "line": 30,
+        "line": 36,
         "character": 16
       },
       "end": {
-        "line": 30,
+        "line": 36,
         "character": 19
       }
     }
   },
   {
-    "label": "SAY-INDEX (Numeric) (GROUP2::SAY-INDEX)",
+    "label": "SAY-INDEX (Numeric) (SAY-INDEX)",
     "kind": 6,
-    "insertText": "GROUP2::SAY-INDEX",
+    "insertText": "SAY-INDEX",
     "data": {
       "start": {
-        "line": 30,
+        "line": 36,
         "character": 16
       },
       "end": {
-        "line": 30,
+        "line": 36,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY-VAR-QUALIF (Alphanumeric) (SAY-VAR-QUALIF OF SUB-GROUP-QUALIF-1 OF GROUP-QUALIF-1)",
+    "kind": 6,
+    "insertText": "SAY-VAR-QUALIF OF SUB-GROUP-QUALIF-1 OF GROUP-QUALIF-1",
+    "data": {
+      "start": {
+        "line": 36,
+        "character": 16
+      },
+      "end": {
+        "line": 36,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY-VAR-QUALIF (Alphanumeric) (SAY-VAR-QUALIF OF SUB-GROUP-QUALIF-2 OF GROUP-QUALIF-2)",
+    "kind": 6,
+    "insertText": "SAY-VAR-QUALIF OF SUB-GROUP-QUALIF-2 OF GROUP-QUALIF-2",
+    "data": {
+      "start": {
+        "line": 36,
+        "character": 16
+      },
+      "end": {
+        "line": 36,
         "character": 19
       }
     }
@@ -201,11 +237,11 @@
     "insertText": "SAY77",
     "data": {
       "start": {
-        "line": 30,
+        "line": 36,
         "character": 16
       },
       "end": {
-        "line": 30,
+        "line": 36,
         "character": 19
       }
     }

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/NotImplemented.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/NotImplemented.txt
@@ -2,7 +2,7 @@
        PROGRAM-ID. TCOBCOMP.
        DATA DIVISION.
        WORKING-STORAGE SECTION.
-      * should suggest nothing!
+      * suggest nothing: usage of OF not implemented
        01 SAY-GROUP1.
           05 VAR1               PIC 9.
        01 GROUP2-SAY.

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/CompletionProcessorTest.cs
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/CompletionProcessorTest.cs
@@ -25,7 +25,7 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
          */
         protected readonly CompletionProcessor _processor = new(new SignatureCompletionContext());
 
-        private void ExecuteTest([CallerMemberName] string sourceFileName = null)
+        private void ExecuteTest(bool isCobolLanguage = false, [CallerMemberName] string sourceFileName = null)
         {
             Debug.Assert(sourceFileName != null);
 
@@ -40,7 +40,10 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
             string expectedProposals = testData[2];
 
             // Parse original source code
-            var options = new TypeCobolOptions();
+            var options = new TypeCobolOptions
+            {
+                IsCobolLanguage = isCobolLanguage
+            };
             var format = DocumentFormat.RDZReferenceFormat;
             /*
              * Assuming the source code is not part of a copy. Testing completion inside a copy
@@ -80,13 +83,31 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
         public void AfterDisplay_NamesUsingUnderscores() => ExecuteTest();
 
         [TestMethod]
+        public void AfterIn_Chain1() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterIn_Chain2() => ExecuteTest(true);
+
+        [TestMethod]
+        public void AfterIn_Filler() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterIn_NotImplemented() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterIn_SeveralParents() => ExecuteTest(true);
+
+        [TestMethod]
+        public void AfterIn_Variable() => ExecuteTest(true);
+
+        [TestMethod]
         public void AfterInto_String() => ExecuteTest();
 
         [TestMethod]
         public void AfterInto_Unstring() => ExecuteTest();
 
         [TestMethod]
-        public void AfterMove_NamesUsingHyphens() => ExecuteTest();
+        public void AfterMove_NamesUsingHyphens() => ExecuteTest(true);
 
         [TestMethod]
         public void AfterMove_NamesUsingUnderscores() => ExecuteTest();
@@ -95,22 +116,22 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
         public void AfterOf_Chain1() => ExecuteTest();
 
         [TestMethod]
-        public void AfterOf_Chain2() => ExecuteTest();
+        public void AfterOf_Chain2() => ExecuteTest(true);
 
         [TestMethod]
         public void AfterOf_IfAddress() => ExecuteTest();
 
         [TestMethod]
-        public void AfterOf_NoResult() => ExecuteTest();
+        public void AfterOf_NotImplemented() => ExecuteTest();
 
         [TestMethod]
         public void AfterOf_SetAddress() => ExecuteTest();
 
         [TestMethod]
-        public void AfterOf_SeveralParents() => ExecuteTest();
+        public void AfterOf_SeveralParents() => ExecuteTest(true);
 
         [TestMethod]
-        public void AfterOf_Variable() => ExecuteTest();
+        public void AfterOf_Variable() => ExecuteTest(true);
 
         [TestMethod]
         public void AfterPerform_NamesUsingHyphens() => ExecuteTest();

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayout/CSV-CopyAtBeginning.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayout/CSV-CopyAtBeginning.txt
@@ -1,0 +1,11 @@
+{"line":0,"character":0}
+---------------------------------------------------------------------------------
+copy
+LineNumber;NodeLevel;LevelNumber;VariableName;PictureTypeOrUsage;Start;End;Length
+1;0;1;TCOQLF;GROUP;1;6;6
+2;1;5;TCOQLF-Var1;PIC X;1;1;1
+3;1;5;TCOQLF-Var2;PIC X;2;2;1
+4;1;5;TCOQLF-Var3;PIC X;3;3;1
+5;1;5;TCOQLF-Var4;PIC X;4;4;1
+6;1;5;TCOQLF-Var5;PIC X;5;5;1
+7;1;5;TCOQLF-Var6;PIC X;6;6;1

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayout/CSV-CopyWithout01AtBeginning.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayout/CSV-CopyWithout01AtBeginning.txt
@@ -1,0 +1,7 @@
+{"line":0,"character":0}
+---------------------------------------------------------------------------------
+copyWithout01
+LineNumber;NodeLevel;LevelNumber;VariableName;PictureTypeOrUsage;Start;End;Length
+2;1;5;Var1;PIC X;1;1;1
+3;1;5;Var2;PIC X;2;2;1
+4;1;5;Var3;PIC X;3;3;1

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayout/CSV-SimplePgmAtBeginning.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayout/CSV-SimplePgmAtBeginning.txt
@@ -1,0 +1,27 @@
+{"line":0,"character":0}
+---------------------------------------------------------------------------------
+TCOZEFR0
+LineNumber;NodeLevel;LevelNumber;VariableName;PictureTypeOrUsage;Start;End;Length
+12;0;1;FILLER (1);GROUP OCCURS 1;1;81;81
+13;1;5;Array1 (1 1);GROUP OCCURS 9;1;81;81
+14;2;10;Var1 (1 1);PIC X;1;1;1
+15;2;10;Array2 (1 1 1);GROUP OCCURS 8;2;9;8
+16;3;15;Var2 (1 1 1);PIC X;2;2;1
+17;0;1;FILLER;GROUP;1;4;4
+18;1;5;GRP-REDEFINED;GROUP;1;3;3
+19;2;10;VAR-1;PIC 9(05) COMP-3;1;3;3
+20;1;5;FILLER;GROUP REDEFINES GRP-REDEFINED;1;3;3
+21;2;10;VAR-RED1;PIC 9(05) COMP-3;1;3;3
+22;1;5;GROUP-WITH-88-1;GROUP;4;4;1
+23;2;10;GROUP-WITH-88-2;PIC 9(01);4;4;1
+28;0;1;Var1-in-ls;PIC XX;1;2;2
+29;0;1;num1;PIC 9(03);1;3;3
+30;0;1;num2;comp-1;1;4;4
+31;0;1;num3;comp-2;1;8;8
+32;0;1;num4;PIC 9(03) comp-3;1;2;2
+33;0;1;num5;PIC 9(03) comp-4;1;2;2
+34;0;1;num6;PIC 9(03) comp-5;1;2;2
+35;0;1;num7;PIC 9(03) packed-decimal;1;2;2
+36;0;1;num8;PIC 9(03) binary;1;2;2
+37;0;1;num9;PIC 9(03) comp;1;2;2
+40;0;1;Var2-in-lk;PIC X(2);1;2;2

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayout/Tree-CopyAtBeginning.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayout/Tree-CopyAtBeginning.txt
@@ -1,0 +1,149 @@
+{"line":0,"character":0}
+---------------------------------------------------------------------------------
+{
+  "dataValues": [
+    0,
+    0,
+    0,
+    "copy",
+    null,
+    0,
+    0,
+    0,
+    null,
+    -1,
+    0
+  ],
+  "children": [
+    {
+      "dataValues": [
+        1,
+        0,
+        0,
+        "working-storage",
+        null,
+        0,
+        0,
+        0,
+        null,
+        0,
+        0
+      ],
+      "children": [
+        {
+          "dataValues": [
+            2,
+            1,
+            1,
+            "TCOQLF",
+            "GROUP",
+            0,
+            1,
+            6,
+            null,
+            0,
+            2
+          ],
+          "children": [
+            {
+              "dataValues": [
+                3,
+                2,
+                5,
+                "TCOQLF-Var1",
+                "PIC X",
+                0,
+                1,
+                1,
+                null,
+                0,
+                2
+              ],
+              "children": []
+            },
+            {
+              "dataValues": [
+                3,
+                3,
+                5,
+                "TCOQLF-Var2",
+                "PIC X",
+                0,
+                2,
+                1,
+                null,
+                1,
+                2
+              ],
+              "children": []
+            },
+            {
+              "dataValues": [
+                3,
+                4,
+                5,
+                "TCOQLF-Var3",
+                "PIC X",
+                0,
+                3,
+                1,
+                null,
+                2,
+                2
+              ],
+              "children": []
+            },
+            {
+              "dataValues": [
+                3,
+                5,
+                5,
+                "TCOQLF-Var4",
+                "PIC X",
+                0,
+                4,
+                1,
+                null,
+                3,
+                2
+              ],
+              "children": []
+            },
+            {
+              "dataValues": [
+                3,
+                6,
+                5,
+                "TCOQLF-Var5",
+                "PIC X",
+                0,
+                5,
+                1,
+                null,
+                4,
+                2
+              ],
+              "children": []
+            },
+            {
+              "dataValues": [
+                3,
+                7,
+                5,
+                "TCOQLF-Var6",
+                "PIC X",
+                0,
+                6,
+                1,
+                null,
+                5,
+                2
+              ],
+              "children": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayout/Tree-CopyWithout01AtBeginning.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayout/Tree-CopyWithout01AtBeginning.txt
@@ -1,0 +1,101 @@
+{"line":0,"character":0}
+---------------------------------------------------------------------------------
+{
+  "dataValues": [
+    0,
+    0,
+    0,
+    "copyWithout01",
+    null,
+    0,
+    0,
+    0,
+    null,
+    -1,
+    0
+  ],
+  "children": [
+    {
+      "dataValues": [
+        1,
+        0,
+        0,
+        "working-storage",
+        null,
+        0,
+        0,
+        0,
+        null,
+        0,
+        0
+      ],
+      "children": [
+        {
+          "dataValues": [
+            2,
+            0,
+            1,
+            "FILLER",
+            "GROUP",
+            0,
+            1,
+            3,
+            null,
+            0,
+            4
+          ],
+          "children": [
+            {
+              "dataValues": [
+                3,
+                2,
+                5,
+                "Var1",
+                "PIC X",
+                0,
+                1,
+                1,
+                null,
+                0,
+                2
+              ],
+              "children": []
+            },
+            {
+              "dataValues": [
+                3,
+                3,
+                5,
+                "Var2",
+                "PIC X",
+                0,
+                2,
+                1,
+                null,
+                1,
+                2
+              ],
+              "children": []
+            },
+            {
+              "dataValues": [
+                3,
+                4,
+                5,
+                "Var3",
+                "PIC X",
+                0,
+                3,
+                1,
+                null,
+                2,
+                2
+              ],
+              "children": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayout/Tree-SimplePgmAtBeginning.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayout/Tree-SimplePgmAtBeginning.txt
@@ -1,0 +1,445 @@
+{"line":0,"character":0}
+---------------------------------------------------------------------------------
+{
+  "dataValues": [
+    0,
+    0,
+    0,
+    "TCOZEFR0",
+    null,
+    0,
+    0,
+    0,
+    null,
+    -1,
+    0
+  ],
+  "children": [
+    {
+      "dataValues": [
+        1,
+        0,
+        0,
+        "working-storage",
+        null,
+        0,
+        0,
+        0,
+        null,
+        0,
+        0
+      ],
+      "children": [
+        {
+          "dataValues": [
+            2,
+            12,
+            1,
+            "FILLER",
+            "GROUP OCCURS 1",
+            1,
+            1,
+            81,
+            null,
+            0,
+            0
+          ],
+          "children": [
+            {
+              "dataValues": [
+                3,
+                13,
+                5,
+                "Array1",
+                "GROUP OCCURS 9",
+                2,
+                1,
+                81,
+                null,
+                0,
+                2
+              ],
+              "children": [
+                {
+                  "dataValues": [
+                    4,
+                    14,
+                    10,
+                    "Var1",
+                    "PIC X",
+                    2,
+                    1,
+                    1,
+                    null,
+                    0,
+                    2
+                  ],
+                  "children": []
+                },
+                {
+                  "dataValues": [
+                    4,
+                    15,
+                    10,
+                    "Array2",
+                    "GROUP OCCURS 8",
+                    3,
+                    2,
+                    8,
+                    null,
+                    1,
+                    2
+                  ],
+                  "children": [
+                    {
+                      "dataValues": [
+                        5,
+                        16,
+                        15,
+                        "Var2",
+                        "PIC X",
+                        3,
+                        2,
+                        1,
+                        null,
+                        0,
+                        2
+                      ],
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "dataValues": [
+            2,
+            17,
+            1,
+            "FILLER",
+            "GROUP",
+            0,
+            1,
+            4,
+            null,
+            1,
+            0
+          ],
+          "children": [
+            {
+              "dataValues": [
+                3,
+                18,
+                5,
+                "GRP-REDEFINED",
+                "GROUP",
+                0,
+                1,
+                3,
+                null,
+                0,
+                2
+              ],
+              "children": [
+                {
+                  "dataValues": [
+                    4,
+                    19,
+                    10,
+                    "VAR-1",
+                    "PIC 9(05) COMP-3",
+                    0,
+                    1,
+                    3,
+                    null,
+                    0,
+                    2
+                  ],
+                  "children": []
+                }
+              ]
+            },
+            {
+              "dataValues": [
+                3,
+                20,
+                5,
+                "FILLER",
+                "GROUP REDEFINES GRP-REDEFINED",
+                0,
+                1,
+                3,
+                null,
+                1,
+                1
+              ],
+              "children": [
+                {
+                  "dataValues": [
+                    4,
+                    21,
+                    10,
+                    "VAR-RED1",
+                    "PIC 9(05) COMP-3",
+                    0,
+                    1,
+                    3,
+                    null,
+                    0,
+                    2
+                  ],
+                  "children": []
+                }
+              ]
+            },
+            {
+              "dataValues": [
+                3,
+                22,
+                5,
+                "GROUP-WITH-88-1",
+                "GROUP",
+                0,
+                4,
+                1,
+                null,
+                2,
+                2
+              ],
+              "children": [
+                {
+                  "dataValues": [
+                    4,
+                    23,
+                    10,
+                    "GROUP-WITH-88-2",
+                    "PIC 9(01)",
+                    0,
+                    4,
+                    1,
+                    null,
+                    0,
+                    2
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "dataValues": [
+        1,
+        0,
+        0,
+        "local-storage",
+        null,
+        0,
+        0,
+        0,
+        null,
+        1,
+        0
+      ],
+      "children": [
+        {
+          "dataValues": [
+            2,
+            28,
+            1,
+            "Var1-in-ls",
+            "PIC XX",
+            0,
+            1,
+            2,
+            null,
+            0,
+            2
+          ],
+          "children": []
+        },
+        {
+          "dataValues": [
+            2,
+            29,
+            1,
+            "num1",
+            "PIC 9(03)",
+            0,
+            1,
+            3,
+            null,
+            1,
+            2
+          ],
+          "children": []
+        },
+        {
+          "dataValues": [
+            2,
+            30,
+            1,
+            "num2",
+            "comp-1",
+            0,
+            1,
+            4,
+            null,
+            2,
+            2
+          ],
+          "children": []
+        },
+        {
+          "dataValues": [
+            2,
+            31,
+            1,
+            "num3",
+            "comp-2",
+            0,
+            1,
+            8,
+            null,
+            3,
+            2
+          ],
+          "children": []
+        },
+        {
+          "dataValues": [
+            2,
+            32,
+            1,
+            "num4",
+            "PIC 9(03) comp-3",
+            0,
+            1,
+            2,
+            null,
+            4,
+            2
+          ],
+          "children": []
+        },
+        {
+          "dataValues": [
+            2,
+            33,
+            1,
+            "num5",
+            "PIC 9(03) comp-4",
+            0,
+            1,
+            2,
+            null,
+            5,
+            2
+          ],
+          "children": []
+        },
+        {
+          "dataValues": [
+            2,
+            34,
+            1,
+            "num6",
+            "PIC 9(03) comp-5",
+            0,
+            1,
+            2,
+            null,
+            6,
+            2
+          ],
+          "children": []
+        },
+        {
+          "dataValues": [
+            2,
+            35,
+            1,
+            "num7",
+            "PIC 9(03) packed-decimal",
+            0,
+            1,
+            2,
+            null,
+            7,
+            2
+          ],
+          "children": []
+        },
+        {
+          "dataValues": [
+            2,
+            36,
+            1,
+            "num8",
+            "PIC 9(03) binary",
+            0,
+            1,
+            2,
+            null,
+            8,
+            2
+          ],
+          "children": []
+        },
+        {
+          "dataValues": [
+            2,
+            37,
+            1,
+            "num9",
+            "PIC 9(03) comp",
+            0,
+            1,
+            2,
+            null,
+            9,
+            2
+          ],
+          "children": []
+        }
+      ]
+    },
+    {
+      "dataValues": [
+        1,
+        0,
+        0,
+        "linkage",
+        null,
+        0,
+        0,
+        0,
+        null,
+        2,
+        0
+      ],
+      "children": [
+        {
+          "dataValues": [
+            2,
+            40,
+            1,
+            "Var2-in-lk",
+            "PIC X(2)",
+            0,
+            1,
+            2,
+            null,
+            0,
+            2
+          ],
+          "children": []
+        }
+      ]
+    }
+  ]
+}

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayoutProcessorCSVTest.cs
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayoutProcessorCSVTest.cs
@@ -42,11 +42,20 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
         public void Copy() => ExecuteTest("copy", true);
 
         [TestMethod]
+        public void CopyAtBeginning() => ExecuteTest("copy", true);
+
+        [TestMethod]
         // To test Generated 01 (virtual node built by the parser) which is ignored in CSV output
         public void CopyWithout01() => ExecuteTest("copyWithout01", true);
 
         [TestMethod]
+        public void CopyWithout01AtBeginning() => ExecuteTest("copyWithout01", true);
+
+        [TestMethod]
         public void SimplePgm() => ExecuteTest("simplePgm");
+
+        [TestMethod]
+        public void SimplePgmAtBeginning() => ExecuteTest("simplePgm");
 
         [TestMethod]
         public void MainPgm() => ExecuteTest("stackedAndNestedPgm");

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayoutProcessorTreeTest.cs
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/DataLayoutProcessorTreeTest.cs
@@ -68,18 +68,26 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
         public void SyntaxError() => ExecuteTest("syntaxError");
 
         [TestMethod]
-     
         public void Copy() => ExecuteTest("copy", true);
+
+        [TestMethod]
+        public void CopyAtBeginning() => ExecuteTest("copy", true);
 
         [TestMethod]
         // To test Generated 01 (virtual node built by the parser) which is present in TREE output
         public void CopyWithout01() => ExecuteTest("copyWithout01", true);
 
         [TestMethod]
+        public void CopyWithout01AtBeginning() => ExecuteTest("copyWithout01", true);
+
+        [TestMethod]
         public void MiscPgm() => ExecuteTest("miscPgm");
 
         [TestMethod]
         public void SimplePgm() => ExecuteTest("simplePgm");
+
+        [TestMethod]
+        public void SimplePgmAtBeginning() => ExecuteTest("simplePgm");
 
         [TestMethod]
         public void MainPgm() => ExecuteTest("stackedAndNestedPgm");

--- a/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/DebugLines/MultipleGenerationsWithDebuggingMode.cbl
+++ b/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/DebugLines/MultipleGenerationsWithDebuggingMode.cbl
@@ -1,0 +1,76 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER.
+           IBM-370 WITH DEBUGGING MODE.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 group1.
+          05 var1 PIC X.
+          05 var2 PIC X.
+       01 var3 PIC X.
+       PROCEDURE DIVISION.
+       MAIN.
+           PERFORM DEBUG-INFOS
+           GOBACK
+           .
+       DEBUG-INFOS.
+      *<DBG>Some previous generation by InsertVariableDisplay
+      D    DISPLAY 'group1'
+      D    DISPLAY '  var1 <' var1 '>'
+      D    DISPLAY '  var2 <' var2 '>'
+      *</DBG>
+       
+           .
+       END PROGRAM TCOMFL06.
+-------------------------------------------------------------------------------------------------
+TypeCobol.LanguageServer.Commands.InsertVariableDisplay.InsertVariableDisplayRefactoringProcessor
+-------------------------------------------------------------------------------------------------
+[
+    {
+        "textDocument": { "uri": "file:/test.expected.cbl" },
+        "position": { "line": 23, "character": 7 }
+    },
+    false,
+    {
+        "vm": 1, "idx": 0, "ch": [
+            {
+                "vm": 0, "name": "var3"
+            }
+        ]
+    }
+]
+-------------------------------------------------------------------------------------------------
+refactoring.label=Debug instructions successfully generated.
+refactoring.source=
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER.
+           IBM-370 WITH DEBUGGING MODE.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 group1.
+          05 var1 PIC X.
+          05 var2 PIC X.
+       01 var3 PIC X.
+       PROCEDURE DIVISION.
+       MAIN.
+           PERFORM DEBUG-INFOS
+           GOBACK
+           .
+       DEBUG-INFOS.
+      *<DBG>Some previous generation by InsertVariableDisplay
+      D    DISPLAY 'group1'
+      D    DISPLAY '  var1 <' var1 '>'
+      D    DISPLAY '  var2 <' var2 '>'
+      *</DBG>
+      *<DBG>InsertVariableDisplay 1959/09/18 11:09 TESTUSER
+      D    DISPLAY 'var3 <' var3 '>'
+      *</DBG>
+
+       
+           .
+       END PROGRAM TCOMFL06.

--- a/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/DebugLines/MultipleGenerationsWithoutDebuggingMode.cbl
+++ b/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/DebugLines/MultipleGenerationsWithoutDebuggingMode.cbl
@@ -1,0 +1,76 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER.
+      *    IBM-370 WITH DEBUGGING MODE.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 group1.
+          05 var1 PIC X.
+          05 var2 PIC X.
+       01 var3 PIC X.
+       PROCEDURE DIVISION.
+       MAIN.
+           PERFORM DEBUG-INFOS
+           GOBACK
+           .
+       DEBUG-INFOS.
+      *<DBG>Some previous generation by InsertVariableDisplay
+      D    DISPLAY 'group1'
+      D    DISPLAY '  var1 <' var1 '>'
+      D    DISPLAY '  var2 <' var2 '>'
+      *</DBG>
+       
+           .
+       END PROGRAM TCOMFL06.
+-------------------------------------------------------------------------------------------------
+TypeCobol.LanguageServer.Commands.InsertVariableDisplay.InsertVariableDisplayRefactoringProcessor
+-------------------------------------------------------------------------------------------------
+[
+    {
+        "textDocument": { "uri": "file:/test.expected.cbl" },
+        "position": { "line": 23, "character": 7 }
+    },
+    false,
+    {
+        "vm": 1, "idx": 0, "ch": [
+            {
+                "vm": 0, "name": "var3"
+            }
+        ]
+    }
+]
+-------------------------------------------------------------------------------------------------
+refactoring.label=Debug instructions successfully generated.
+refactoring.source=
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER.
+      *    IBM-370 WITH DEBUGGING MODE.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 group1.
+          05 var1 PIC X.
+          05 var2 PIC X.
+       01 var3 PIC X.
+       PROCEDURE DIVISION.
+       MAIN.
+           PERFORM DEBUG-INFOS
+           GOBACK
+           .
+       DEBUG-INFOS.
+      *<DBG>Some previous generation by InsertVariableDisplay
+      D    DISPLAY 'group1'
+      D    DISPLAY '  var1 <' var1 '>'
+      D    DISPLAY '  var2 <' var2 '>'
+      *</DBG>
+      *<DBG>InsertVariableDisplay 1959/09/18 11:09 TESTUSER
+      D    DISPLAY 'var3 <' var3 '>'
+      *</DBG>
+
+       
+           .
+       END PROGRAM TCOMFL06.

--- a/TypeCobol.LanguageServer/Completion Factory/CodeElementMatcher.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CodeElementMatcher.cs
@@ -28,7 +28,8 @@ namespace TypeCobol.LanguageServer
             { TokenType.SET, false },
             { TokenType.OF, false },
             { TokenType.INTO, false },
-            { TokenType.DISPLAY, false }
+            { TokenType.DISPLAY, false },
+            { TokenType.IN, false },
         };
 
         /// <summary>

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionFactoryHelpers.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionFactoryHelpers.cs
@@ -191,7 +191,7 @@ namespace TypeCobol.LanguageServer
             return results;
         }
 
-        public static CompletionItem CreateCompletionItemForSingleVariable(DataDefinition parent, DataDefinition variable, TypeCobolOptions options, bool qualify)
+        public static CompletionItem CreateCompletionItemForSingleVariable(DataDefinition parent, DataDefinition variable, TypeCobolOptions options, bool qualify, TokenType qualificationTokenType = TokenType.OF)
         {
             string name = variable.Name;
             string type = variable.DataType.Name;
@@ -230,7 +230,8 @@ namespace TypeCobol.LanguageServer
                 if (options.IsCobolLanguage)
                 {
                     nameParts.Reverse();
-                    insertText = string.Join(" OF ", nameParts);
+                    var qualificationToken = TokenUtils.GetTokenStringFromTokenType(qualificationTokenType);
+                    insertText = string.Join($" {qualificationToken} ", nameParts);
                 }
                 else
                 {

--- a/TypeCobol.LanguageServer/Context/UnknownDocumentException.cs
+++ b/TypeCobol.LanguageServer/Context/UnknownDocumentException.cs
@@ -1,0 +1,15 @@
+﻿namespace TypeCobol.LanguageServer.Context
+{
+    /// <summary>
+    /// Exception used to signal that a document could not be found by this server
+    /// using the URI given by the client.
+    /// </summary>
+    public class UnknownDocumentException : Exception
+    {
+        public UnknownDocumentException(string uri)
+            : base($"Unknown document: '{uri}'")
+        {
+
+        }
+    }
+}

--- a/TypeCobol.LanguageServer/Processor/CompletionProcessor.cs
+++ b/TypeCobol.LanguageServer/Processor/CompletionProcessor.cs
@@ -95,8 +95,8 @@ namespace TypeCobol.LanguageServer.Processor
                                                                            || dataDefinition.Usage == DataUsage.Pointer32; //Or usage is pointer/pointer-32
                         items = new CompletionForVariable(userFilterToken, keepCompatibleTypes).ComputeProposals(compilationUnit, matchingCodeElement);
                         break;
-                    case TokenType.OF:
-                        items = new CompletionForOf(userFilterToken, position).ComputeProposals(compilationUnit, matchingCodeElement);
+                    case TokenType.IN or TokenType.OF:
+                        items = new CompletionForInOrOf(userFilterToken, position, lastSignificantToken.TokenType).ComputeProposals(compilationUnit, matchingCodeElement);
                         break;
                     default:
                         // Unable to suggest anything

--- a/TypeCobol.LanguageServer/Processor/DataLayoutProcessor.cs
+++ b/TypeCobol.LanguageServer/Processor/DataLayoutProcessor.cs
@@ -122,11 +122,23 @@ namespace TypeCobol.LanguageServer
                 return null;
             }
 
-            // Get the node corresponding to the position, and then its enclosing program
+            // No need to look for program when document is a copy, simply return the main program generated around the copy content
+            if (compilationUnit.TextSourceInfo.IsCopy)
+            {
+                return mainProgram;
+            }
+
+            // In a regular program, get the node corresponding to the position, and then its enclosing program
             var location = CodeElementLocator.FindCodeElementAt(compilationUnit, position);
             var program = location.Node?.GetProgramNode();
             if (program == null)
             {
+                if (position.IsBefore(mainProgram.CodeElement))
+                {
+                    // Cursor is located before main program, so return it
+                    return mainProgram;
+                }
+
                 // Most certainly the AST is invalid, abort with an exception
                 throw new InvalidDataException($"Could not find enclosing program in '{compilationUnit.TextSourceInfo.Name}' for position ({position.line}, {position.character}).");
             }

--- a/TypeCobol.LanguageServer/TypeCobolCustomLanguageServer/TypeCobolCustomLanguageServer.cs
+++ b/TypeCobol.LanguageServer/TypeCobolCustomLanguageServer/TypeCobolCustomLanguageServer.cs
@@ -1,6 +1,7 @@
 ﻿#if EUROINFO_RULES
 using TypeCobol.CustomExceptions;
 #endif
+using TypeCobol.LanguageServer.Context;
 using TypeCobol.LanguageServer.JsonRPC;
 using TypeCobol.LanguageServer.VsCodeProtocol;
 #if EUROINFO_RULES
@@ -244,7 +245,7 @@ namespace TypeCobol.LanguageServer.TypeCobolCustomLanguageServerProtocol
                 return new GetDataLayoutResult() { csvResult = csvResult };
             }
 
-            throw new Exception($"Unknown document: '{uri}'");
+            throw new UnknownDocumentException(uri);
         }
 
 #if EUROINFO_RULES
@@ -268,7 +269,7 @@ namespace TypeCobol.LanguageServer.TypeCobolCustomLanguageServerProtocol
                        };
             }
 
-            throw new Exception($"Unknown document: '{parameter.textDocument.uri}'");
+            throw new UnknownDocumentException(parameter.textDocument.uri);
         }
 #endif
 

--- a/TypeCobol/Compiler/FileCompiler.cs
+++ b/TypeCobol/Compiler/FileCompiler.cs
@@ -146,7 +146,7 @@ namespace TypeCobol.Compiler
                     var message = string.IsNullOrEmpty(libraryName)
                         ? $"Cobol source file not found: {fileName}"
                         : $"Cobol source file not found: {fileName} in {libraryName}";
-                    throw new Exception(message);
+                    throw new FileNotFoundException(message);
                 }
             }
             else

--- a/TypeCobol/Compiler/Nodes/Attributes.cs
+++ b/TypeCobol/Compiler/Nodes/Attributes.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System.Diagnostics;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 
@@ -114,7 +113,6 @@ namespace TypeCobol.Compiler.Nodes {
 
     internal class ReceiverUsageAttribute : Attribute
     {
-
         public object GetValue(object o, SymbolTable table)
         {
             var node = (Node)o;
@@ -132,16 +130,13 @@ namespace TypeCobol.Compiler.Nodes {
 
                 foreach (var varWritten in variablesWrittenRaw)
                 {
-                    if (varWritten.Count > 1)
-                        throw new Exception("Ambiguous Receiver Name");// Ambiguous variable handeling is done before, in the checkers
-                    else
-                        variablesWritten.Add(varWritten.First());
+                    // Ambiguous variable handling is done before, in the checkers
+                    Debug.Assert(varWritten.Count == 1);
+                    variablesWritten.Add(varWritten[0]);
                 }
-
             }
-            if (variablesWritten == null) return null;
-            if (variablesWritten.Count == 0) return null;
-            else return variablesWritten.First().Usage;
+
+            return variablesWritten.Count == 0 ? null : variablesWritten[0].Usage;
         }
     }
     internal class HashAttribute : Attribute

--- a/TypeCobol/Compiler/Nodes/Documentation.cs
+++ b/TypeCobol/Compiler/Nodes/Documentation.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using System.Text;
 using System.Xml.Serialization;
 using System.Runtime.Serialization.Json;
@@ -180,20 +176,13 @@ namespace TypeCobol.Compiler.Nodes
         
         public static Documentation CreateAppropriateDocumentation(IDocumentable node)
         {
-            if (node is Program)
+            return node switch
             {
-                return new DocumentationForProgram(node as Program);
-            }
-            else if (node is FunctionDeclaration)
-            {
-                return new DocumentationForFunction(node as FunctionDeclaration);
-            }
-            else if (node is TypeDefinition)
-            {
-                return new DocumentationForType(node as TypeDefinition);
-            }
-            else
-                throw new Exception("Documentable Nodes are: Program, FunctionDeclaration, TypeDefinition");
+                Program program => new DocumentationForProgram(program),
+                FunctionDeclaration functionDeclaration => new DocumentationForFunction(functionDeclaration),
+                TypeDefinition typeDefinition => new DocumentationForType(typeDefinition),
+                _ => throw new NotSupportedException("Documentable Nodes are: Program, FunctionDeclaration, TypeDefinition")
+            };
         }
     }
 


### PR DESCRIPTION
## Completion
- WI #2717 Implement completion after IN (#2771)

## Bugfix
- WI #2768 Handle cursor positioned before main program or at beginning of copy in DataLayout (#2770)
- WI #2772 In InsertVariableDisplay consider inactive debug lines as comments (#2773)

## Internal
- WI #2721 Avoid using untyped exceptions (#2769)
