### PR TITLE
WI #2776 In InsertVariableDisplay always consider EXEC nodes as a whole to avoid insert code inside them

### DIFF
--- a/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/ExecSql/InsertAfterExecSql.cbl
+++ b/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/ExecSql/InsertAfterExecSql.cbl
@@ -1,0 +1,66 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 group1.
+          05 label-id    PIC 9(4).
+          05 label-value PIC X(200).
+       PROCEDURE DIVISION.
+           EXEC SQL
+              SELECT
+                 LABEL_VALUE
+              INTO
+                 :label-value
+              FROM
+                 T_LABELS
+              WHERE
+                 LABEL_ID = :label-id
+           END-EXEC
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.
+-------------------------------------------------------------------------------------------------
+TypeCobol.LanguageServer.Commands.InsertVariableDisplay.InsertVariableDisplayRefactoringProcessor
+-------------------------------------------------------------------------------------------------
+[
+    {
+        "textDocument": { "uri": "file:/test.expected.cbl" },
+        "position": { "line": 12, "character": 18 }
+    },
+    false,
+    {
+        "vm": 1, "idx": 0, "ch": [
+            {
+                "vm": 0, "name": "group1"
+            }
+        ]
+    }
+]
+-------------------------------------------------------------------------------------------------
+refactoring.label=Debug instructions successfully generated.
+refactoring.source=
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 group1.
+          05 label-id    PIC 9(4).
+          05 label-value PIC X(200).
+       PROCEDURE DIVISION.
+           EXEC SQL
+              SELECT
+                 LABEL_VALUE
+              INTO
+                 :label-value
+              FROM
+                 T_LABELS
+              WHERE
+                 LABEL_ID = :label-id
+           END-EXEC
+      *<DBG>InsertVariableDisplay 1959/09/18 11:09 TESTUSER
+      D    DISPLAY 'group1 <' group1 '>'
+      *</DBG>
+
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.

--- a/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/ExecSql/InsertBeforeExecSql.cbl
+++ b/TypeCobol.LanguageServer.Test/RefactoringTests/InsertVariableDisplay/ExecSql/InsertBeforeExecSql.cbl
@@ -1,0 +1,66 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 group1.
+          05 label-id    PIC 9(4).
+          05 label-value PIC X(200).
+       PROCEDURE DIVISION.
+           EXEC SQL
+              SELECT
+                 LABEL_VALUE
+              INTO
+                 :label-value
+              FROM
+                 T_LABELS
+              WHERE
+                 LABEL_ID = :label-id
+           END-EXEC
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.
+-------------------------------------------------------------------------------------------------
+TypeCobol.LanguageServer.Commands.InsertVariableDisplay.InsertVariableDisplayRefactoringProcessor
+-------------------------------------------------------------------------------------------------
+[
+    {
+        "textDocument": { "uri": "file:/test.expected.cbl" },
+        "position": { "line": 12, "character": 18 }
+    },
+    true,
+    {
+        "vm": 1, "idx": 0, "ch": [
+            {
+                "vm": 0, "name": "group1"
+            }
+        ]
+    }
+]
+-------------------------------------------------------------------------------------------------
+refactoring.label=Debug instructions successfully generated.
+refactoring.source=
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 group1.
+          05 label-id    PIC 9(4).
+          05 label-value PIC X(200).
+       PROCEDURE DIVISION.
+      *<DBG>InsertVariableDisplay 1959/09/18 11:09 TESTUSER
+      D    DISPLAY 'group1 <' group1 '>'
+      *</DBG>
+
+           EXEC SQL
+              SELECT
+                 LABEL_VALUE
+              INTO
+                 :label-value
+              FROM
+                 T_LABELS
+              WHERE
+                 LABEL_ID = :label-id
+           END-EXEC
+           GOBACK
+           .
+       END PROGRAM TCOMFL06.

--- a/TypeCobol.LanguageServer/Commands/InsertVariableDisplay/InsertVariableDisplayRefactoringProcessor.cs
+++ b/TypeCobol.LanguageServer/Commands/InsertVariableDisplay/InsertVariableDisplayRefactoringProcessor.cs
@@ -65,6 +65,13 @@ namespace TypeCobol.LanguageServer.Commands.InsertVariableDisplay
             {
                 throw new InvalidOperationException("Unable to locate DISPLAY insertion location.");
             }
+
+            // #2776: always consider EXEC nodes as a whole
+            if (_location is ExecText)
+            {
+                Debug.Assert(_location.Parent is Exec);
+                _location = _location.Parent;
+            }
         }
 
         public override (string Label, List<TextEdit> TextEdits) PerformRefactoring(CompilationUnit compilationUnit)


### PR DESCRIPTION
Fixes #2776 