### PR TITLE
v2.10.2

### DIFF
--- a/TypeCobol.LanguageServer/Workspace.cs
+++ b/TypeCobol.LanguageServer/Workspace.cs
@@ -258,7 +258,7 @@ namespace TypeCobol.LanguageServer
             docContext.LanguageServerConnection(true);
 
             fileCompiler.CompilationResultsForProgram.SetOwnerThread(Thread.CurrentThread);
-            fileCompiler.CompilationResultsForProgram.CodeAnalysisCompleted += FinalCompilationStepCompleted;
+            fileCompiler.CompilationResultsForProgram.CodeAnalysisCompleted += (sender, _) => FinalCompilationStepCompleted(docContext.Uri, (CompilationUnit)sender);
             fileCompiler.CompilationResultsForProgram.UpdateTokensLines();
 
             if (lsrOptions != LsrTestingOptions.LsrSourceDocumentTesting)
@@ -307,26 +307,6 @@ namespace TypeCobol.LanguageServer
         internal bool TryGetOpenedDocument(Uri docUri, out DocumentContext openedDocumentContext)
         {
             return this._allOpenedDocuments.TryGetValue(docUri, out openedDocumentContext);
-        }
-
-        /// <summary>
-        /// Try to get the DocumentContext instance by name
-        /// </summary>
-        /// <param name="name">The document's name</param>
-        /// <param name="openedDocumentContext"></param>
-        /// <returns>true if the DocumentContext has been found, false otherwise</returns>
-        private bool TryGetOpenedDocumentByName(string name, out DocumentContext openedDocumentContext)
-        {
-            openedDocumentContext = null;
-            foreach (var entry in this._allOpenedDocuments)
-            {
-                if (entry.Key.LocalPath.Contains(name))
-                {
-                    openedDocumentContext = entry.Value;
-                    return true;
-                }
-            }
-            return false;
         }
 
         /// <summary>
@@ -924,44 +904,25 @@ namespace TypeCobol.LanguageServer
         /// <summary>
         /// CodeAnalysis completion event handler.
         /// </summary>
-        /// <param name="cUnit">Sender of the event is the CompilationUnit.</param>
-        /// <param name="programEvent">Event arg, contains the version number of the most up-to-date InspectedProgramClassDocument.</param>
-        private void FinalCompilationStepCompleted(object cUnit, ProgramClassEvent programEvent)
+        /// <param name="fileUri">Target document identifier.</param>
+        /// <param name="compilationUnit">Compilation results after final compilation step completed.</param>
+        private void FinalCompilationStepCompleted(Uri fileUri, CompilationUnit compilationUnit)
         {
-            var compilationUnit = cUnit as CompilationUnit;
-
-            // Search for corresponding opened document.
-            Uri fileUri = null;
-            if (TryGetOpenedDocumentByName(compilationUnit.TextSourceInfo.Name, out var documentCtx))
-            {
-                fileUri = documentCtx.Uri;
-            }
-
-            // No document found
-            if (fileUri == null)  return;
-
-            // Need to handle the groups instead of the diagnostics, so the order of appearance will be the same within the groups
-            // This is meant to avoid the modification of the LSR tests
-            IEnumerable<Diagnostic> diags = new List<Diagnostic>();
-            var severityGroups = compilationUnit?.AllDiagnostics().GroupBy(d => d.Info.Severity);
-
-            if (severityGroups != null)
-            {
-                foreach (var group in severityGroups.OrderBy(d => d.Key))
-                {
-                    // Add Errors first, then Warnings, then Infos
-                    diags = diags.Any() ? diags.Concat(group) : group;
-                }
-            }
+            // Group and order diagnostics by severity: Errors first, then Warnings, then Infos
+            var diags = compilationUnit.AllDiagnostics()
+                .GroupBy(diagnostic => diagnostic.Info.Severity)
+                .OrderBy(group => group.Key)
+                .SelectMany(group => group) // Flatten diagnostic groups now that they are correctly ordered
+                .Take(Configuration.MaximumDiagnostics == 0 ? 200 : Configuration.MaximumDiagnostics) // Limit final diagnostic count
+                .ToList();
 
             if (DiagnosticsEvent != null)
-                DiagnosticsEvent(fileUri, new DiagnosticEvent() { Diagnostics = diags.Take(Configuration.MaximumDiagnostics == 0 
-                    ? 200 : Configuration.MaximumDiagnostics) });
+                DiagnosticsEvent(fileUri, new DiagnosticEvent() { Diagnostics = diags });
 
             if (MissingCopiesEvent != null && compilationUnit?.MissingCopies.Count > 0)
                 MissingCopiesEvent(fileUri, new MissingCopiesEvent() { Copies = new List<string>(compilationUnit.MissingCopies) });
 
-            DocumentModifiedEvent?.Invoke(fileUri, new EventArgs());
+            DocumentModifiedEvent?.Invoke(fileUri, EventArgs.Empty);
         }
 
         #region Data Layout

--- a/TypeCobol.Test/Parser/Programs/Cobol85/RedefinesWithReplace.PGM.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/RedefinesWithReplace.PGM.txt
@@ -1,0 +1,19 @@
+--- Diagnostics ---
+Line 10[34,40] <27, Error, Syntax> - Syntax error : mismatched input ':zoneA:' expecting user defined word RuleStack=codeElement>dataDescriptionEntry>redefinesClause>dataNameReference,  OffendingSymbol=[34,40::zoneA:]<PartialCobolWord>
+Line 10[8,41] <30, Error, Semantics> - Semantic error: Illegal REDEFINES: Target cannot be identified
+
+--- Program ---
+PROGRAM: TCOBCOMP common:False initial:False recursive:False
+ author: ? written: ? compiled: ? installation: ? security: ?
+--- Intrinsic:Namespace:Program:Global:Local
+-- DATA --------
+  zone1:Alphanumeric
+  zone1-redef:Alphanumeric
+  z-label:Alphanumeric
+  z-content:Alphanumeric
+--- Intrinsic
+-- TYPES -------
+  BOOL:BOOL
+  DATE:DATE
+  CURRENCY:CURRENCY
+  STRING:STRING

--- a/TypeCobol.Test/Parser/Programs/Cobol85/RedefinesWithReplace.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/RedefinesWithReplace.rdz.cbl
@@ -1,0 +1,16 @@
+﻿       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TCOBCOMP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       REPLACE ==:zone:== BY ==zone1==.
+       01 :zone: PIC X(120).
+      * Undefined REDEFINES target, we get 2 diagnostics:
+      * - one for the invalid parsing of the Redefines entry
+      * - one for the invalid semantics of the REDEFINES
+       01 :zone:-redef REDEFINES :zoneA:.
+          05 z-label   PIC X(20).
+          05 z-content PIC X(100).
+       PROCEDURE DIVISION.
+           GOBACK
+           .
+       END PROGRAM TCOBCOMP.

--- a/TypeCobol/Compiler/CodeElements/Expressions/StorageArea.cs
+++ b/TypeCobol/Compiler/CodeElements/Expressions/StorageArea.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using TypeCobol.Compiler.Nodes;
 using TypeCobol.Compiler.Scanner;
 
@@ -536,7 +532,7 @@ namespace TypeCobol.Compiler.CodeElements
         [CanBeNull]
         public ExternalName IntrinsicFunctionName { get; private set; }
         public override string FunctionName { get { return IntrinsicFunctionName?.Name; } }
-        public override Token FunctionNameToken { get { return IntrinsicFunctionName?.NameLiteral.Token; } }
+        public override Token FunctionNameToken { get { return IntrinsicFunctionName?.NameLiteral?.Token; } }
 
         public override bool NeedDeclaration
         {
@@ -567,7 +563,7 @@ namespace TypeCobol.Compiler.CodeElements
         [CanBeNull]
         public SymbolReference UserDefinedFunctionName { get; private set;  }
         public override string FunctionName { get { return UserDefinedFunctionName?.Name; } }
-        public override Token FunctionNameToken { get { return UserDefinedFunctionName?.NameLiteral.Token; } }
+        public override Token FunctionNameToken { get { return UserDefinedFunctionName?.NameLiteral?.Token; } }
 
         public override string Namespace { get { return (UserDefinedFunctionName as QualifiedSymbolReference) == null ? null : ((QualifiedSymbolReference)UserDefinedFunctionName).Tail.Name; } }
 
@@ -592,7 +588,7 @@ namespace TypeCobol.Compiler.CodeElements
 
         public SymbolReference ProcedureName { get; private set; }
         public override string FunctionName { get { return ProcedureName.Name; } }
-        public override Token FunctionNameToken { get { return ProcedureName.NameLiteral.Token; } }
+        public override Token FunctionNameToken { get { return ProcedureName.NameLiteral?.Token; } }
         
         public List<CallSiteParameter> InputParameters { get; private set; }
         public List<CallSiteParameter> InoutParameters { get; private set; }

--- a/TypeCobol/Compiler/CodeModel/SymbolTable.cs
+++ b/TypeCobol/Compiler/CodeModel/SymbolTable.cs
@@ -819,7 +819,7 @@ namespace TypeCobol.Compiler.CodeModel
             {
                 //If paragraph is qualified we get a paragraph and a section name
                 var qualifiedSymbolReference = (QualifiedSymbolReference) symbolRef;
-                paragraphName = qualifiedSymbolReference.NameLiteral.Value;
+                paragraphName = qualifiedSymbolReference.Head.Name;
                 parentSectionName = qualifiedSymbolReference.Tail.Name;
             }
             else
@@ -830,7 +830,7 @@ namespace TypeCobol.Compiler.CodeModel
             }
 
             //Retrieve all paragraphs with matching name, then apply additional filters
-            if (Paragraphs.TryGetValue(paragraphName, out var candidates))
+            if (paragraphName != null && Paragraphs.TryGetValue(paragraphName, out var candidates))
             {
                 if (parentSectionName != null)
                 {

--- a/TypeCobol/Compiler/Diagnostics/Cobol2002Checker.cs
+++ b/TypeCobol/Compiler/Diagnostics/Cobol2002Checker.cs
@@ -1,12 +1,9 @@
-﻿using System.Linq;
-using System.Collections.Generic;
-using TypeCobol.Compiler.AntlrUtils;
+﻿using TypeCobol.Compiler.AntlrUtils;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.CodeElements.Expressions;
 using TypeCobol.Compiler.Parser;
 using TypeCobol.Compiler.Parser.Generated;
 using TypeCobol.Compiler.Nodes;
-using TypeCobol.Compiler.Scanner;
 
 namespace TypeCobol.Compiler.Diagnostics
 {
@@ -147,7 +144,9 @@ namespace TypeCobol.Compiler.Diagnostics
 
             if (redefinedVariable == null)
             {
-                string message = "Illegal REDEFINES: Symbol \'" + redefinesSymbolReference + "\' is not referenced";
+                var message = redefinesSymbolReference.Name != null
+                    ? "Illegal REDEFINES: Symbol \'" + redefinesSymbolReference + "\' is not referenced"
+                    : "Illegal REDEFINES: Target cannot be identified";
                 DiagnosticUtils.AddError(redefinesNode, message, redefinesSymbolReference, code: MessageCode.SemanticTCErrorInParser);
                 return;
             }

--- a/TypeCobol/Compiler/Diagnostics/CodeElementCheckers.cs
+++ b/TypeCobol/Compiler/Diagnostics/CodeElementCheckers.cs
@@ -256,7 +256,7 @@ namespace TypeCobol.Compiler.Diagnostics
         {
             foreach (var inputParameter in statement.InputParameters)
             {
-                var errorPosition = inputParameter.StorageAreaOrValue?.MainSymbolReference?.NameLiteral.Token;
+                var errorPosition = inputParameter.StorageAreaOrValue?.MainSymbolReference?.NameLiteral?.Token;
 
                 // TODO#249 these checks should be done during semantic phase, after symbol type resolution
                 // TODO#249 if input is a file name AND input.SendingMode.Value == SendingMode.ByContent OR ByValue
@@ -736,10 +736,16 @@ namespace TypeCobol.Compiler.Diagnostics
             {
                 foreach (var intrinsicFunction in intrinsicFunctions)
                 {
-                    Token token = intrinsicFunction.NameLiteral.Token;
                     var intrinsicFunctionName = intrinsicFunction.Name;
                     if (!CobolIntrinsicFunctions.IsAllowedInRepositoryParagraph(intrinsicFunctionName))
                     {
+                        /*
+                         * NameLiteral cannot be null here, otherwise intrinsicFuntionName would also be null
+                         * and IsAllowedInRepositoryParagraph would then have returned true.
+                         */
+                        System.Diagnostics.Debug.Assert(intrinsicFunction.NameLiteral != null);
+
+                        Token token = intrinsicFunction.NameLiteral.Token;
                         DiagnosticUtils.AddError(paragraph, $"\"{intrinsicFunctionName}\" was specified in the \"FUNCTION\" phrase of the \"REPOSITORY\" paragraph, but the keyword \"FUNCTION\" is always required for this function.", token);
                     }
                 }

--- a/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
+++ b/TypeCobol/Compiler/Diagnostics/TypeCobolChecker.cs
@@ -618,10 +618,9 @@ namespace TypeCobol.Compiler.Diagnostics
             var functions = functionDeclaration.SymbolTable.GetFunction(headerNameURI, functionDeclaration.Profile);
             if (functions.Count > 1)
             {
-                Token nameToken = header.FunctionName.NameLiteral.Token;
                 DiagnosticUtils.AddError(functionDeclaration,
                     "A function \"" + headerNameURI.Head + "\" with the same profile already exists in namespace \"" +
-                    headerNameURI.Tail + "\".", nameToken, null, MessageCode.SemanticTCErrorInParser);
+                    headerNameURI.Tail + "\".", header.FunctionName, MessageCode.SemanticTCErrorInParser);
             }
         }
 

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolExpressionsBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolExpressionsBuilder.cs
@@ -2,7 +2,6 @@
 using TypeCobol.Compiler.AntlrUtils;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.Parser.Generated;
-using System.Collections.Generic;
 using TypeCobol.Compiler.Diagnostics;
 using TypeCobol.Compiler.Scanner;
 
@@ -50,6 +49,21 @@ namespace TypeCobol.Compiler.Parser
         private CobolWordsBuilder CobolWordsBuilder { get; }
 
         private UnsupportedLanguageLevelFeaturesChecker LanguageLevelChecker { get; }
+
+        private void AddToSymbolInformations(SymbolDefinition specialRegisterDefinition, SymbolReference specialRegisterReference)
+        {
+            var specialRegisterNameToken = specialRegisterDefinition?.NameLiteral?.Token;
+            if (specialRegisterNameToken != null)
+            {
+                CobolWordsBuilder.symbolInformationForTokens[specialRegisterNameToken] = specialRegisterDefinition;
+            }
+
+            var specialRegisterReferenceToken = specialRegisterReference?.NameLiteral?.Token;
+            if (specialRegisterReferenceToken != null)
+            {
+                CobolWordsBuilder.symbolInformationForTokens[specialRegisterReferenceToken] = specialRegisterReference;
+            }
+        }
 
         #region --- (Data storage area) Identifiers 1. Table elements reference : subscripting data names or condition names ---
 
@@ -240,13 +254,8 @@ namespace TypeCobol.Compiler.Parser
             var specialRegister = new FilePropertySpecialRegister(
                 ParseTreeUtils.GetFirstToken(context.LINAGE_COUNTER()),
                 CobolWordsBuilder.CreateFileNameReference(context.fileNameReference()));
-            if(specialRegister.DataDescriptionEntry != null) {
-                var dataDescription = specialRegister.DataDescriptionEntry;
-                CobolWordsBuilder.symbolInformationForTokens[specialRegister.DataDescriptionEntry.DataName.NameLiteral.Token] = specialRegister.DataDescriptionEntry.DataName;
-            }
-            if (specialRegister.SymbolReference != null) {
-                CobolWordsBuilder.symbolInformationForTokens[specialRegister.SymbolReference.NameLiteral.Token] = specialRegister.SymbolReference;
-            }
+
+            AddToSymbolInformations(specialRegister.DataDescriptionEntry?.DataName, specialRegister.SymbolReference);
             return specialRegister;
         }
 
@@ -255,15 +264,8 @@ namespace TypeCobol.Compiler.Parser
             var specialRegister = new StorageAreaPropertySpecialRegister(
                 ParseTreeUtils.GetFirstToken(context.ADDRESS()),
                 CreateStorageAreaReference(context.storageAreaReference()));
-            if (specialRegister.DataDescriptionEntry != null)
-            {
-                var dataDescription = specialRegister.DataDescriptionEntry;
-                CobolWordsBuilder.symbolInformationForTokens[specialRegister.DataDescriptionEntry.DataName.NameLiteral.Token] = specialRegister.DataDescriptionEntry.DataName;
-            }
-            if (specialRegister.SymbolReference != null)
-            {
-                CobolWordsBuilder.symbolInformationForTokens[specialRegister.SymbolReference.NameLiteral.Token] = specialRegister.SymbolReference;
-            }
+
+            AddToSymbolInformations(specialRegister.DataDescriptionEntry?.DataName, specialRegister.SymbolReference);
             return specialRegister;
         }
 
@@ -272,15 +274,8 @@ namespace TypeCobol.Compiler.Parser
             var specialRegister = new StorageAreaPropertySpecialRegister(
                 ParseTreeUtils.GetFirstToken(context.LENGTH()),
                 CreateStorageAreaReference(context.storageAreaReference()));
-            if (specialRegister.DataDescriptionEntry != null)
-            {
-                var dataDescription = specialRegister.DataDescriptionEntry;
-                CobolWordsBuilder.symbolInformationForTokens[specialRegister.DataDescriptionEntry.DataName.NameLiteral.Token] = specialRegister.DataDescriptionEntry.DataName;
-            }
-            if (specialRegister.SymbolReference != null)
-            {
-                CobolWordsBuilder.symbolInformationForTokens[specialRegister.SymbolReference.NameLiteral.Token] = specialRegister.SymbolReference;
-            }
+
+            AddToSymbolInformations(specialRegister.DataDescriptionEntry?.DataName, specialRegister.SymbolReference);
             return specialRegister;
         }
 
@@ -317,8 +312,12 @@ namespace TypeCobol.Compiler.Parser
             if (functionCall.FunctionName != null && functionCall.FunctionNameToken != null)
             {
                 var functionCallResult = new FunctionCallResult(functionCall);
+                System.Diagnostics.Debug.Assert(functionCallResult.DataDescriptionEntry.DataName != null);
+                System.Diagnostics.Debug.Assert(functionCallResult.DataDescriptionEntry.DataName.NameLiteral.Token != null);
                 CobolWordsBuilder.symbolInformationForTokens[functionCallResult.DataDescriptionEntry.DataName.NameLiteral.Token] =
                     functionCallResult.DataDescriptionEntry.DataName;
+                System.Diagnostics.Debug.Assert(functionCallResult.SymbolReference != null);
+                System.Diagnostics.Debug.Assert(functionCallResult.SymbolReference.NameLiteral.Token != null);
                 CobolWordsBuilder.symbolInformationForTokens[functionCallResult.SymbolReference.NameLiteral.Token] =
                     functionCallResult.SymbolReference;
                 return functionCallResult;

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolWordsBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolWordsBuilder.cs
@@ -23,8 +23,17 @@ namespace TypeCobol.Compiler.Parser
                 symbolInformationForTokens[nameLiteral.Token] = symbolInfo;
         }
 
+        private void AddToSymbolInformations(SymbolInformation symbolInformation)
+        {
+            var token = symbolInformation.NameLiteral?.Token;
+            if (token != null)
+            {
+                symbolInformationForTokens[token] = symbolInformation;
+            }
+        }
+
         #region --- Compile-time constant values used in the Cobol grammar ---
-        
+
 
         internal static BooleanValue CreateBooleanValue(IParseTree context)
         {
@@ -67,6 +76,8 @@ namespace TypeCobol.Compiler.Parser
             if (context.symbolicCharacterReference() != null)
             {
                 var symbolicCharacterReference = CreateSymbolicCharacterReference(context.symbolicCharacterReference());
+                System.Diagnostics.Debug.Assert(symbolicCharacterReference.NameLiteral != null);
+                System.Diagnostics.Debug.Assert(symbolicCharacterReference.NameLiteral.Token != null);
                 return new CharacterValue(symbolicCharacterReference);
             }
 
@@ -172,6 +183,8 @@ namespace TypeCobol.Compiler.Parser
             if (context.symbolicCharacterReference() != null)
             {
                 var symbolicCharacterReference = CreateSymbolicCharacterReference(context.symbolicCharacterReference());
+                System.Diagnostics.Debug.Assert(symbolicCharacterReference.NameLiteral != null);
+                System.Diagnostics.Debug.Assert(symbolicCharacterReference.NameLiteral.Token != null);
                 return new RepeatedCharacterValue(allToken, symbolicCharacterReference);
             }
 
@@ -803,7 +816,9 @@ namespace TypeCobol.Compiler.Parser
             
             var reference = CreateQualifiedSymbolReference(new SymbolReference(headLiteral, SymbolType.IndexName), new SymbolReference(CreateAlphanumericValue(tail[0]), SymbolType.IndexName), false);
             for (int c = 1; c < tail.Length; c++) reference = CreateQualifiedSymbolReference(reference, new SymbolReference(CreateAlphanumericValue(tail[c]), SymbolType.IndexName), false);
-            symbolInformationForTokens[reference.NameLiteral.Token] = reference;
+
+            AddToSymbolInformations(reference);
+
             return reference;
         }
 
@@ -871,7 +886,7 @@ namespace TypeCobol.Compiler.Parser
         private SymbolReference CreateQualifiedParagraphNameReference(CodeElementsParser.ParagraphNameReferenceContext head, CodeElementsParser.SectionNameReferenceContext tail, bool isCOBOL = true)
         {
             var reference = CreateQualifiedSymbolReference(CreateParagraphNameReference(head), CreateSectionNameReference(tail), isCOBOL);
-            symbolInformationForTokens[reference.NameLiteral.Token] = reference;
+            AddToSymbolInformations(reference);
             return reference;
         }
 
@@ -912,13 +927,11 @@ namespace TypeCobol.Compiler.Parser
                 }
                 qname = CreateQualifiedSymbolReference(qname, current, isCOBOL);
             }
-            if (qname != null)
-            {
-                symbolInformationForTokens[qname.NameLiteral.Token] = qname;
-                return qname;
-            }
 
-            return null;
+            if (qname != null)
+                AddToSymbolInformations(qname);
+
+            return qname;
         }
         private SymbolReference CreateQualifiedSymbolReference(SymbolReference head, SymbolReference tail, bool isCOBOL = true)
         {
@@ -954,7 +967,8 @@ namespace TypeCobol.Compiler.Parser
                     qname = CreateQualifiedSymbolReference(qname, part, isCOBOL);
                 }
             }
-            symbolInformationForTokens[qname.NameLiteral.Token] = qname;
+
+            AddToSymbolInformations(qname);
             return qname;
         }
 
@@ -1015,7 +1029,7 @@ namespace TypeCobol.Compiler.Parser
         {
             var reference = CreateQualifiedSymbolReference(CreateDataNameReferenceOrConditionNameReferenceOrConditionForUPSISwitchNameReferenceOrTCFunctionProcedure(head), CreateDataNameReferenceOrFileNameReferenceOrMnemonicForUPSISwitchNameReference(tail[0]), isCOBOL);
             for (int c = 1; c < tail.Length; c++) reference = CreateQualifiedSymbolReference(reference, CreateDataNameReferenceOrFileNameReferenceOrMnemonicForUPSISwitchNameReference(tail[c]), isCOBOL);
-            symbolInformationForTokens[reference.NameLiteral.Token] = reference;
+            AddToSymbolInformations(reference);
             return reference;
         }
 
@@ -1134,7 +1148,7 @@ namespace TypeCobol.Compiler.Parser
             {
                 ExternalName libraryName = CreateLibraryName(context.libraryName());
                 var qualifiedTextName = new QualifiedTextName(textName, libraryName);
-                symbolInformationForTokens[qualifiedTextName.NameLiteral.Token] = qualifiedTextName;
+                AddToSymbolInformations(qualifiedTextName);
                 return qualifiedTextName;
             }
         }

--- a/TypeCobol/Compiler/Parser/DiagnosticUtils.cs
+++ b/TypeCobol/Compiler/Parser/DiagnosticUtils.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Antlr4.Runtime;
+﻿using Antlr4.Runtime;
 using TypeCobol.Compiler.AntlrUtils;
 using TypeCobol.Compiler.CodeElements;
 using TypeCobol.Compiler.Diagnostics;
@@ -58,20 +55,25 @@ namespace TypeCobol.Compiler.Parser
             node.AddDiagnostic(diagnostic);
         }
 
-        internal static void AddError(Node node, string message, SymbolReference symbol, MessageCode code = MessageCode.SyntaxErrorInParser)
+        internal static void AddError(Node node, string message, SymbolInformation symbol, MessageCode code = MessageCode.SyntaxErrorInParser)
         {
-            var diagnostic = new ParserDiagnostic(message, symbol.NameLiteral.Token, null, code);
-            node.AddDiagnostic(diagnostic);
+            var token = symbol?.NameLiteral?.Token;
+            if (token != null)
+            {
+                AddError(node, message, token, null, code);
+            }
+            else
+            {
+                AddError(node, message, code);
+            }
         }
 
         internal static void AddError(Node node, string message, DataDefinitionEntry data, MessageCode code = MessageCode.SyntaxErrorInParser)
         {
-            ParserDiagnostic diagnostic;
-
-            if (data?.DataName != null)
+            var dataName = data?.DataName;
+            if (dataName != null)
             {
-                diagnostic = new ParserDiagnostic(message, data?.DataName != null ? data.DataName.NameLiteral.Token : data.ConsumedTokens[0], null, code);
-                node.AddDiagnostic(diagnostic);
+                AddError(node, message, dataName, code);
             }
             else
             {

--- a/TypeCobol/Compiler/Scanner/TokensLinesIterator.cs
+++ b/TypeCobol/Compiler/Scanner/TokensLinesIterator.cs
@@ -387,7 +387,9 @@ namespace TypeCobol.Compiler.Scanner
             if (startLineIndex < 0 || stopLineIndex < 0 || stopLineIndex < startLineIndex || 
                 ((startLineIndex == stopLineIndex) && (stopToken.StartIndex < startToken.StartIndex)))
             {
-                throw new InvalidOperationException("Invalid start or stop token : line or columns number do not define a valid selection interval");
+                string message = $"Invalid selection interval: {startToken}@{startLineIndex + 1} -> {stopToken}@{stopLineIndex + 1} in {DocumentPath}.";
+                if (startLineIndex == stopLineIndex) message += $" Line text: '{startLine.Text}'.";
+                throw new InvalidOperationException(message);
             }
 
             // Save iterator position (to restore it before return)


### PR DESCRIPTION
## Hotfixes
- WI #2799 Capture document URI to properly handle final compilation step (#2800)
- WI #2306 Protect against NullReferenceException when reading NameLiteral property (#2801)
- WI #2232 Improve error message for invalid selection in SelectAllTokensBetween method (#2802)
