### PR TITLE
Fix parser hang on unsupported SQL statements when EnableSqlParsing is true

### DIFF
--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -2001,8 +2001,15 @@ namespace TypeCobol.Compiler.Scanner
 
             if (tokensLine.ScanState.AfterExecSql)
             {
-                // Expect SQL code
-                tokensLine.ScanState.InsideSql = true;
+                // Only enable SQL token parsing for statements that have grammar rules.
+                // Unsupported statements (INSERT, UPDATE, DELETE, DECLARE CURSOR, OPEN,
+                // FETCH, CLOSE, SELECT with INTO/WHERE/JOIN) fall back to ExecStatementText
+                // to avoid ANTLR parser hangs during error recovery.
+                if (!compilerOptions.EnableSqlParsing || IsSupportedSqlStatement(startIndex, endIndex))
+                {
+                    tokensLine.ScanState.InsideSql = true;
+                }
+                // else: unsupported SQL → InsideSql stays false → ExecStatementText fallback
             }
 
             if (tokensLine.ScanState.InsideSql && compilerOptions.EnableSqlParsing)
@@ -2021,6 +2028,65 @@ namespace TypeCobol.Compiler.Scanner
             // Not SQL code, consume all chars as ExecStatementText
             currentIndex = endIndex + 1;
             return new Token(TokenType.ExecStatementText, startIndex, endIndex, tokensLine);
+        }
+
+        /// <summary>
+        /// Checks whether the SQL statement starting at startIndex is supported by the ANTLR grammar.
+        /// Only statements with complete grammar rules should be parsed as SQL tokens.
+        /// Unsupported statements (INSERT, UPDATE, DELETE, DECLARE CURSOR, OPEN cursor,
+        /// FETCH, CLOSE cursor, and SELECT with complex clauses) are handled as ExecStatementText
+        /// to prevent parser hangs.
+        /// </summary>
+        private bool IsSupportedSqlStatement(int startIndex, int endIndex)
+        {
+            // Supported SQL keywords that have full grammar rules in CobolCodeElements.g4
+            string[] supportedKeywords =
+            {
+                "COMMIT", "ROLLBACK", "TRUNCATE", "WHENEVER", "LOCK",
+                "RELEASE", "SAVEPOINT", "CONNECT", "DROP", "SET",
+                "GET", "ALTER", "EXECUTE"
+            };
+
+            // Skip leading whitespace
+            int pos = startIndex;
+            while (pos <= endIndex && line[pos] == ' ')
+                pos++;
+
+            if (pos > endIndex)
+                return false;
+
+            int remaining = endIndex - pos + 1;
+
+            foreach (var keyword in supportedKeywords)
+            {
+                if (remaining >= keyword.Length)
+                {
+                    bool match = true;
+                    for (int i = 0; i < keyword.Length; i++)
+                    {
+                        if (char.ToUpperInvariant(line[pos + i]) != keyword[i])
+                        {
+                            match = false;
+                            break;
+                        }
+                    }
+
+                    if (match)
+                    {
+                        // Keyword must be followed by whitespace, end of text, or non-letter
+                        if (remaining == keyword.Length ||
+                            !char.IsLetterOrDigit(line[pos + keyword.Length]))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            // SELECT is only partially supported (no WHERE, INTO, JOIN, column names)
+            // so it is NOT included above — it causes parser hangs on real-world queries.
+            // INSERT, UPDATE, DELETE, DECLARE, OPEN, FETCH, CLOSE have no grammar rules at all.
+            return false;
         }
 
         private Token ScanKeywordOrUserDefinedWord(int startIndex)

--- a/TypeCobol/Compiler/Sql/CodeElements/SqlStatementElement.cs
+++ b/TypeCobol/Compiler/Sql/CodeElements/SqlStatementElement.cs
@@ -19,6 +19,7 @@ namespace TypeCobol.Compiler.Sql.CodeElements
         {
             switch (tokenType)
             {
+                // Statements with full grammar rules
                 case TokenType.SQL_ALTER:
                 case TokenType.SQL_COMMIT:
                 case TokenType.SQL_CONNECT:
@@ -33,6 +34,16 @@ namespace TypeCobol.Compiler.Sql.CodeElements
                 case TokenType.SQL_SET:
                 case TokenType.SQL_TRUNCATE:
                 case TokenType.SQL_WHENEVER:
+                // DML statements without grammar rules — listed here so that
+                // ANTLR error recovery stops at their boundaries instead of
+                // consuming tokens indefinitely.
+                case TokenType.SQL_INSERT:
+                case TokenType.SQL_UPDATE:
+                case TokenType.SQL_DELETE:
+                case TokenType.SQL_DECLARE:
+                case TokenType.SQL_OPEN:
+                case TokenType.SQL_FETCH:
+                case TokenType.SQL_CLOSE:
                     return true;
                 default:
                     return false;


### PR DESCRIPTION
## Summary

- Fix infinite hang in `CompileOnce()` when `EnableSqlParsing = true` and the COBOL source contains SQL DML statements not supported by the ANTLR grammar (INSERT, UPDATE, DELETE, DECLARE CURSOR, OPEN, FETCH, CLOSE) or SELECT with WHERE/INTO/JOIN clauses.
- The Scanner now checks the first keyword of each `EXEC SQL` block against the list of statements with complete grammar rules before enabling SQL token parsing. Unsupported statements fall back to `ExecStatementText` mode.
- `IsSqlStatementStartingKeyword()` is extended with DML tokens so ANTLR error recovery stops at statement boundaries.

## Problem

A COBOL program with standard DB2 SQL (`synth_cobol_sql.cbl`, 204 lines) caused `CompileOnce()` to never return. The file contains:

| SQL Statement | Grammar Support | Behavior Before Fix |
|---|---|---|
| `CONNECT TO` / `CONNECT RESET` | Full rule | OK |
| `COMMIT` | Full rule | OK |
| `SELECT col1, col2 INTO :var FROM table WHERE ...` | Partial (only `SELECT table.*`) | **Hangs** |
| `INSERT INTO table VALUES (...)` | No rule | **Hangs** |
| `UPDATE table SET col = val WHERE ...` | No rule | **Hangs** |
| `DELETE FROM table WHERE ...` | No rule | **Hangs** |
| `DECLARE CURSOR FOR SELECT ...` | No rule | **Hangs** |
| `OPEN` / `FETCH` / `CLOSE` cursor | No rule | **Hangs** |

When the ANTLR parser encounters SQL tokens with no matching grammar rule, error recovery tries all ~100 `codeElement` alternatives for each token, causing exponential backtracking.

## Changes

### `Scanner.cs`
- Added `IsSupportedSqlStatement(startIndex, endIndex)` method that peeks at the first SQL keyword after `EXEC SQL`
- Modified `ScanSqlCodeOrExecStatementTextOrExecSqlInclude()`: only sets `InsideSql = true` if the SQL keyword is in the supported list (COMMIT, ROLLBACK, CONNECT, TRUNCATE, SAVEPOINT, DROP, LOCK, RELEASE, WHENEVER, SET, GET, ALTER, EXECUTE)
- Unsupported SQL falls through to `ExecStatementText` — same behavior as `EnableSqlParsing = false` for those blocks

### `SqlStatementElement.cs`
- Added `SQL_INSERT`, `SQL_UPDATE`, `SQL_DELETE`, `SQL_DECLARE`, `SQL_OPEN`, `SQL_FETCH`, `SQL_CLOSE` to `IsSqlStatementStartingKeyword()` so error recovery stops consuming at DML statement boundaries

## Test plan

- [x] Compilation of `synth_cobol_sql.cbl` (204 lines, 14 EXEC SQL blocks with all DML types): **30s+ timeout → < 1 second**
- [x] Supported SQL statements (COMMIT, CONNECT, ROLLBACK, etc.) still parsed as SQL tokens
- [x] No regression on existing COBOL test files without SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)