### PR TITLE
WI #2552 Fix IndexOutOfRangeException in Scanner when parsing NationalHexa or UTF8Hexa literals

### DIFF
--- a/TypeCobol.Test/Parser/Scanner/ResultFiles/AlphanumericLiterals3.txt
+++ b/TypeCobol.Test/Parser/Scanner/ResultFiles/AlphanumericLiterals3.txt
@@ -32,3 +32,6 @@ Line 0[1,12] <19, Warning, Tokens> - The number of characters in an hexadecimal 
 [1,21+:NX'74007500740075000']<HexadecimalNationalLiteral>(',Y,Y){tutu}
 Line 0[1,21] <20, Warning, Tokens> - The number of characters in an hexadecimal national literal should be a multiple of 4
 
+-- Line 8 --
+[1,2:NX]<UserDefinedWord>
+

--- a/TypeCobol.Test/Parser/Scanner/ResultFiles/UTF8Literals.txt
+++ b/TypeCobol.Test/Parser/Scanner/ResultFiles/UTF8Literals.txt
@@ -40,3 +40,6 @@
 -- Line 14 --
 [1,1:A]<UserDefinedWord>
 
+-- Line 15 --
+[1,2:UX]<UserDefinedWord>
+

--- a/TypeCobol.Test/Parser/Scanner/TestTokenTypes.cs
+++ b/TypeCobol.Test/Parser/Scanner/TestTokenTypes.cs
@@ -133,7 +133,8 @@ namespace TypeCobol.Test.Parser.Scanner
                 "X\"A396A396\"",
                 "NX'7400750074007500'",
                 "X\"A396A3960\"",
-                "NX'74007500740075000'"
+                "NX'74007500740075000'",
+                "NX"
             };
             result = ScannerUtils.ScanLines(testLines);
             ScannerUtils.CheckWithResultFile(result, testName);
@@ -163,7 +164,8 @@ namespace TypeCobol.Test.Parser.Scanner
                 @"ux""E2ADA0""",
                 @"ux'E2ADA2'",
                 @"B",
-                @"A"
+                @"A",
+                @"UX"
             };
             result = ScannerUtils.ScanLines(testLines);
             ScannerUtils.CheckWithResultFile(result, testName);

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -1391,8 +1391,8 @@ namespace TypeCobol.Compiler.Scanner
                         currentIndex++;
                         return ScanAlphanumericLiteral(startIndex, TokenType.NationalLiteral, _multiStringConcatBitPosition);
                     }
-                    else if (currentIndex < lastIndex     && (line[currentIndex + 1] == 'X' || line[currentIndex + 1] == 'x') &&
-                             currentIndex < (lastIndex+1) && (line[currentIndex + 2] == '"' || line[currentIndex + 2] == '\''))
+                    else if (currentIndex <     lastIndex && (line[currentIndex + 1] == 'X' || line[currentIndex + 1] == 'x') &&
+                             currentIndex + 1 < lastIndex && (line[currentIndex + 2] == '"' || line[currentIndex + 2] == '\''))
                     {
                         // consume N and X chars
                         currentIndex += 2;
@@ -1426,8 +1426,8 @@ namespace TypeCobol.Compiler.Scanner
                         currentIndex++;
                         return ScanAlphanumericLiteral(startIndex, TokenType.UTF8Literal, _multiStringConcatBitPosition);
                     }
-                    else if (currentIndex < lastIndex && (line[currentIndex + 1] == 'X' || line[currentIndex + 1] == 'x') &&
-                        currentIndex < (lastIndex + 1) && (line[currentIndex + 2] == '"' || line[currentIndex + 2] == '\''))
+                    else if (currentIndex     < lastIndex && (line[currentIndex + 1] == 'X' || line[currentIndex + 1] == 'x') &&
+                             currentIndex + 1 < lastIndex && (line[currentIndex + 2] == '"' || line[currentIndex + 2] == '\''))
                     {
                         // consume U and X chars
                         currentIndex += 2;


### PR DESCRIPTION
Fixes #2552

Or at least will remove sources of such error. We may reopen the issue if same error still happens.