### PR TITLE
v2.10.3

### DIFF
--- a/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOpeningParenthesisTreatedAsUserDefinedWord.txt
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/Completion/AfterOpeningParenthesisTreatedAsUserDefinedWord.txt
@@ -1,0 +1,20 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DVZS0OSM.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 var1 PIC X(10).
+       PROCEDURE DIVISION.
+      * #2804 Requesting completion after this opening parenthesis
+      * yields nothing because the parenthesis is used as text filter
+      * on variables.
+
+           DISPLAY (
+
+           GOBACK
+           .
+
+       END PROGRAM DVZS0OSM.
+---------------------------------------------------------------------------------
+{"line":10,"character":20}
+---------------------------------------------------------------------------------
+[]

--- a/TypeCobol.LanguageServer.Test/ProcessorTests/CompletionProcessorTest.cs
+++ b/TypeCobol.LanguageServer.Test/ProcessorTests/CompletionProcessorTest.cs
@@ -65,10 +65,13 @@ namespace TypeCobol.LanguageServer.Test.ProcessorTests
         }
 
         [TestMethod]
-        public void SimpleCompletionForVariable() => ExecuteTest();
+        public void AfterOpeningParenthesisTreatedAsUserDefinedWord() => ExecuteTest();
 
         [TestMethod]
         public void CompletionAfterUserDefinedWord() => ExecuteTest();
+
+        [TestMethod]
+        public void SimpleCompletionForVariable() => ExecuteTest();
 
 #if EUROINFO_RULES
         [TestMethod]

--- a/TypeCobol.LanguageServer/Completion Factory/CompletionContext.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionContext.cs
@@ -54,7 +54,7 @@ namespace TypeCobol.LanguageServer
                 return false;
             }
 
-            string userFilterText = UserFilterText;
+            string userFilterText = Regex.Escape(UserFilterText);
             if (userFilterText.Length == 0)
             {
                 return true;


### PR DESCRIPTION
# Bugfix
-	WI #2792 Avoid an error when asking for completion on a variable ending with a '(' or a '['