### PR TITLE
WI #2837 Add INSERT statement parsing with host variable bindings

### DIFF
--- a/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/ExecInDataDivision_NoEndExec.Mix.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/ExecInDataDivision_NoEndExec.Mix.txt
@@ -1,6 +1,6 @@
 ﻿       IDENTIFICATION DIVISION.
        PROGRAM-ID. TCOMFL06.
-Line 3[8,21] <27, Error, Syntax> - Syntax error : extraneous input 'datadivision.' expecting {ExecStatementText, ExecStatementEnd, CommitStatement, SelectStatement, RollbackStatement, TruncateStatement, SavepointStatement, WhenEverStatement, LockTableStatement, ReleaseSavepointStatement, ConnectStatement, DropTableStatement, SetAssignmentStatement, GetDiagnosticsStatement, AlterSequenceStatement, ExecuteImmediateStatement}
+Line 3[8,21] <27, Error, Syntax> - Syntax error : extraneous input 'datadivision.' expecting {ExecStatementText, ExecStatementEnd, CommitStatement, SelectStatement, RollbackStatement, TruncateStatement, SavepointStatement, WhenEverStatement, LockTableStatement, ReleaseSavepointStatement, ConnectStatement, DropTableStatement, SetAssignmentStatement, GetDiagnosticsStatement, AlterSequenceStatement, ExecuteImmediateStatement, InsertStatement}
        data division.
        working-storage section.
       *Issue #2121, this would previously throw an InvalidCastException

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/ExecSqlWithInsertStatement.SQL.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/ExecSqlWithInsertStatement.SQL.txt
@@ -1,0 +1,31 @@
+--- Diagnostics ---
+Line 22[26,26] <27, Error, Syntax> - Syntax error : mismatched input ',' expecting '.' RuleStack=codeElement>insertStatement>fullselect>subselect>sql_selectClause>selections>selection>tableOrViewAllColumnsSelection>dot,  OffendingSymbol=[26,26:,]<SQL_CommaSeparator>
+Line 22[32,35] <27, Error, Syntax> - Syntax error : mismatched input 'FROM' expecting '.' RuleStack=codeElement>insertStatement>fullselect>subselect>sql_selectClause>selections>selection>tableOrViewAllColumnsSelection>dot,  OffendingSymbol=[32,35:FROM]<SQL_FROM>
+
+--- Sql Statements ---
+line 11: InsertStatement
+- TableName = EMPLOYEE
+- Columns = [NAME, AGE]
+- HasSubselect = False
+- HostVariables:
+  - IN WS-NAME -> NAME
+  - IN WS-AGE -> AGE
+line 16: InsertStatement
+- TableName = HR.EMPLOYEE
+- Columns = [SALARY]
+- HasSubselect = False
+- HostVariables:
+  - IN WS-SALARY -> SALARY
+line 21: InsertStatement
+- TableName = ARCHIVE.EMPLOYEE
+- Columns = [NAME, AGE]
+- HasSubselect = True
+- HostVariables = <NONE>
+line 26: InsertStatement
+- TableName = EMPLOYEE
+- Columns = <NULL>
+- HasSubselect = False
+- HostVariables:
+  - IN WS-NAME -> <NULL>
+  - IN WS-AGE -> <NULL>
+  - IN WS-SALARY -> <NULL>

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/ExecSqlWithInsertStatement.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/ExecSqlWithInsertStatement.rdz.cbl
@@ -1,0 +1,30 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TSTINSRT.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-NAME          PIC X(30).
+       01  WS-AGE           PIC 9(3).
+       01  WS-SALARY        PIC 9(7)V99.
+       PROCEDURE DIVISION.
+      * Simple INSERT with host variables
+           EXEC SQL
+              INSERT INTO EMPLOYEE (NAME, AGE)
+              VALUES (:WS-NAME, :WS-AGE)
+           END-EXEC
+      * INSERT with schema-qualified table
+           EXEC SQL
+              INSERT INTO HR.EMPLOYEE (SALARY)
+              VALUES (:WS-SALARY)
+           END-EXEC
+      * INSERT with subselect
+           EXEC SQL
+              INSERT INTO ARCHIVE.EMPLOYEE (NAME, AGE)
+              SELECT NAME, AGE FROM EMPLOYEE
+           END-EXEC
+      * INSERT without column list
+           EXEC SQL
+              INSERT INTO EMPLOYEE
+              VALUES (:WS-NAME, :WS-AGE, :WS-SALARY)
+           END-EXEC
+           GOBACK.
+       END PROGRAM TSTINSRT.

--- a/TypeCobol.Test/Utils/Comparators.cs
+++ b/TypeCobol.Test/Utils/Comparators.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Collections.Generic;
+using System.Text;
 using Antlr4.Runtime;
 using TypeCobol.Compiler;
 using TypeCobol.Compiler.CodeElements;
@@ -7,6 +8,7 @@ using TypeCobol.Compiler.Nodes;
 using TypeCobol.Compiler.Parser;
 using TypeCobol.Compiler.Preprocessor;
 using TypeCobol.Compiler.Scanner;
+using TypeCobol.Compiler.Sql.CodeElements;
 using TypeCobol.Compiler.Sql.CodeElements.Statements;
 using TypeCobol.Compiler.Sql.Model;
 using TypeCobol.Compiler.Text;
@@ -834,6 +836,40 @@ namespace TypeCobol.Test.Utils
                 DumpObject(nameof(executeImmediateStatement.StatementVariable), executeImmediateStatement.StatementVariable);
                 DumpObject(nameof(executeImmediateStatement.StatementExpression), executeImmediateStatement.StatementExpression);
                 return true;
+            }
+
+            public override bool Visit(InsertStatement insertStatement)
+            {
+                _writer.WriteLine($"line {insertStatement.Line}: {nameof(InsertStatement)}");
+                DumpObject(nameof(insertStatement.TableName), insertStatement.TableName);
+                DumpStringList(nameof(insertStatement.Columns), insertStatement.Columns);
+                DumpObject(nameof(insertStatement.HasSubselect), insertStatement.HasSubselect);
+                DumpHostVariableBindings(insertStatement.HostVariables);
+                return true;
+            }
+
+            private void DumpStringList(string name, IList<string> values)
+            {
+                if (values == null)
+                {
+                    _writer.WriteLine($"- {name} = <NULL>");
+                    return;
+                }
+                _writer.WriteLine($"- {name} = [{string.Join(", ", values)}]");
+            }
+
+            private void DumpHostVariableBindings(IList<HostVariableBinding> bindings, string name = "HostVariables")
+            {
+                if (bindings == null || bindings.Count == 0)
+                {
+                    _writer.WriteLine($"- {name} = <NONE>");
+                    return;
+                }
+                _writer.WriteLine($"- {name}:");
+                foreach (var b in bindings)
+                {
+                    _writer.WriteLine($"  - {b.Direction} {b.VariableName} -> {b.ColumnName ?? "<NULL>"}");
+                }
             }
         }
 

--- a/TypeCobol/AntlrGrammar/CobolCodeElements.g4
+++ b/TypeCobol/AntlrGrammar/CobolCodeElements.g4
@@ -228,6 +228,7 @@ codeElement:
 	| getDiagnosticsStatement
 	| alterSequenceStatement
 	| executeImmediateStatement
+	| insertStatement
 
 //	[TYPECOBOL]
 	| tcCodeElement;
@@ -8529,6 +8530,15 @@ repeatedSourceValue: sourceValue (SQL_CommaSeparator sourceValue)*;
 executeImmediateStatement : SQL_EXECUTE SQL_IMMEDIATE (sqlVariable | stringExpression);
 //TODO extend stringExpression to support all expressions that yield a string (i.e string concat, function calls returning text,...)
 stringExpression: AlphanumericLiteral;
+
+// INSERT statement
+// See Documentation [https://www.ibm.com/docs/en/db2-for-zos/12?topic=statements-insert]
+insertStatement:
+    SQL_INSERT SQL_INTO tableOrViewOrCorrelationName
+    insertColumnList?
+    (SQL_VALUES LeftParenthesisSeparator repeatedSourceValue RightParenthesisSeparator | fullselect);
+insertColumnList:
+    LeftParenthesisSeparator column_name (SQL_CommaSeparator column_name)* RightParenthesisSeparator;
 // ------------------------------
 // End of DB2 coprocessor
 // ------------------------------

--- a/TypeCobol/Compiler/CodeElements/CobolLanguageLevelVisitor.cs
+++ b/TypeCobol/Compiler/CodeElements/CobolLanguageLevelVisitor.cs
@@ -412,6 +412,8 @@ namespace TypeCobol.Compiler.CodeElements
         bool Visit([NotNull] AlterSequence alterSequence);
         bool Visit([NotNull] ExecuteImmediateStatement executeImmediateStatement);
         bool Visit([NotNull] ExecuteImmediate executeImmediate);
+        bool Visit([NotNull] InsertStatement insertStatement);
+        bool Visit([NotNull] Insert insert);
     }
 
 
@@ -1661,6 +1663,14 @@ namespace TypeCobol.Compiler.CodeElements
             return true;
         }
         public virtual bool Visit([NotNull] ExecuteImmediate executeImmediate)
+        {
+            return true;
+        }
+        public virtual bool Visit([NotNull] InsertStatement insertStatement)
+        {
+            return true;
+        }
+        public virtual bool Visit([NotNull] Insert insert)
         {
             return true;
         }

--- a/TypeCobol/Compiler/CodeElements/CodeElementType.cs
+++ b/TypeCobol/Compiler/CodeElements/CodeElementType.cs
@@ -176,6 +176,7 @@
         GetDiagnosticsStatement,
         AlterSequenceStatement,
         ExecuteImmediateStatement,
+        InsertStatement,
 
         // [TYPECOBOL]
         LibraryCopy,

--- a/TypeCobol/Compiler/CodeElements/StatementElement.cs
+++ b/TypeCobol/Compiler/CodeElements/StatementElement.cs
@@ -143,7 +143,8 @@
         SetAssignmentStatement,
         GetDiagnosticsStatement,
         AlterSequenceStatement,
-        ExecuteImmediateStatement
+        ExecuteImmediateStatement,
+        InsertStatement
 
     }
 }

--- a/TypeCobol/Compiler/CupParser/NodeBuilder/IProgramClassBuilder.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/IProgramClassBuilder.cs
@@ -885,6 +885,11 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
         /// </summary>
         /// <param name="executeImmediate">The corresponding  ExecuteImmediate Statement Code Element</param>
         void OnExecuteImmediateStatement([NotNull] ExecuteImmediateStatement executeImmediate);
+        /// <summary>
+        /// Enter an Insert Statement Node
+        /// </summary>
+        /// <param name="insert">The corresponding Insert Statement Code Element</param>
+        void OnInsertStatement([NotNull] InsertStatement insert);
         #endregion
     }
 }

--- a/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilder.cs
@@ -1798,5 +1798,11 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
             Exit();
             Dispatcher.OnExecuteImmediateStatement(executeImmediate);
         }
+        public void OnInsertStatement([NotNull] InsertStatement insert)
+        {
+            Enter(new Insert(insert), insert);
+            Exit();
+            Dispatcher.OnInsertStatement(insert);
+        }
     }
 }

--- a/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilderNodeDispatcher.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilderNodeDispatcher.cs
@@ -906,5 +906,9 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
         {
             foreach (var listener in _listeners) listener.OnExecuteImmediateStatement(executeImmediate);
         }
+        public void OnInsertStatement([NotNull] InsertStatement insert)
+        {
+            foreach (var listener in _listeners) listener.OnInsertStatement(insert);
+        }
     }
 }

--- a/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilderNodeListener.cs
+++ b/TypeCobol/Compiler/CupParser/NodeBuilder/ProgramClassBuilderNodeListener.cs
@@ -894,5 +894,6 @@ namespace TypeCobol.Compiler.CupParser.NodeBuilder
         {
 
         }
+        public void OnInsertStatement([NotNull] InsertStatement insert) { }
     }
 }

--- a/TypeCobol/Compiler/CupParser/TypeCobolProgram.cup
+++ b/TypeCobol/Compiler/CupParser/TypeCobolProgram.cup
@@ -248,6 +248,7 @@ terminal TypeCobol.Compiler.Sql.CodeElements.Statements.SetAssignmentStatement S
 terminal TypeCobol.Compiler.Sql.CodeElements.Statements.GetDiagnosticsStatement GetDiagnosticsStatement;
 terminal TypeCobol.Compiler.Sql.CodeElements.Statements.AlterSequenceStatement AlterSequenceStatement;
 terminal TypeCobol.Compiler.Sql.CodeElements.Statements.ExecuteImmediateStatement ExecuteImmediateStatement;
+terminal TypeCobol.Compiler.Sql.CodeElements.Statements.InsertStatement InsertStatement;
 
 
 terminal TypeCobol.Compiler.CodeElements.LibraryCopyCodeElement LibraryCopy;
@@ -831,6 +832,8 @@ sqlStatement ::= CommitStatement:stmt
 {: my_parser.Builder.OnAlterSequenceStatement(stmt); :}
 |	ExecuteImmediateStatement:stmt
 {: my_parser.Builder.OnExecuteImmediateStatement(stmt); :}
+|	InsertStatement:stmt
+{: my_parser.Builder.OnInsertStatement(stmt); :}
 ;
 
 execStatementEnd ::= ExecStatementEnd:stmt

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder/CobolCodeElementBuilder.cs
@@ -2463,5 +2463,11 @@ namespace TypeCobol.Compiler.Parser
             CodeElement = executeImmediateStatement;
             ExecuteImmediateStatementChecker.OnCodeElement(executeImmediateStatement, context);
         }
+
+        public override void EnterInsertStatement([NotNull] CodeElementsParser.InsertStatementContext context)
+        {
+            Context = context;
+            CodeElement = _sqlCodeElementBuilder.CreateInsertStatement(context);
+        }
     }
 }

--- a/TypeCobol/Compiler/Sql/CodeElements/HostVariableBinding.cs
+++ b/TypeCobol/Compiler/Sql/CodeElements/HostVariableBinding.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace TypeCobol.Compiler.Sql.CodeElements
+{
+    public enum HostVariableDirection
+    {
+        IN,
+        OUT
+    }
+
+    public class HostVariableBinding
+    {
+        public string ColumnName { get; set; }
+        public string VariableName { get; set; }
+        public string IndicatorName { get; set; }
+        public HostVariableDirection Direction { get; set; }
+
+        public HostVariableBinding(string variableName, HostVariableDirection direction, string columnName = null, string indicatorName = null)
+        {
+            VariableName = variableName;
+            Direction = direction;
+            ColumnName = columnName;
+            IndicatorName = indicatorName;
+        }
+    }
+}

--- a/TypeCobol/Compiler/Sql/CodeElements/SqlCodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Sql/CodeElements/SqlCodeElementBuilder.cs
@@ -937,5 +937,82 @@ namespace TypeCobol.Compiler.Sql.CodeElements
 
             return null;
         }
+
+        public InsertStatement CreateInsertStatement(CodeElementsParser.InsertStatementContext context)
+        {
+            string tableName = ExtractQualifiedTableName(context.tableOrViewOrCorrelationName());
+
+            List<string> columns = null;
+            if (context.insertColumnList() != null)
+            {
+                columns = new List<string>();
+                foreach (var col in context.insertColumnList().column_name())
+                {
+                    columns.Add(col.GetText());
+                }
+            }
+
+            var hostVariables = new List<HostVariableBinding>();
+            bool hasSubselect = false;
+
+            if (context.repeatedSourceValue() != null)
+            {
+                int colIndex = 0;
+                foreach (var value in context.repeatedSourceValue().sourceValue())
+                {
+                    // sourceValue can contain a hostVariable via sqlExpression → sqlVariable → hostVariable
+                    var hostVar = FindHostVariable(value);
+                    if (hostVar != null)
+                    {
+                        string colName = columns != null && colIndex < columns.Count ? columns[colIndex] : null;
+                        var binding = CreateHostVariableBinding(hostVar, HostVariableDirection.IN, colName);
+                        hostVariables.Add(binding);
+                    }
+                    colIndex++;
+                }
+            }
+            else if (context.fullselect() != null)
+            {
+                hasSubselect = true;
+            }
+
+            return new InsertStatement(tableName, columns, hostVariables, hasSubselect);
+        }
+
+        private string ExtractQualifiedTableName(CodeElementsParser.TableOrViewOrCorrelationNameContext context)
+        {
+            if (context?.Name == null) return null;
+            string name = context.Name.Text;
+            if (context.SchemaName != null)
+                name = context.SchemaName.Text + "." + name;
+            if (context.DBMS != null)
+                name = context.DBMS.Text + "." + name;
+            return name;
+        }
+
+        private HostVariableBinding CreateHostVariableBinding(CodeElementsParser.HostVariableContext context, HostVariableDirection direction, string columnName = null)
+        {
+            string varName = context.mainVariable?.Text;
+            string indName = context.indicatorVariable?.Text;
+            return new HostVariableBinding(varName, direction, columnName, indName);
+        }
+
+        /// <summary>
+        /// Navigate sourceValue → sqlExpression → sqlVariable → hostVariable
+        /// </summary>
+        private CodeElementsParser.HostVariableContext FindHostVariable(Antlr4.Runtime.ParserRuleContext context)
+        {
+            if (context == null) return null;
+            if (context is CodeElementsParser.HostVariableContext hv) return hv;
+            foreach (var child in context.children ?? System.Array.Empty<Antlr4.Runtime.Tree.IParseTree>())
+            {
+                if (child is Antlr4.Runtime.ParserRuleContext childCtx)
+                {
+                    var result = FindHostVariable(childCtx);
+                    if (result != null) return result;
+                }
+            }
+            return null;
+        }
     }
 }

--- a/TypeCobol/Compiler/Sql/CodeElements/Statements/InsertStatement.cs
+++ b/TypeCobol/Compiler/Sql/CodeElements/Statements/InsertStatement.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using TypeCobol.Compiler.CodeElements;
+
+namespace TypeCobol.Compiler.Sql.CodeElements.Statements
+{
+    public class InsertStatement : SqlStatementElement
+    {
+        public string TableName { get; }
+        public IList<string> Columns { get; }
+        public IList<HostVariableBinding> HostVariables { get; }
+        public bool HasSubselect { get; }
+
+        public InsertStatement(string tableName, IList<string> columns, IList<HostVariableBinding> hostVariables, bool hasSubselect)
+            : base(CodeElementType.InsertStatement, StatementType.InsertStatement)
+        {
+            TableName = tableName;
+            Columns = columns;
+            HostVariables = hostVariables ?? new List<HostVariableBinding>();
+            HasSubselect = hasSubselect;
+        }
+
+        public override bool VisitCodeElement(IASTVisitor astVisitor)
+        {
+            return base.VisitCodeElement(astVisitor) && astVisitor.Visit(this);
+        }
+    }
+}

--- a/TypeCobol/Compiler/Sql/Model/SqlObject.cs
+++ b/TypeCobol/Compiler/Sql/Model/SqlObject.cs
@@ -28,6 +28,10 @@ namespace TypeCobol.Compiler.Sql.Model
                     //Special case for QualifiedSymbolReference which is also IEnumerable, we want to use SymbolReference.ToString() here
                     output.WriteLine(symbolReference.ToString());
                     break;
+                case string str:
+                    //string is IEnumerable<char> but we want to dump it as a single value
+                    output.WriteLine(str);
+                    break;
                 case System.Collections.IEnumerable enumerable:
                 {
                     output.WriteLine("[");

--- a/TypeCobol/Compiler/Sql/Nodes/Insert.cs
+++ b/TypeCobol/Compiler/Sql/Nodes/Insert.cs
@@ -1,0 +1,15 @@
+using TypeCobol.Compiler.CodeElements;
+using TypeCobol.Compiler.Nodes;
+using TypeCobol.Compiler.Sql.CodeElements.Statements;
+
+namespace TypeCobol.Compiler.Sql.Nodes
+{
+    public class Insert : GenericNode<InsertStatement>, Statement
+    {
+        public Insert(InsertStatement statement) : base(statement) { }
+        public override bool VisitNode(IASTVisitor astVisitor)
+        {
+            return astVisitor.Visit(this);
+        }
+    }
+}


### PR DESCRIPTION
## Contexte

Cette PR remplace [#2846](https://github.com/TypeCobolTeam/TypeCobol/pull/2846) qui contenait des modifications résiduelles liées à `UnsupportedSqlStatement` (approche abandonnée). Recréée depuis `develop` à jour, elle ne conserve que les modifs strictement nécessaires à `InsertStatement`, conformément à la demande de @fm-117 (mail du 24/04).

S'appuie sur le fix parser `#2848` (protect scanner against empty tokens) déjà mergé sur `develop` — plus de boucle infinie côté scanner SQL sur les caractères `<` non gérés.

## Summary

- **Nouveau** `InsertStatement` (CodeElement) avec `TableName`, `Columns`, `HostVariables`, `HasSubselect`
- **Nouveau** `Insert` AST node (`GenericNode<InsertStatement>`)
- **Nouvelle classe partagée** `HostVariableBinding` (mapping colonne → variable hôte, prête à être réutilisée par UPDATE/DELETE/SELECT/CURSOR à venir)
- **Règle ANTLR** `insertStatement` + `insertColumnList` (cf. [doc IBM DB2 z/OS](https://www.ibm.com/docs/en/db2-for-zos/12?topic=statements-insert))
- **Infrastructure** : enum `CodeElementType.InsertStatement`, enum `StatementType.InsertStatement`, terminal + production CUP, visitor, builder, dispatcher, listener
- `SqlCodeElementBuilder.CreateInsertStatement()` + helpers (`ExtractQualifiedTableName`, `CreateHostVariableBinding`, `FindHostVariable`)
- **Side fix** : `SqlObject.DumpProperty` traitait les `string` via le case `IEnumerable` (héritage de `IEnumerable<char>`) et les dumpait caractère par caractère. Ajout d'un case `string str` dédié — sans ce fix, `TableName` était dumpé caractère par caractère dans la sortie de test. Indépendant de l'INSERT mais bloquant pour la lisibilité du dump SQL.

## Périmètre — ce qui n'est PAS dans la PR

- Aucun fichier `.claude/`, `docs/superpowers/`, `.mcp.json`, `CHANGELOG.md`
- Aucune trace de l'ancien `UnsupportedSqlStatement` (vérifié par `git diff | grep -i unsupported` → vide)
- Pas de modification du scanner / parser core (le fix `#2848` côté team suffit)

## Stack à venir

Cette PR est la première d'une série atomique (1 statement = 1 PR, comme demandé). Les suivantes seront restackées au-dessus une fois celle-ci mergée :

1. ✅ INSERT (cette PR)
2. UPDATE (SET / WHERE bindings)
3. DELETE (WHERE bindings)
4. DECLARE CURSOR (FullSelect / prepared stmt)
5. SELECT INTO (enrichissement avec INTO/WHERE bindings)
6. OPEN cursor (USING bindings)

## Test plan

4 scénarios couverts dans `ExecSqlWithInsertStatement.rdz.cbl` + `.SQL.txt` :

- [x] INSERT simple avec variables hôtes — `INSERT INTO EMPLOYEE (NAME, AGE) VALUES (:WS-NAME, :WS-AGE)`
- [x] INSERT avec table qualifiée par schéma — `INSERT INTO HR.EMPLOYEE (SALARY) VALUES (:WS-SALARY)`
- [x] INSERT avec sous-select — `INSERT INTO ARCHIVE.EMPLOYEE (NAME, AGE) SELECT NAME, AGE FROM EMPLOYEE` (les diagnostics du subselect proviennent du `fullselect`/`tableOrViewAllColumnsSelection` existant — pas de régression)
- [x] INSERT sans liste de colonnes — `INSERT INTO EMPLOYEE VALUES (:WS-NAME, :WS-AGE, :WS-SALARY)`

Vérifications :

- [x] `dotnet build TypeCobol.sln -c Debug` — 0 erreur
- [x] `dotnet test TypeCobol.Test` — **63 passed / 0 failed / 26 skipped**
- [x] `dotnet test TypeCobol.Analysis.Test` — **104 passed / 0 failed / 38 skipped**
- [x] Pas de régression sur `ExecInDataDivision_NoEndExec.Mix.txt` (la liste des tokens attendus est mise à jour pour inclure `InsertStatement`)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>