### PR TITLE
WI #2817 Prevent from NullReferenceException in completion after IN/OF

### DIFF
--- a/TypeCobol.LanguageServer/Completion Factory/CompletionForInOrOf.cs
+++ b/TypeCobol.LanguageServer/Completion Factory/CompletionForInOrOf.cs
@@ -95,11 +95,8 @@ namespace TypeCobol.LanguageServer
                 {
                     // IN/OF is used to qualify a variable => retrieve the first variable in the IN/OF chain
                     var tokenFirstVariable = tokensUntilCursor.TakeWhile(t => t.TokenType is TokenType.UserDefinedWord or TokenType.IN or TokenType.OF).LastOrDefault();
-                    if (tokenFirstVariable == null)
-                    {
-                        // It can happen! In this case we rely on tokenBefore to be able to return something
-                        tokenFirstVariable = tokenBefore;
-                    }
+                    // Real life: tokenFirstVariable can be null! In this case we rely on tokenBefore to be able to return something
+                    tokenFirstVariable ??= tokenBefore;
                     return [ GetCompletionForParent(node, tokenBefore, tokenFirstVariable, compilationUnit.CompilerOptions) ];
                 }
                 case TokenType.ADDRESS:


### PR DESCRIPTION
Fixes #2817

I cannot reproduce the problem.
However we see that we cannot add a null symbol or a symbol with null name in the symbol table (cf `SymbolTable.AddVariable`).
Therefore, it is very likely that the right-hand side of the predicate is null, i.e. `firstVariableName`.