### PR TITLE
WI #2843 Include sub-directories for copy folders

### DIFF
--- a/TypeCobol.LanguageServer/WorkspaceProject.cs
+++ b/TypeCobol.LanguageServer/WorkspaceProject.cs
@@ -189,7 +189,7 @@ namespace TypeCobol.LanguageServer
                 var newCompilationProject = new CompilationProject(oldCompilationProject.Name, oldCompilationProject.RootDirectory, Helpers.DEFAULT_EXTENSIONS, newFormat, newOptions, newAnalyzerProvider);
                 foreach (var newCopyFolder in newCopyFolders)
                 {
-                    newCompilationProject.SourceFileProvider.AddLocalDirectoryLibrary(newCopyFolder, false, Helpers.DEFAULT_COPY_EXTENSIONS, newFormat);
+                    newCompilationProject.SourceFileProvider.AddLocalDirectoryLibrary(newCopyFolder, true, Helpers.DEFAULT_COPY_EXTENSIONS, newFormat);
                 }
 
                 Project = newCompilationProject;

--- a/TypeCobol/Parser.cs
+++ b/TypeCobol/Parser.cs
@@ -61,7 +61,7 @@ namespace TypeCobol
             SourceFileProvider sourceFileProvider = project.SourceFileProvider;
             copies = copies ?? new List<string>();
             foreach (var folder in copies) {
-                sourceFileProvider.AddLocalDirectoryLibrary(folder, false, Helpers.DEFAULT_COPY_EXTENSIONS, format.Encoding, format.EndOfLineDelimiter, format.FixedLineLength);
+                sourceFileProvider.AddLocalDirectoryLibrary(folder, true, Helpers.DEFAULT_COPY_EXTENSIONS, format.Encoding, format.EndOfLineDelimiter, format.FixedLineLength);
             }
             compiler = new FileCompiler(null, filename, format.ColumnsLayout, isCopy, project.SourceFileProvider, project, options, CustomSymbols, project);
             


### PR DESCRIPTION
Fixes #2843

- use subdirs for copy folders of `CompilationProject` created to be used in a `WorkspaceProject` (affects compilation through LanguageServer)
- use subdirs when compiling through the CLI
- use subdirs when parsing a TypeCobol dependency
- keep the `false` value for the root directory of the `CompilationProject` which is always added as a copy folder (but not its subdirs)
- test code using the `Parser.Init` helper method will now use subdirs while other keep the previous parameter.

