### PR TITLE
 v2.14.0 (pre-release)

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore ./TypeCobol.sln
     - name: Build CSCup

--- a/Common.props
+++ b/Common.props
@@ -5,8 +5,8 @@
 	<PropertyGroup>
 		<!-- Allow all build configurations for every project -->
 		<Configurations>Debug;Release;EI_Debug;EI_Release</Configurations>
-		<!-- Targeting .NET 8.0, with default language level (C# 12) -->
-		<TargetFramework>net8.0</TargetFramework>
+		<!-- Targeting .NET 10.0, with default language level (C# 14) -->
+		<TargetFramework>net10.0</TargetFramework>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<!-- Nullable checks as errors -->
 		<WarningsAsErrors>Nullable</WarningsAsErrors>

--- a/TypeCobol.LanguageServer.Test.LanguageServerRobot.Installer/TypeCobol.LanguageServer.Test.LanguageServerRobot.Installer.csproj
+++ b/TypeCobol.LanguageServer.Test.LanguageServerRobot.Installer/TypeCobol.LanguageServer.Test.LanguageServerRobot.Installer.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="TypeCobol.LanguageServer.Robot.Monitor" Version="1.5.1" />
-		<PackageReference Include="TypeCobol.LanguageServerRobot" Version="1.8.1" />
+		<PackageReference Include="TypeCobol.LanguageServerRobot" Version="1.9.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/TypeCobol.LanguageServer/WorkspaceProject.cs
+++ b/TypeCobol.LanguageServer/WorkspaceProject.cs
@@ -189,7 +189,7 @@ namespace TypeCobol.LanguageServer
                 var newCompilationProject = new CompilationProject(oldCompilationProject.Name, oldCompilationProject.RootDirectory, Helpers.DEFAULT_EXTENSIONS, newFormat, newOptions, newAnalyzerProvider);
                 foreach (var newCopyFolder in newCopyFolders)
                 {
-                    newCompilationProject.SourceFileProvider.AddLocalDirectoryLibrary(newCopyFolder, false, Helpers.DEFAULT_COPY_EXTENSIONS, newFormat);
+                    newCompilationProject.SourceFileProvider.AddLocalDirectoryLibrary(newCopyFolder, true, Helpers.DEFAULT_COPY_EXTENSIONS, newFormat);
                 }
 
                 Project = newCompilationProject;

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/UnsupportedByScanner.SQL.txt
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/UnsupportedByScanner.SQL.txt
@@ -1,0 +1,21 @@
+﻿--- Diagnostics ---
+Line 10[31,31] <59, Error, Tokens> - Syntax is not supported, found unexpected char '$': line text is '        WHERE DATE_FIN $ :WS-DATE-FIN'.
+Line 10[16,20] <27, Error, Syntax> - Syntax error : extraneous input 'WHERE' expecting {separator, numeric literal, character string, symbol, statement starting keyword, keyword, Formalized Comments elements, Sql statement starting keyword} RuleStack=,  OffendingSymbol=[16,20:WHERE]<SQL_WHERE>
+
+--- Sql Statements ---
+line 8: SelectStatement
+- FullSelect = FullSelect
+  - SubSelect = SubSelect
+    - SelectClause = SelectClause
+      - SelectionModifier = <NULL>
+      - Selections = [
+        - Selections[0] = StarSelection
+      ]
+    - FromClause = FromClause
+      - TableReferences = [
+        - TableReferences[0] = SingleTableReference
+          - TableOrViewName = TableViewCorrelationName
+            - Name = PROJECTS
+          - CorrelationClause = <NULL>
+      ]
+  - SubQuery = <NULL>

--- a/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/UnsupportedByScanner.rdz.cbl
+++ b/TypeCobol.Test/Parser/Programs/Cobol85/ExecSql/UnsupportedByScanner.rdz.cbl
@@ -1,0 +1,12 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. UnsupportedBySqlScanner.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 WS-DATE-FIN        PIC X(10).
+       PROCEDURE DIVISION.
+           EXEC SQL
+               SELECT * FROM PROJECTS
+      * KO: operator '$' is not supported by SQL scanner
+               WHERE DATE_FIN $ :WS-DATE-FIN
+           END-EXEC
+       END PROGRAM UnsupportedBySqlScanner.

--- a/TypeCobol/Compiler/CodeElements/Statement/UnstringStatement.cs
+++ b/TypeCobol/Compiler/CodeElements/Statement/UnstringStatement.cs
@@ -94,12 +94,12 @@ public class UnstringStatement: StatementElement, VariableWriter {
             variablesWritten = new Dictionary<StorageArea, object>();
             if (ReceivingFields == null) return variablesWritten;
             string sending = SendingField == null? null : SendingField.ToString();
-            foreach(var field in ReceivingFields)
+            foreach(var @field in ReceivingFields)
             {
-                if (field.ReceivingField?.StorageArea == null) continue;
+                if (@field.ReceivingField?.StorageArea == null) continue;
         
-                if (!variablesWritten.ContainsKey(field.ReceivingField.StorageArea)) {
-                    variablesWritten.Add(field.ReceivingField.StorageArea, sending);
+                if (!variablesWritten.ContainsKey(@field.ReceivingField.StorageArea)) {
+                    variablesWritten.Add(@field.ReceivingField.StorageArea, sending);
                 }
                 
             }

--- a/TypeCobol/Compiler/Diagnostics/MessageCode.cs
+++ b/TypeCobol/Compiler/Diagnostics/MessageCode.cs
@@ -67,6 +67,7 @@ namespace TypeCobol.Compiler.Diagnostics
         InvalidCharInsidePseudoText = 55,
         DirectiveSyntaxWarning = 56,
         DirectiveSyntaxError = 57,
-        InvalidNumberOfCharsInHexaUTF8Literal = 58
+        InvalidNumberOfCharsInHexaUTF8Literal = 58,
+        FoundUnsupportedCharWhileScanning = 59
     }
 }

--- a/TypeCobol/Compiler/Diagnostics/Resources/DiagnosticMessages.csv
+++ b/TypeCobol/Compiler/Diagnostics/Resources/DiagnosticMessages.csv
@@ -56,3 +56,4 @@ Category;Code;Severity;MessageTemplate;Document;PageNumber;ReferenceText
 3;56;2;Warning: {0};0;0;
 3;57;1;Error: {0};0;0;
 2;58;2;The number of characters in an hexadecimal UTF-8 literal should be a multiple of 2 and must not exceed 320;1;36;An even number of hexadecimal digits must be specified. Each group of two hexadecimal digits represents a single encoding unit of a UTF-8 character.
+2;59;1;Syntax is not supported, found unexpected char '{0}': {1};0;0;

--- a/TypeCobol/Compiler/Scanner/AbstractScanner.cs
+++ b/TypeCobol/Compiler/Scanner/AbstractScanner.cs
@@ -42,7 +42,20 @@ namespace TypeCobol.Compiler.Scanner
         /// Scan from current index and return the token found.
         /// </summary>
         /// <returns>Token instance, null if no token could be scanned.</returns>
-        public Token? GetNextToken() => GetTokenStartingFrom(currentIndex);
+        public Token? GetNextToken()
+        {
+            var token = GetTokenStartingFrom(currentIndex);
+
+            // Safety check: always avoid creating empty tokens otherwise the scanner will run on an infinite loop.
+            // The index MUST progress, so force scan an invalid token of length 1 instead of an empty one.
+            if (token?.Length == 0)
+            {
+                token = ScanOneChar(currentIndex, TokenType.InvalidToken);
+                tokensLine.AddDiagnostic(MessageCode.FoundUnsupportedCharWhileScanning, token, token.Text, $"line text is '{tokensLine.SourceText}'.");
+            }
+
+            return token;
+        }
 
         /// <summary>
         /// Scan from given index and return the token found.

--- a/TypeCobol/Compiler/Scanner/Scanner.cs
+++ b/TypeCobol/Compiler/Scanner/Scanner.cs
@@ -2013,7 +2013,7 @@ namespace TypeCobol.Compiler.Scanner
                     _sqlScanner = new SqlScanner(line, currentIndex, lastIndex, tokensLine, compilerOptions);
                 }
 
-                var sqlToken = _sqlScanner.GetTokenStartingFrom(currentIndex);
+                var sqlToken = _sqlScanner.GetTokenStartingFrom(currentIndex); // May be empty, it's ok this will be checked by caller method GetNextToken
                 currentIndex = _sqlScanner.CurrentIndex;
                 return sqlToken;
             }

--- a/TypeCobol/Parser.cs
+++ b/TypeCobol/Parser.cs
@@ -61,7 +61,7 @@ namespace TypeCobol
             SourceFileProvider sourceFileProvider = project.SourceFileProvider;
             copies = copies ?? new List<string>();
             foreach (var folder in copies) {
-                sourceFileProvider.AddLocalDirectoryLibrary(folder, false, Helpers.DEFAULT_COPY_EXTENSIONS, format.Encoding, format.EndOfLineDelimiter, format.FixedLineLength);
+                sourceFileProvider.AddLocalDirectoryLibrary(folder, true, Helpers.DEFAULT_COPY_EXTENSIONS, format.Encoding, format.EndOfLineDelimiter, format.FixedLineLength);
             }
             compiler = new FileCompiler(null, filename, format.ColumnsLayout, isCopy, project.SourceFileProvider, project, options, CustomSymbols, project);
             


### PR DESCRIPTION
This minor release upgrade our target frameork to .NET 10.0.

## Copy lookup
- WI #2843 Include sub-directories for copy folders (#2844)

## Bug fix
- WI #2847 Protect scanner against empty tokens (#2848)

## Technical
- WI #2852 Upgrade to .NET 10 (#2853)
