### PR TITLE
WI #2232 Limit probability of InvalidOperationException during preprocessing step

### DIFF
--- a/TypeCobol/Compiler/Preprocessor/PreprocessorStep.cs
+++ b/TypeCobol/Compiler/Preprocessor/PreprocessorStep.cs
@@ -159,7 +159,7 @@ namespace TypeCobol.Compiler.Preprocessor
                         CompilerDirective compilerDirective = directiveBuilder.CompilerDirective;
                         bool errorFoundWhileParsingDirective = compilerDirective == null || compilerDirective.ParsingDiagnostics != null || cupCobolErrorStrategy.Diagnostics != null;
 
-                        int? firstLineIndex = null;
+                        int? diagnosticsLineIndex = null;
                         if (compilerDirective != null)
                         {
                             // 5. Get all tokens consumed while parsing the compiler directive
@@ -168,7 +168,7 @@ namespace TypeCobol.Compiler.Preprocessor
                             Token stopToken = tokensIterator.LastToken;
                             if (stopToken == null) stopToken = startToken;
                             MultilineTokensGroupSelection tokensSelection = tokensIterator.SelectAllTokensBetween(startToken, stopToken);
-                            firstLineIndex = tokensSelection.FirstLineIndex;
+                            diagnosticsLineIndex = tokensSelection.FirstLineIndex;
 
                             // 5. a Set consumed tokens of the compiler directive
                             compilerDirective.ConsumedTokens = tokensSelection;
@@ -233,7 +233,7 @@ namespace TypeCobol.Compiler.Preprocessor
                         // 7. Register compiler directive parse errors
                         if (errorFoundWhileParsingDirective)
                         {
-                            ProcessedTokensLine compilerDirectiveLine = firstLineIndex.HasValue ? documentLines[firstLineIndex.Value] : line;
+                            ProcessedTokensLine compilerDirectiveLine = diagnosticsLineIndex.HasValue ? documentLines[diagnosticsLineIndex.Value] : line;
                             if (compilerDirective != null && compilerDirective.ParsingDiagnostics != null)
                             {
                                 foreach (Diagnostic directiveDiag in compilerDirective.ParsingDiagnostics)


### PR DESCRIPTION
Ok this is not a fix but rather an attempt to limit uses of `SelectAllTokensBetween`.

As our logs show that the method was invoked on tokens that should not participate in a CompilerDirective building, it means that something very wrong happened... However the directive builder should also not create anything in that case so the method should not be called with this new code.
