### PR TITLE
WI #2727 Improve insertText for variables located under OCCURS

### DIFF
--- a/TypeCobol.LanguageServer.Test/LSRTests/MoveZeroSpaceCompletion/input/MoveZeroSpaceCompletion.tlsp
+++ b/TypeCobol.LanguageServer.Test/LSRTests/MoveZeroSpaceCompletion/input/MoveZeroSpaceCompletion.tlsp
@@ -95,7 +95,7 @@
     },
     {
       "category": 1,
-      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"result\":{\"isIncomplete\":false,\"items\":[{\"label\":\"buf (Alphanumeric) (MyLevel1Test::buf)\",\"kind\":6,\"insertText\":\"MyLevel1Test::buf\"},{\"label\":\"char (Alphanumeric) (MyLevel1Test::buf::char)\",\"kind\":6,\"insertText\":\"MyLevel1Test::buf::char\"},{\"label\":\"len (Numeric) (len)\",\"kind\":6,\"insertText\":\"len\"},{\"label\":\"MyLevel1Test (Alphanumeric) (MyLevel1Test)\",\"kind\":6,\"insertText\":\"MyLevel1Test\"},{\"label\":\"var2 (Alphanumeric) (var2)\",\"kind\":6,\"insertText\":\"var2\"},{\"label\":\"W-Alphabetic (Alphabetic) (W-Alphabetic)\",\"kind\":6,\"insertText\":\"W-Alphabetic\"}]}}"
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"result\":{\"isIncomplete\":false,\"items\":[{\"label\":\"buf (Alphanumeric) (MyLevel1Test::buf)\",\"kind\":6,\"insertText\":\"MyLevel1Test::buf\"},{\"label\":\"char (Alphanumeric) (MyLevel1Test::buf::char()\",\"kind\":6,\"insertText\":\"MyLevel1Test::buf::char(\"},{\"label\":\"len (Numeric) (len)\",\"kind\":6,\"insertText\":\"len\"},{\"label\":\"MyLevel1Test (Alphanumeric) (MyLevel1Test)\",\"kind\":6,\"insertText\":\"MyLevel1Test\"},{\"label\":\"var2 (Alphanumeric) (var2)\",\"kind\":6,\"insertText\":\"var2\"},{\"label\":\"W-Alphabetic (Alphabetic) (W-Alphabetic)\",\"kind\":6,\"insertText\":\"W-Alphabetic\"}]}}"
     },
     {
       "category": 0,
@@ -179,7 +179,7 @@
     },
     {
       "category": 1,
-      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"4\",\"result\":{\"isIncomplete\":false,\"items\":[{\"label\":\"buf (Alphanumeric) (MyLevel1Test::buf)\",\"kind\":6,\"insertText\":\"MyLevel1Test::buf\"},{\"label\":\"char (Alphanumeric) (MyLevel1Test::buf::char)\",\"kind\":6,\"insertText\":\"MyLevel1Test::buf::char\"},{\"label\":\"MyLevel1Test (Alphanumeric) (MyLevel1Test)\",\"kind\":6,\"insertText\":\"MyLevel1Test\"},{\"label\":\"var2 (Alphanumeric) (var2)\",\"kind\":6,\"insertText\":\"var2\"},{\"label\":\"W-Alphabetic (Alphabetic) (W-Alphabetic)\",\"kind\":6,\"insertText\":\"W-Alphabetic\"}]}}"
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"4\",\"result\":{\"isIncomplete\":false,\"items\":[{\"label\":\"buf (Alphanumeric) (MyLevel1Test::buf)\",\"kind\":6,\"insertText\":\"MyLevel1Test::buf\"},{\"label\":\"char (Alphanumeric) (MyLevel1Test::buf::char()\",\"kind\":6,\"insertText\":\"MyLevel1Test::buf::char(\"},{\"label\":\"MyLevel1Test (Alphanumeric) (MyLevel1Test)\",\"kind\":6,\"insertText\":\"MyLevel1Test\"},{\"label\":\"var2 (Alphanumeric) (var2)\",\"kind\":6,\"insertText\":\"var2\"},{\"label\":\"W-Alphabetic (Alphabetic) (W-Alphabetic)\",\"kind\":6,\"insertText\":\"W-Alphabetic\"}]}}"
     },
     {
       "category": 0,
@@ -263,7 +263,7 @@
     },
     {
       "category": 1,
-      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"6\",\"result\":{\"isIncomplete\":false,\"items\":[{\"label\":\"buf (Alphanumeric) (MyLevel1Test::buf)\",\"kind\":6,\"insertText\":\"MyLevel1Test::buf\"},{\"label\":\"char (Alphanumeric) (MyLevel1Test::buf::char)\",\"kind\":6,\"insertText\":\"MyLevel1Test::buf::char\"},{\"label\":\"len (Numeric) (len)\",\"kind\":6,\"insertText\":\"len\"},{\"label\":\"MyLevel1Test (Alphanumeric) (MyLevel1Test)\",\"kind\":6,\"insertText\":\"MyLevel1Test\"},{\"label\":\"var2 (Alphanumeric) (var2)\",\"kind\":6,\"insertText\":\"var2\"},{\"label\":\"W-Alphabetic (Alphabetic) (W-Alphabetic)\",\"kind\":6,\"insertText\":\"W-Alphabetic\"}]}}"
+      "message": "{\"jsonrpc\":\"2.0\",\"id\":\"6\",\"result\":{\"isIncomplete\":false,\"items\":[{\"label\":\"buf (Alphanumeric) (MyLevel1Test::buf)\",\"kind\":6,\"insertText\":\"MyLevel1Test::buf\"},{\"label\":\"char (Alphanumeric) (MyLevel1Test::buf::char()\",\"kind\":6,\"insertText\":\"MyLevel1Test::buf::char(\"},{\"label\":\"len (Numeric) (len)\",\"kind\":6,\"insertText\":\"len\"},{\"label\":\"MyLevel1Test (Alphanumeric) (MyLevel1Test)\",\"kind\":6,\"insertText\":\"MyLevel1Test\"},{\"label\":\"var2 (Alphanumeric) (var2)\",\"kind\":6,\"insertText\":\"var2\"},{\"label\":\"W-Alphabetic (Alphabetic) (W-Alphabetic)\",\"kind\":6,\"insertText\":\"W-Alphabetic\"}]}}"
     },
     {
       "category": 0,

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterCall/Occurs.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterCall/Occurs.txt
@@ -1,0 +1,96 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should not suggest: no picture
+       01 GROUP-PROCESS.
+          05 VAR1            PIC X.
+       01 GROUP1 OCCURS 10.
+          05 VAR2            PIC X.
+      * should suggest: alphanumeric picture
+          05 VAR-PROCESS OCCURS 10    PIC X.
+      * should not suggest: not alphanumeric picture
+          05 NOT-VAR-PROCESS PIC 9.
+       PROCEDURE DIVISION.
+       main.
+           CALL proc
+           GOBACK
+           .
+       DECLARE PROCEDURE proc1 PRIVATE.
+       END-DECLARE.
+       
+       DECLARE PROCEDURE another-proc1 PRIVATE.
+       END-DECLARE.
+       
+       DECLARE PROCEDURE func1 PRIVATE.
+       END-DECLARE.
+       
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ProcNested1.
+       END PROGRAM ProcNested1.
+       
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. NestedProc1.
+       END PROGRAM NestedProc1.
+       
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. AnotherNested.
+       END PROGRAM AnotherNested.
+       
+       END PROGRAM TCOMFL06.
+---------------------------------------------------------------------------------
+{"line":15,"character":20}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "proc1",
+    "kind": 3,
+    "insertText": "proc1",
+    "data": [
+      {
+        "start": {
+          "line": 15,
+          "character": 16
+        },
+        "end": {
+          "line": 15,
+          "character": 20
+        }
+      },
+      {
+        "label": "TCOMFL06.proc1",
+        "parameters": []
+      },
+      null
+    ]
+  },
+  {
+    "label": "VAR-PROCESS",
+    "kind": 6,
+    "insertText": "VAR-PROCESS(, )",
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 16
+      },
+      "end": {
+        "line": 15,
+        "character": 20
+      }
+    }
+  },
+  {
+    "label": "ProcNested1",
+    "kind": 9,
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 16
+      },
+      "end": {
+        "line": 15,
+        "character": 20
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterDisplay/Occurs.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterDisplay/Occurs.txt
@@ -1,0 +1,88 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+      * should suggest: matching variables
+       01 SAY-VAR1 OCCURS 10           PIC 9.
+       01 GROUP1 OCCURS 10.
+          05 SAY-VAR2                  PIC 9.
+       01 GROUP2 OCCURS 10.
+          05 GROUP21 OCCURS 10.
+             10 SAY-VAR21              PIC 9.
+             10 SAY-VAR22 OCCURS 10    PIC 9.
+      * should not suggest: index
+       01 GROUP3 OCCURS 10 INDEXED BY SAY-INDEX.
+          05 VAR3                      PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           DISPLAY SAY
+           GOBACK
+           .
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":19,"character":22}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-VAR1 (Numeric) (SAY-VAR1()",
+    "kind": 6,
+    "insertText": "SAY-VAR1(",
+    "data": {
+      "start": {
+        "line": 19,
+        "character": 19
+      },
+      "end": {
+        "line": 19,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "SAY-VAR2 (Numeric) (GROUP1::SAY-VAR2()",
+    "kind": 6,
+    "insertText": "GROUP1::SAY-VAR2(",
+    "data": {
+      "start": {
+        "line": 19,
+        "character": 19
+      },
+      "end": {
+        "line": 19,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "SAY-VAR21 (Numeric) (GROUP2::GROUP21::SAY-VAR21(, ))",
+    "kind": 6,
+    "insertText": "GROUP2::GROUP21::SAY-VAR21(, )",
+    "data": {
+      "start": {
+        "line": 19,
+        "character": 19
+      },
+      "end": {
+        "line": 19,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "SAY-VAR22 (Numeric) (GROUP2::GROUP21::SAY-VAR22(, , ))",
+    "kind": 6,
+    "insertText": "GROUP2::GROUP21::SAY-VAR22(, , )",
+    "data": {
+      "start": {
+        "line": 19,
+        "character": 19
+      },
+      "end": {
+        "line": 19,
+        "character": 22
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/Occurs.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterIn/Occurs.txt
@@ -1,0 +1,39 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+      * should suggest: matching group
+      *  (subscript is missing while it is required)
+       01 SAY-GROUP.
+          05 GROUP1.
+             10 VAR-OCC OCCURS 10         PIC 9.
+          05 GROUP2.
+             10 VAR-OCC OCCURS 10         PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           MOVE VAR-OCC IN GROUP1 IN SAY
+           GOBACK
+           .
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":15,"character":40}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-GROUP (Alphanumeric) (SAY-GROUP)",
+    "kind": 6,
+    "insertText": "SAY-GROUP",
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 37
+      },
+      "end": {
+        "line": 15,
+        "character": 40
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterInto/Occurs.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterInto/Occurs.txt
@@ -1,0 +1,100 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should suggest: matching alpha variables
+       01 SAY-VAR1              PIC X.
+       01 GROUP1-SAY OCCURS 10.
+          05 VAR2-SAY           PIC BX.
+          05 VAR3-SAY OCCURS 5  PIC X.
+       01 SAY-FUNCTION-POINTER USAGE FUNCTION-POINTER.
+      * should not suggest: not matching, not alpha
+       01 VAR4                  PIC X.
+       01 VAR5-SAY              PIC 9.
+       01 GROUP2 OCCURS 10 INDEXED BY SAY-INDEX
+                                PIC X.
+       01 GROUP3.
+          05 VAR6               PIC X.
+             88 SAY88-YES              VALUE 'Y'.
+             88 SAY88-NO               VALUE 'N'.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           STRING VAR4 DELIMITED BY SPACE INTO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P-SAY-HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S-SAY-CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":22,"character":50}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-FUNCTION-POINTER (Alphanumeric) (SAY-FUNCTION-POINTER)",
+    "kind": 6,
+    "insertText": "SAY-FUNCTION-POINTER",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 47
+      },
+      "end": {
+        "line": 22,
+        "character": 50
+      }
+    }
+  },
+  {
+    "label": "SAY-VAR1 (Alphanumeric) (SAY-VAR1)",
+    "kind": 6,
+    "insertText": "SAY-VAR1",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 47
+      },
+      "end": {
+        "line": 22,
+        "character": 50
+      }
+    }
+  },
+  {
+    "label": "VAR2-SAY (AlphanumericEdited) (GROUP1-SAY::VAR2-SAY()",
+    "kind": 6,
+    "insertText": "GROUP1-SAY::VAR2-SAY(",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 47
+      },
+      "end": {
+        "line": 22,
+        "character": 50
+      }
+    }
+  },
+  {
+    "label": "VAR3-SAY (Alphanumeric) (GROUP1-SAY::VAR3-SAY(, ))",
+    "kind": 6,
+    "insertText": "GROUP1-SAY::VAR3-SAY(, )",
+    "data": {
+      "start": {
+        "line": 22,
+        "character": 47
+      },
+      "end": {
+        "line": 22,
+        "character": 50
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterMove/Occurs.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterMove/Occurs.txt
@@ -1,0 +1,100 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+      * should suggest: matching variables
+       01 SAY-VAR1 OCCURS 10           PIC 9.
+       01 GROUP1 OCCURS 10  INDEXED BY SAY-INDEX.
+          05 SAY-VAR2                  PIC 9.
+       01 GROUP2 OCCURS 10.
+          05 GROUP21 OCCURS 10.
+             10 SAY-VAR21              PIC 9.
+             10 SAY-VAR22 OCCURS 10    PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           MOVE SAY
+           GOBACK
+           .
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":16,"character":19}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-INDEX (Numeric) (GROUP1::SAY-INDEX)",
+    "kind": 6,
+    "insertText": "GROUP1::SAY-INDEX",
+    "data": {
+      "start": {
+        "line": 16,
+        "character": 16
+      },
+      "end": {
+        "line": 16,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY-VAR1 (Numeric) (SAY-VAR1()",
+    "kind": 6,
+    "insertText": "SAY-VAR1(",
+    "data": {
+      "start": {
+        "line": 16,
+        "character": 16
+      },
+      "end": {
+        "line": 16,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY-VAR2 (Numeric) (GROUP1::SAY-VAR2()",
+    "kind": 6,
+    "insertText": "GROUP1::SAY-VAR2(",
+    "data": {
+      "start": {
+        "line": 16,
+        "character": 16
+      },
+      "end": {
+        "line": 16,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY-VAR21 (Numeric) (GROUP2::GROUP21::SAY-VAR21(, ))",
+    "kind": 6,
+    "insertText": "GROUP2::GROUP21::SAY-VAR21(, )",
+    "data": {
+      "start": {
+        "line": 16,
+        "character": 16
+      },
+      "end": {
+        "line": 16,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY-VAR22 (Numeric) (GROUP2::GROUP21::SAY-VAR22(, , ))",
+    "kind": 6,
+    "insertText": "GROUP2::GROUP21::SAY-VAR22(, , )",
+    "data": {
+      "start": {
+        "line": 16,
+        "character": 16
+      },
+      "end": {
+        "line": 16,
+        "character": 19
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/Occurs.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOf/Occurs.txt
@@ -1,0 +1,54 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+       01 MAIN-GROUP.
+          05 GROUP11.
+      * should suggest: matching variables
+             10 SAY-OCC OCCURS 10         PIC 9.
+          05 GROUP12.
+      * should suggest: matching variables
+             10 SAY-OCC OCCURS 10         PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           MOVE SAY
+           GOBACK
+           .
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":15,"character":19}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY-OCC (Numeric) (MAIN-GROUP::GROUP11::SAY-OCC()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP11::SAY-OCC(",
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 16
+      },
+      "end": {
+        "line": 15,
+        "character": 19
+      }
+    }
+  },
+  {
+    "label": "SAY-OCC (Numeric) (MAIN-GROUP::GROUP12::SAY-OCC()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP12::SAY-OCC(",
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 16
+      },
+      "end": {
+        "line": 15,
+        "character": 19
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterPerform/Occurs.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterPerform/Occurs.txt
@@ -1,0 +1,208 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOMFL06.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      * should be suggested
+       01 group1.
+          05 say-var1 OCCURS 5     PIC 9.
+          05 group2 OCCURS 5.
+             10 var2-say OCCURS 5  PIC 9.
+             10 var3-say-var3      PIC 9.
+      * should not (does not contain 'say', not numeric)
+       01 item-numeric  PIC 9.
+       01 item-text-1   PIC X.
+       PROCEDURE DIVISION.
+       main.
+           PERFORM say
+           GOBACK
+           .
+       s1-say-hello-world SECTION.
+       p1-say-hello.
+           DISPLAY "hello"
+           .
+       p2-say-world.
+           DISPLAY "world"
+           .
+       s2-say-goodbye-end SECTION.
+       p1-say-goodbye.
+           DISPLAY "goodbye"
+           .
+       p2-say-end.
+           DISPLAY "end of PGM"
+           .
+       say-something.
+           DISPLAY "something"
+           .
+       say-nothing SECTION.
+           CONTINUE
+           .
+       do-something SECTION.
+       one-way.
+           MOVE item-text-1 TO item-text-2
+           .
+       and-the-other.
+           MOVE item-text-2 TO item-text-1
+           .
+       END PROGRAM TCOMFL06.
+---------------------------------------------------------------------------------
+{"line":15,"character":22}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "p1-say-goodbye",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 19
+      },
+      "end": {
+        "line": 15,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "p1-say-hello",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 19
+      },
+      "end": {
+        "line": 15,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "p2-say-end",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 19
+      },
+      "end": {
+        "line": 15,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "p2-say-world",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 19
+      },
+      "end": {
+        "line": 15,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "say-something",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 19
+      },
+      "end": {
+        "line": 15,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "s1-say-hello-world",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 19
+      },
+      "end": {
+        "line": 15,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "s2-say-goodbye-end",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 19
+      },
+      "end": {
+        "line": 15,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "say-nothing",
+    "kind": 18,
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 19
+      },
+      "end": {
+        "line": 15,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "say-var1 PIC 9",
+    "kind": 6,
+    "insertText": "say-var1(",
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 19
+      },
+      "end": {
+        "line": 15,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "var2-say PIC 9",
+    "kind": 6,
+    "insertText": "var2-say(, )",
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 19
+      },
+      "end": {
+        "line": 15,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "var3-say-var3 PIC 9",
+    "kind": 6,
+    "insertText": "var3-say-var3(",
+    "data": {
+      "start": {
+        "line": 15,
+        "character": 19
+      },
+      "end": {
+        "line": 15,
+        "character": 22
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterSearch/WithUserFilter.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterSearch/WithUserFilter.txt
@@ -1,0 +1,98 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+       01 GROUP-TABLE.
+      * should suggest: matching tables
+          05 TABLE1 OCCURS 10 INDEXED BY VAR-INDEX1.
+             10 VAR-KEY1 PIC X(5).
+             10 TABLE11 OCCURS 10 INDEXED BY VAR-INDEX11.
+                15 VAR-KEY11 PIC X(5).
+                15 TABLE111 OCCURS 5
+                    ASCENDING KEY IS KEY111
+                    INDEXED BY VAR-INDEX111.
+                    20 VAR-KEY111 PIC X(5).
+                    20 VAR-KEY112 PIC X(10).
+          05 TABLE2 OCCURS 10 INDEXED BY VAR-INDEX2.
+             10 VAR-KEY2 PIC X(5).
+
+       01 GROUP-NOT-TABLE.
+      * should not suggest: not OCCURS
+          05 VAR-TABLE-NOT-OCC PIC X.
+      * should not suggest: not table
+          05 VAR-TABLE-OCC OCCURS 10 PIC X.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           SEARCH TABL
+           AT END
+
+           GOBACK
+           .
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":27,"character":22}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "TABLE1 (Array) (GROUP-TABLE::TABLE1)",
+    "kind": 6,
+    "insertText": "GROUP-TABLE::TABLE1",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 18
+      },
+      "end": {
+        "line": 27,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "TABLE11 (Array) (GROUP-TABLE::TABLE1::TABLE11)",
+    "kind": 6,
+    "insertText": "GROUP-TABLE::TABLE1::TABLE11",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 18
+      },
+      "end": {
+        "line": 27,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "TABLE111 (Array) (GROUP-TABLE::TABLE1::TABLE11::TABLE111)",
+    "kind": 6,
+    "insertText": "GROUP-TABLE::TABLE1::TABLE11::TABLE111",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 18
+      },
+      "end": {
+        "line": 27,
+        "character": 22
+      }
+    }
+  },
+  {
+    "label": "TABLE2 (Array) (GROUP-TABLE::TABLE2)",
+    "kind": 6,
+    "insertText": "GROUP-TABLE::TABLE2",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 18
+      },
+      "end": {
+        "line": 27,
+        "character": 22
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterSet/Occurs.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterSet/Occurs.txt
@@ -1,0 +1,164 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+       01 MAIN-GROUP OCCURS 10.
+      * should suggest: matching variables + numeric and valid usage
+          05 SAY_POINTER USAGE POINTER.
+          05 SAY_POINTER-32 USAGE POINTER-32.
+          05 SAY_VAR1              PIC 9.
+          05 GROUP1.
+             10 VAR2_SAY           PIC 99.
+          05 VAR3_SAY_VAR3         PIC 9(2).
+          05 GROUP2.
+             10 VAR4               PIC 9.
+                88 SAY88-YES              VALUE 1.
+                88 SAY88-NO               VALUE 0.
+          05 GROUP3 OCCURS 10 INDEXED BY SAY_INDEX
+                                PIC X.
+      * should not suggest: not matching, not numeric, invalid usage
+          05 VAR5                  PIC 9.
+          05 NOT_SAY_ALPHA         PIC X.
+          05 NOT_SAY_FUNCTION_POINTER USAGE FUNCTION-POINTER.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           SET SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":26,"character":18}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY88-NO (Level88) (MAIN-GROUP::GROUP2::VAR4::SAY88-NO()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP2::VAR4::SAY88-NO(",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 15
+      },
+      "end": {
+        "line": 26,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY88-YES (Level88) (MAIN-GROUP::GROUP2::VAR4::SAY88-YES()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP2::VAR4::SAY88-YES(",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 15
+      },
+      "end": {
+        "line": 26,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY_INDEX (Numeric) (MAIN-GROUP::GROUP3::SAY_INDEX)",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP3::SAY_INDEX",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 15
+      },
+      "end": {
+        "line": 26,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY_POINTER (Alphanumeric) (MAIN-GROUP::SAY_POINTER()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::SAY_POINTER(",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 15
+      },
+      "end": {
+        "line": 26,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY_POINTER-32 (Alphanumeric) (MAIN-GROUP::SAY_POINTER-32()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::SAY_POINTER-32(",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 15
+      },
+      "end": {
+        "line": 26,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "SAY_VAR1 (Numeric) (MAIN-GROUP::SAY_VAR1()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::SAY_VAR1(",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 15
+      },
+      "end": {
+        "line": 26,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (Numeric) (MAIN-GROUP::GROUP1::VAR2_SAY()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP1::VAR2_SAY(",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 15
+      },
+      "end": {
+        "line": 26,
+        "character": 18
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Numeric) (MAIN-GROUP::VAR3_SAY_VAR3()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::VAR3_SAY_VAR3(",
+    "data": {
+      "start": {
+        "line": 26,
+        "character": 15
+      },
+      "end": {
+        "line": 26,
+        "character": 18
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterSort/WithUserFilter.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterSort/WithUserFilter.txt
@@ -1,0 +1,99 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+       01 GROUP-TABLE.
+      * should suggest: matching tables
+          05 TABLE1 OCCURS 10 INDEXED BY VAR-INDEX1.
+             10 VAR-KEY1 PIC X(5).
+             10 TABLE11 OCCURS 10 INDEXED BY VAR-INDEX11.
+                15 VAR-KEY11 PIC X(5).
+                15 TABLE111 OCCURS 5
+                    ASCENDING KEY IS KEY111
+                    INDEXED BY VAR-INDEX111.
+                    20 VAR-KEY111 PIC X(5).
+                    20 VAR-KEY112 PIC X(10).
+          05 TABLE2 OCCURS 10 INDEXED BY VAR-INDEX2.
+             10 VAR-KEY2 PIC X(5).
+      * should not suggest: not matching tables
+          05 ARRAY OCCURS 10 INDEXED BY VAR-INDEX.
+             10 VAR-KEY PIC X(5).
+
+       01 GROUP-NOT-TABLE.
+      * should not suggest: not OCCURS
+          05 VAR-TABLE-NOT-OCC PIC X.
+      * should not suggest: not table
+          05 VAR-TABLE-OCC OCCURS 10 PIC X.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           SORT TABL
+           GOBACK
+           .
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":30,"character":20}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "TABLE1 (Array) (GROUP-TABLE::TABLE1)",
+    "kind": 6,
+    "insertText": "GROUP-TABLE::TABLE1",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 20
+      }
+    }
+  },
+  {
+    "label": "TABLE11 (Array) (GROUP-TABLE::TABLE1::TABLE11)",
+    "kind": 6,
+    "insertText": "GROUP-TABLE::TABLE1::TABLE11",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 20
+      }
+    }
+  },
+  {
+    "label": "TABLE111 (Array) (GROUP-TABLE::TABLE1::TABLE11::TABLE111)",
+    "kind": 6,
+    "insertText": "GROUP-TABLE::TABLE1::TABLE11::TABLE111",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 20
+      }
+    }
+  },
+  {
+    "label": "TABLE2 (Array) (GROUP-TABLE::TABLE2)",
+    "kind": 6,
+    "insertText": "GROUP-TABLE::TABLE2",
+    "data": {
+      "start": {
+        "line": 30,
+        "character": 16
+      },
+      "end": {
+        "line": 30,
+        "character": 20
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterSort/WithoutUserFilter.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterSort/WithoutUserFilter.txt
@@ -1,0 +1,56 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+
+       01 GROUP-TABLE.
+      * should suggest: tables
+          05 TABLE1 OCCURS 10 INDEXED BY VAR-INDEX1.
+             10 VAR-KEY1 PIC X(5).
+             10 TABLE11 OCCURS 10 INDEXED BY VAR-INDEX11.
+                15 VAR-KEY11 PIC X(5).
+                15 TABLE111 OCCURS 5
+                    ASCENDING KEY IS KEY111
+                    INDEXED BY VAR-INDEX111.
+                    20 VAR-KEY111 PIC X(5).
+                    20 VAR-KEY112 PIC X(10).
+          05 TABLE2 OCCURS 10 INDEXED BY VAR-INDEX2.
+             10 VAR-KEY2 PIC X(5).
+
+       01 GROUP-NOT-TABLE.
+      * should not suggest: not OCCURS
+          05 VAR-NOT-OCC PIC X.
+      * should not suggest: not table
+          05 VAR-OCC OCCURS 10 PIC X.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           SORT 
+           GOBACK
+           .
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":27,"character":16}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "TABLE1 (Array) (GROUP-TABLE::TABLE1)",
+    "kind": 6,
+    "insertText": "GROUP-TABLE::TABLE1"
+  },
+  {
+    "label": "TABLE11 (Array) (GROUP-TABLE::TABLE1::TABLE11)",
+    "kind": 6,
+    "insertText": "GROUP-TABLE::TABLE1::TABLE11"
+  },
+  {
+    "label": "TABLE111 (Array) (GROUP-TABLE::TABLE1::TABLE11::TABLE111)",
+    "kind": 6,
+    "insertText": "GROUP-TABLE::TABLE1::TABLE11::TABLE111"
+  },
+  {
+    "label": "TABLE2 (Array) (GROUP-TABLE::TABLE2)",
+    "kind": 6,
+    "insertText": "GROUP-TABLE::TABLE2"
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/AddOccurs.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/AddOccurs.txt
@@ -1,0 +1,105 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 MAIN-GROUP OCCURS 10.
+      * should suggest: matching variables and sender type
+          05 SAY_VAR1 OCCURS 10    PIC 9.
+          05 GROUP1.
+             10 VAR2_SAY           PIC 99.
+          05 VAR3_SAY_VAR3         PIC 9(2).
+          05 GROUP2 OCCURS 10 INDEXED BY SAY_INDEX
+                                   PIC X.
+      * should not suggest: not matching variables, 88, not sender type
+          05 VAR5                  PIC 9.
+          05 VAR6SAY               PIC 9.
+          05 GROUP3.
+             10 VAR7               PIC 9.
+                88 SAY88-YES              VALUE 1.
+                88 SAY88-NO               VALUE 0.
+          05 SAY_POINTER USAGE POINTER.
+          05 SAY_POINTER-32 USAGE POINTER-32.
+          05 VAR4_SAY              PIC X.
+          05 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+          05 SAY_SENDER            PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           ADD SAY_SENDER TO SAY
+           GOBACK
+           .
+      * should not suggest (paragraph)
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest (section)
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":27,"character":32}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY_INDEX (Numeric) (MAIN-GROUP::GROUP2::SAY_INDEX)",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP2::SAY_INDEX",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 29
+      },
+      "end": {
+        "line": 27,
+        "character": 32
+      }
+    }
+  },
+  {
+    "label": "SAY_VAR1 (Numeric) (MAIN-GROUP::SAY_VAR1(, ))",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::SAY_VAR1(, )",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 29
+      },
+      "end": {
+        "line": 27,
+        "character": 32
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (Numeric) (MAIN-GROUP::GROUP1::VAR2_SAY()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP1::VAR2_SAY(",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 29
+      },
+      "end": {
+        "line": 27,
+        "character": 32
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Numeric) (MAIN-GROUP::VAR3_SAY_VAR3()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::VAR3_SAY_VAR3(",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 29
+      },
+      "end": {
+        "line": 27,
+        "character": 32
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/InspectOccurs.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/InspectOccurs.txt
@@ -1,0 +1,105 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 MAIN-GROUP OCCURS 10.
+      * should suggest: matching variables and sender type
+          05 SAY_VAR1              PIC 9.
+          05 GROUP1.
+             10 VAR2_SAY           PIC 99.
+          05 VAR3_SAY_VAR3         PIC 9(2).
+          05 GROUP2 OCCURS 10 INDEXED BY SAY_INDEX
+                                   PIC X.
+      * should not suggest: not matching variables, 88, not sender type
+          05 VAR5                  PIC 9.
+          05 VAR6SAY               PIC 9.
+          05 GROUP3.
+             10 VAR7               PIC 9.
+                88 SAY88-YES              VALUE 1.
+                88 SAY88-NO               VALUE 0.
+          05 SAY_POINTER USAGE POINTER.
+          05 SAY_POINTER-32 USAGE POINTER-32.
+          05 VAR4_SAY              PIC X.
+          05 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+          05 SAY_SENDER            PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           INSPECT VAR5 CONVERTING SAY_SENDER TO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":27,"character":52}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY_INDEX (Numeric) (MAIN-GROUP::GROUP2::SAY_INDEX)",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP2::SAY_INDEX",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 49
+      },
+      "end": {
+        "line": 27,
+        "character": 52
+      }
+    }
+  },
+  {
+    "label": "SAY_VAR1 (Numeric) (MAIN-GROUP::SAY_VAR1()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::SAY_VAR1(",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 49
+      },
+      "end": {
+        "line": 27,
+        "character": 52
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (Numeric) (MAIN-GROUP::GROUP1::VAR2_SAY()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP1::VAR2_SAY(",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 49
+      },
+      "end": {
+        "line": 27,
+        "character": 52
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Numeric) (MAIN-GROUP::VAR3_SAY_VAR3()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::VAR3_SAY_VAR3(",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 49
+      },
+      "end": {
+        "line": 27,
+        "character": 52
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/MoveOccurs.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/MoveOccurs.txt
@@ -1,0 +1,105 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 MAIN-GROUP OCCURS 10.
+      * should suggest: matching variables and sender type
+          05 SAY_VAR1              PIC 9.
+          05 GROUP1 OCCURS 10.
+             10 VAR2_SAY           PIC 99.
+          05 VAR3_SAY_VAR3         PIC 9(2).
+          05 GROUP2 OCCURS 10 INDEXED BY SAY_INDEX
+                                   PIC X.
+      * should not suggest: not matching variables, 88, sender type
+          05 VAR5                  PIC 9.
+          05 VAR6SAY               PIC 9.
+          05 GROUP3.
+             10 VAR7               PIC 9.
+                88 SAY88-YES              VALUE 1.
+                88 SAY88-NO               VALUE 0.
+          05 SAY_POINTER USAGE POINTER.
+          05 SAY_POINTER-32 USAGE POINTER-32.
+          05 VAR4_SAY              PIC X.
+          05 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+          05 SAY_SENDER            PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           MOVE SAY_SENDER TO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":27,"character":33}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY_INDEX (Numeric) (MAIN-GROUP::GROUP2::SAY_INDEX)",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP2::SAY_INDEX",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 30
+      },
+      "end": {
+        "line": 27,
+        "character": 33
+      }
+    }
+  },
+  {
+    "label": "SAY_VAR1 (Numeric) (MAIN-GROUP::SAY_VAR1()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::SAY_VAR1(",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 30
+      },
+      "end": {
+        "line": 27,
+        "character": 33
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (Numeric) (MAIN-GROUP::GROUP1::VAR2_SAY(, ))",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP1::VAR2_SAY(, )",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 30
+      },
+      "end": {
+        "line": 27,
+        "character": 33
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Numeric) (MAIN-GROUP::VAR3_SAY_VAR3()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::VAR3_SAY_VAR3(",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 30
+      },
+      "end": {
+        "line": 27,
+        "character": 33
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/SetOccurs.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterTo/SetOccurs.txt
@@ -1,0 +1,105 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 MAIN-GROUP OCCURS 10.
+      * should suggest: matching variables and sender type
+          05 SAY_VAR1              PIC 9.
+          05 GROUP1 OCCURS 5.
+             10 VAR2_SAY OCCURS 5  PIC 99.
+          05 VAR3_SAY_VAR3         PIC 9(2).
+          05 GROUP2 OCCURS 10 INDEXED BY SAY_INDEX
+                                   PIC X.
+      * should not suggest: not matching variables, 88, not sender type
+          05 VAR5                  PIC 9.
+          05 VAR6SAY               PIC 9.
+          05 GROUP3.
+             10 VAR7               PIC 9.
+                88 SAY88-YES              VALUE 1.
+                88 SAY88-NO               VALUE 0.
+          05 SAY_POINTER USAGE POINTER.
+          05 SAY_POINTER-32 USAGE POINTER-32.
+          05 VAR4_SAY              PIC X.
+          05 SAY_FUNCTION-POINTER USAGE FUNCTION-POINTER.
+          05 SAY_SENDER            PIC 9.
+
+       PROCEDURE DIVISION.
+       MAIN.
+           SET SAY_SENDER TO SAY
+           GOBACK
+           .
+      * should not suggest: paragraph
+       P_SAY_HELLO.
+           DISPLAY "Hello"
+           .
+      * should not suggest: section
+       S_SAY_CONTINUE SECTION.
+           CONTINUE
+           .
+
+       END PROGRAM TCOBCOMP.
+---------------------------------------------------------------------------------
+{"line":27,"character":32}
+---------------------------------------------------------------------------------
+[
+  {
+    "label": "SAY_INDEX (Numeric) (MAIN-GROUP::GROUP2::SAY_INDEX)",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP2::SAY_INDEX",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 29
+      },
+      "end": {
+        "line": 27,
+        "character": 32
+      }
+    }
+  },
+  {
+    "label": "SAY_VAR1 (Numeric) (MAIN-GROUP::SAY_VAR1()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::SAY_VAR1(",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 29
+      },
+      "end": {
+        "line": 27,
+        "character": 32
+      }
+    }
+  },
+  {
+    "label": "VAR2_SAY (Numeric) (MAIN-GROUP::GROUP1::VAR2_SAY(, , ))",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::GROUP1::VAR2_SAY(, , )",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 29
+      },
+      "end": {
+        "line": 27,
+        "character": 32
+      }
+    }
+  },
+  {
+    "label": "VAR3_SAY_VAR3 (Numeric) (MAIN-GROUP::VAR3_SAY_VAR3()",
+    "kind": 6,
+    "insertText": "MAIN-GROUP::VAR3_SAY_VAR3(",
+    "data": {
+      "start": {
+        "line": 27,
+        "character": 29
+      },
+      "end": {
+        "line": 27,
+        "character": 32
+      }
+    }
+  }
+]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/CompletionProcessorTest.cs
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/CompletionProcessorTest.cs
@@ -78,11 +78,17 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
         public void AfterCall_WithUserFilterTextEI() => ExecuteTest();
 #else
         [TestMethod]
+        public void AfterCall_Occurs() => ExecuteTest();
+
+        [TestMethod]
         public void AfterCall_WithoutUserFilterText() => ExecuteTest();
 
         [TestMethod]
         public void AfterCall_WithUserFilterText() => ExecuteTest();
 #endif
+
+        [TestMethod]
+        public void AfterDisplay_Occurs() => ExecuteTest();
 
         [TestMethod]
         public void AfterDisplay_NamesUsingHyphens() => ExecuteTest();
@@ -103,10 +109,16 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
         public void AfterIn_NotImplemented() => ExecuteTest();
 
         [TestMethod]
+        public void AfterIn_Occurs() => ExecuteTest();
+
+        [TestMethod]
         public void AfterIn_SeveralParents() => ExecuteTest(true);
 
         [TestMethod]
         public void AfterIn_Variable() => ExecuteTest(true);
+
+        [TestMethod]
+        public void AfterInto_Occurs() => ExecuteTest();
 
         [TestMethod]
         public void AfterInto_String() => ExecuteTest();
@@ -121,6 +133,9 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
         public void AfterMove_NamesUsingUnderscores() => ExecuteTest();
 
         [TestMethod]
+        public void AfterMove_Occurs() => ExecuteTest();
+
+        [TestMethod]
         public void AfterOf_Chain1() => ExecuteTest();
 
         [TestMethod]
@@ -131,6 +146,9 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
 
         [TestMethod]
         public void AfterOf_NotImplemented() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterOf_Occurs() => ExecuteTest();
 
         [TestMethod]
         public void AfterOf_SetAddress() => ExecuteTest();
@@ -148,13 +166,31 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
         public void AfterPerform_NamesUsingUnderscores() => ExecuteTest();
 
         [TestMethod]
+        public void AfterPerform_Occurs() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterSearch_WithUserFilter() => ExecuteTest();
+
+        [TestMethod]
         public void AfterSet_NamesUsingHyphens() => ExecuteTest();
 
         [TestMethod]
         public void AfterSet_NamesUsingUnderscores() => ExecuteTest();
 
         [TestMethod]
+        public void AfterSet_Occurs() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterSort_WithoutUserFilter() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterSort_WithUserFilter() => ExecuteTest();
+
+        [TestMethod]
         public void AfterTo_AddLiteral() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_AddOccurs() => ExecuteTest();
 
         [TestMethod]
         public void AfterTo_AddVariable() => ExecuteTest();
@@ -163,7 +199,13 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
         public void AfterTo_Inspect() => ExecuteTest();
 
         [TestMethod]
+        public void AfterTo_InspectOccurs() => ExecuteTest();
+
+        [TestMethod]
         public void AfterTo_MoveLiteral() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_MoveOccurs() => ExecuteTest();
 
         [TestMethod]
         public void AfterTo_MoveSpaces() => ExecuteTest();
@@ -179,6 +221,9 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
 
         [TestMethod]
         public void AfterTo_SetNothingAfterTo() => ExecuteTest();
+
+        [TestMethod]
+        public void AfterTo_SetOccurs() => ExecuteTest();
 
         [TestMethod]
         public void AfterTo_SetOf() => ExecuteTest();

--- a/TypeCobol.LanguageServer/Completion Factory/CodeElementMatcher.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CodeElementMatcher.cs
@@ -30,6 +30,8 @@ namespace TypeCobol.LanguageServer
             { TokenType.INTO, false },
             { TokenType.DISPLAY, false },
             { TokenType.IN, false },
+            { TokenType.SEARCH, false },
+            { TokenType.SORT, false },
         };
 
         /// <summary>

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionAfterPerform.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionAfterPerform.cs
@@ -51,7 +51,7 @@ namespace TypeCobol.LanguageServer
                 return new CompletionItem
                 {
                     label = $"{numericVariable.Name} PIC {numericVariable.Picture.NormalizedValue}",
-                    insertText = numericVariable.Name,
+                    insertText = numericVariable.Name + CompletionFactoryHelpers.GetSubscript(numericVariable),
                     kind = CompletionItemKind.Variable
                 };
             }

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionForInOrOf.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionForInOrOf.cs
@@ -49,7 +49,7 @@ namespace TypeCobol.LanguageServer
                     }
                     else if (matching && MatchesWithUserFilter(parentDataDefinition))
                     {
-                        completionItems.Add(CompletionFactoryHelpers.CreateCompletionItemForSingleVariable(null, parentDataDefinition, options, true, _lastSignificantTokenType));
+                        completionItems.Add(CompletionFactoryHelpers.CreateCompletionItemForSingleVariable(null, parentDataDefinition, true, options, true, _lastSignificantTokenType));
                     }
 
                     parentNode = parentDataDefinition.Parent;
@@ -142,7 +142,7 @@ namespace TypeCobol.LanguageServer
             }
 
             var variables = potentialVariables.Select(v => new KeyValuePair<DataDefinitionPath, DataDefinition>(null, v));
-            return CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, options);
+            return CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, true, options);
 
             bool IsRootDataItem(DataDefinition dataDef)
             {

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionForProcedure.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionForProcedure.cs
@@ -39,7 +39,7 @@ namespace TypeCobol.LanguageServer
                 return new CompletionItem
                 {
                     label = variable.Name,
-                    insertText = variable.Name,
+                    insertText = variable.Name + CompletionFactoryHelpers.GetSubscript(variable),
                     kind = CompletionItemKind.Variable
                 };
             }

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionForProcedureParameter.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionForProcedureParameter.cs
@@ -166,7 +166,7 @@ namespace TypeCobol.LanguageServer
                 .Where(MatchesWithUserFilter) //Filter on user text
                 .Distinct()
                 .SelectMany(d => node.SymbolTable.GetVariablesExplicitWithQualifiedName(new URI(d.Name)));
-            var completionItems = CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, compilationUnit.CompilerOptions);
+            var completionItems = CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, true, compilationUnit.CompilerOptions);
 
             Token callToken = codeElement.ConsumedTokens.First(t => t.TokenType == TokenType.CALL);
             Dictionary<ParameterDescription.PassingTypes, string> paramWithCase = CompletionFactoryHelpers.GetParamsUsingMatchingCase(callToken);

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionForQualifiedName.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionForQualifiedName.cs
@@ -177,7 +177,7 @@ namespace TypeCobol.LanguageServer
                 }
 
                 var variables = childrenCandidates.Select(v => new KeyValuePair<DataDefinitionPath, DataDefinition>(null, v));
-                var variableItems = CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, compilationUnit.CompilerOptions, true);
+                var variableItems = CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, true, compilationUnit.CompilerOptions, true);
 
                 if (firstSignificantToken != null)
                 {

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionForTo.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionForTo.cs
@@ -186,7 +186,7 @@ namespace TypeCobol.LanguageServer
                 //don't do this if there is no need to qualify or let method CreateCompletionItemsForVariableSetAndDisambiguate call this if necessary
                 .SelectMany(v => node.SymbolTable.GetVariablesExplicitWithQualifiedName(new URI(v.Name)));
 
-            return [ CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, compilationUnit.CompilerOptions) ];
+            return [ CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, true, compilationUnit.CompilerOptions) ];
         }
     }
 }

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionForVariable.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionForVariable.cs
@@ -10,11 +10,13 @@ namespace TypeCobol.LanguageServer
     internal class CompletionForVariable : CompletionContext
     {
         private readonly Predicate<DataDefinition> _dataDefinitionFilter;
+        private readonly bool _addSubscript;
 
-        public CompletionForVariable(Token userFilterToken, Predicate<DataDefinition> additionalDataDefinitionFilter)
+        public CompletionForVariable(Token userFilterToken, Predicate<DataDefinition> additionalDataDefinitionFilter, bool addSubscript = true)
             : base(userFilterToken)
         {
             _dataDefinitionFilter = additionalDataDefinitionFilter;
+            _addSubscript = addSubscript;
         }
 
         protected override IEnumerable<IEnumerable<CompletionItem>> ComputeProposalGroups(CompilationUnit compilationUnit, CodeElement codeElement)
@@ -27,7 +29,7 @@ namespace TypeCobol.LanguageServer
                 .GetVariables(d => MatchesWithUserFilter(d) && _dataDefinitionFilter(d), SymbolTable.Scope.Program)
                 .Select(v => new KeyValuePair<DataDefinitionPath, DataDefinition>(null, v));
 
-            return [ CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, compilationUnit.CompilerOptions) ];
+            return [ CompletionFactoryHelpers.CreateCompletionItemsForVariableSetAndDisambiguate(variables, _addSubscript, compilationUnit.CompilerOptions) ];
         }
     }
 }

--- a/TypeCobol.LanguageServer/Processor/CompletionProcessor.cs
+++ b/TypeCobol.LanguageServer/Processor/CompletionProcessor.cs
@@ -98,6 +98,11 @@ namespace TypeCobol.LanguageServer.Processor
                     case TokenType.IN or TokenType.OF:
                         items = new CompletionForInOrOf(userFilterToken, position, lastSignificantToken.TokenType).ComputeProposals(compilationUnit, matchingCodeElement);
                         break;
+                    case TokenType.SEARCH or TokenType.SORT:
+                        // Filtering on OCCURS
+                        Predicate<DataDefinition> occursVariables = dataDefinition => dataDefinition.DataType == DataType.Occurs;
+                        items = new CompletionForVariable(userFilterToken, occursVariables, false).ComputeProposals(compilationUnit, matchingCodeElement);
+                        break;
                     default:
                         // Unable to suggest anything
                         items = new List<CompletionItem>();


### PR DESCRIPTION
Fixes #2727

One LSR completion test was targeting a variable in an OCCURS => adapt it

Subscript is added for every statement except SEARCH and SORT.
