### PR TITLE
WI #2720 Fix null reference exception in DataLayoutNodeBuilder.From

### DIFF
--- a/TypeCobol.LanguageServer/Processor/DataLayoutProcessor.cs
+++ b/TypeCobol.LanguageServer/Processor/DataLayoutProcessor.cs
@@ -234,13 +234,15 @@ namespace TypeCobol.LanguageServer
 
             internal static DataLayoutNode From(DataDefinition dataDefinition, DataLayoutNode parent, int index)
             {
-                Debug.Assert((dataDefinition != null) && (dataDefinition.CodeElement != null) && (parent != null));
+                Debug.Assert(dataDefinition != null);
+                Debug.Assert(dataDefinition.CodeElement != null);
+                Debug.Assert(parent != null);
 
                 bool incrementDimension = dataDefinition.IsTableOccurence;
 
                 int logicalLevel = parent.LogicalLevel + 1;
                 int line = dataDefinition.CodeElement.GetLineInMainSource() + 1;
-                long physicalLevel = (dataDefinition.CodeElement.LevelNumber != null) ? dataDefinition.CodeElement.LevelNumber.Value : 0;
+                long physicalLevel = dataDefinition.CodeElement.LevelNumber?.Value ?? 0;
                 bool isNamed = !string.IsNullOrEmpty(dataDefinition.Name);
                 var name = isNamed ? dataDefinition.Name : FILLER;
                 int occursDimension = parent.OccursDimension + (incrementDimension ? 1 : 0);


### PR DESCRIPTION
Fixes #2720 

I cannot reproduce the problem.

The method `DataLayoutNodeBuilder.From` is called only once in `CollectDataLayoutNodes `with an `if` clause that guarantees that `dataDefinition `and `CodeElement `cannot be null.
I have added `Debug.Assert` to make it explicit.

Access to 3 null candidates (`LevelNumber`, `usage.Token`, `CodeElement.RedefinesDataName`) is now protected.

Method is split into 2 parts to make investigation easier if problem persists.